### PR TITLE
Fix States::Wait Path initialize arguments

### DIFF
--- a/examples/workflow.asl
+++ b/examples/workflow.asl
@@ -66,6 +66,12 @@
         "bar": "baz"
       },
       "ResultPath": "$.result",
+      "Next": "WaitState"
+    },
+
+    "WaitState": {
+      "Type": "Wait",
+      "Seconds": 1,
       "Next": "NextState"
     },
 

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -12,8 +12,8 @@ module Floe
           @next    = payload["Next"]
           @seconds = payload["Seconds"].to_i
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"), context)
-          @output_path = Path.new(payload.fetch("OutputPath", "$"), context)
+          @input_path  = Path.new(payload.fetch("InputPath", "$"))
+          @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
         def run!(*)

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -1,21 +1,22 @@
 RSpec.describe Floe::Workflow::States::Pass do
   let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
-  let(:state)    { workflow.states_by_name["PassState"] }
+  let(:state)    { workflow.states_by_name["WaitState"] }
 
   describe "#run!" do
-    it "sets the result to the result path" do
+    it "sleeps for the requested amount of time" do
+      expect(state).to receive(:sleep).with(state.seconds)
+
       _, output = state.run!({})
-      expect(output["result"]).to include(state.result)
     end
   end
 
   it "#to_dot" do
-    expect(state.to_dot).to eq "  PassState"
+    expect(state.to_dot).to eq "  WaitState"
   end
 
   it "#to_dot_transitions" do
     expect(state.to_dot_transitions).to eq [
-      "  PassState -> WaitState"
+      "  WaitState -> NextState"
     ]
   end
 end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Floe::Workflow do
         FirstMatchState
         SecondMatchState
         PassState
+        WaitState
         FailState [ style=bold color=red ]
         SuccessState [ style=bold color=green ]
         NextState [ style=bold ]
@@ -20,7 +21,8 @@ RSpec.describe Floe::Workflow do
         ChoiceState -> FailState [ label="Default" ]
         FirstMatchState -> PassState
         SecondMatchState -> NextState
-        PassState -> NextState
+        PassState -> WaitState
+        WaitState -> NextState
       }
     DOT
   end


### PR DESCRIPTION
The Path class was converted to take only a payload and the context is passed later, and the Wait state initializer wasn't updated to match.

This was changed in https://github.com/ManageIQ/floe/pull/27/files#diff-52717b57bdde93e7013b314f78b10e30611aa208e2f99d3ea0dabfda253fa2cbL13-R13 and I just missed the Wait state due to the missing spec coverage of this state (added)