### PR TITLE
Add Workflow.run! and Workflow.step

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -18,7 +18,7 @@ Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.joi
 require "logger"
 Floe.logger = Logger.new(STDOUT)
 
-workflow = Floe::Workflow.load(opts[:workflow], opts[:inputs], opts[:credentials])
+workflow = Floe::Workflow.load(opts[:workflow], {"global" => opts[:inputs]}, opts[:credentials])
 
 runner_klass = case opts[:docker_runner]
                when "docker"

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -35,7 +35,11 @@ module Floe
       end
 
       def context
-        workflow.context
+        workflow.context["global"]
+      end
+
+      def status
+        end? ? "success" : "running"
       end
 
       def run!(input)

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -28,6 +28,10 @@ module Floe
           true
         end
 
+        def status
+          "errored"
+        end
+
         private def to_dot_attributes
           super.merge(:color => "red")
         end


### PR DESCRIPTION
NOTE previously was https://github.com/ManageIQ/manageiq-floe/pull/6, reopened to clean up the main fork's branches

This commit pushes executing a full workflow into the Workflow class. A notable change here is that the incoming context is not just the inputs, but the full context including "global", "states", and "current_state". This allows stepping, persisting the context, then resuming from that context.

@agrare I wanted to discuss this one first before merge, because it change the inputs and I didn't know if you had other thoughts on how this should be done.  In the future, I'm wondering if the incoming context should be a defined class instead of a raw Hash, since it's easy to start messing up the names.

Required for https://github.com/agrare/manageiq-providers-workflows/pull/1

