### PR TITLE
Add options to Workflow::Runner initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add ability to pass options to `Floe::Workflow::Runner` (#48)
 
 ## [0.1.1] - 2023-06-05
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}'
 ```
 
 By default Floe will use `docker` to run `docker://` type resources, but `podman` and `kubernetes` are also supported runners.
-A different runner can be specified with the `--runner` option:
+A different runner can be specified with the `--docker-runner` option:
 
 ```
-bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --docker_runner podman
-bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --docker_runner kubernetes --docker_runner-options namespace=default server=https://k8s.example.com:6443 token=my-token
+bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --docker-runner podman
+bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --docker-runner kubernetes --docker-runner-options namespace=default server=https://k8s.example.com:6443 token=my-token
 ```
 
 ### Ruby Library

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Floe can be run as a command-line utility or as a ruby class.
 bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}'
 ```
 
-By default Floe will use `docker` to run `docker://` type resources, but `podman` and `kubernet` are also supported runners.
+By default Floe will use `docker` to run `docker://` type resources, but `podman` and `kubernetes` are also supported runners.
 A different runner can be specified with the `--runner` option:
 
 ```
 bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --runner podman
-bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --runner kubernetes --runner-option namespace=default
+bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --runner kubernetes --runner-option namespace=default --runner-option server=https://k8s.example.com:6443 --runner-option token=my-token
 ```
 
 ### Ruby Library
@@ -51,7 +51,7 @@ require 'floe'
 
 Floe::Workflow::Runner.docker_runner = Floe::Workflow::Runner::Podman.new
 # Or
-Floe::Workflow::Runner.docker_runner = Floe::Workflow::Runner::Kubernetes.new("namespace" => "default")
+Floe::Workflow::Runner.docker_runner = Floe::Workflow::Runner::Kubernetes.new("namespace" => "default", "server" => "https://k8s.example.com:6443", "token" => "my-token")
 
 workflow = Floe::Workflow.load(File.read("workflow.asl"))
 workflow.run!

--- a/README.md
+++ b/README.md
@@ -28,10 +28,30 @@ Floe can be run as a command-line utility or as a ruby class.
 bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}'
 ```
 
+By default Floe will use `docker` to run `docker://` type resources, but `podman` and `kubernet` are also supported runners.
+A different runner can be specified with the `--runner` option:
+
+```
+bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --runner podman
+bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --runner kubernetes --runner-option namespace=default
+```
+
 ### Ruby Library
 
 ```ruby
 require 'floe'
+
+workflow = Floe::Workflow.load(File.read("workflow.asl"))
+workflow.run!
+```
+
+You can also specify a specific docker runner and runner options:
+```ruby
+require 'floe'
+
+Floe::Workflow::Runner.docker_runner = Floe::Workflow::Runner::Podman.new
+# Or
+Floe::Workflow::Runner.docker_runner = Floe::Workflow::Runner::Kubernetes.new("namespace" => "default")
 
 workflow = Floe::Workflow.load(File.read("workflow.asl"))
 workflow.run!

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ By default Floe will use `docker` to run `docker://` type resources, but `podman
 A different runner can be specified with the `--runner` option:
 
 ```
-bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --runner podman
-bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --runner kubernetes --runner-option namespace=default --runner-option server=https://k8s.example.com:6443 --runner-option token=my-token
+bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --docker_runner podman
+bundle exec ruby exe/floe --workflow examples/workflow.asl --inputs='{"foo": 1}' --docker_runner kubernetes --docker_runner-options namespace=default server=https://k8s.example.com:6443 token=my-token
 ```
 
 ### Ruby Library

--- a/exe/floe
+++ b/exe/floe
@@ -7,14 +7,31 @@ require "optimist"
 opts = Optimist.options do
   version "v#{Floe::VERSION}\n"
   opt :workflow, "Path to your workflow json", :type => :string, :required => true
-  opt :inputs, "JSON payload to input to the workflow", :type => :string, :default => '{}'
-  opt :credentials, "JSON payload with credentials", :type => :string, :default => '{}'
+  opt :inputs, "JSON payload to input to the workflow", :type => :string, :default => "{}"
+  opt :credentials, "JSON payload with credentials", :type => :string, :default => "{}"
+  opt :runner, "Type of runner for docker images", :type => :string, :default => "docker"
+  opt :runner_option, "Options to pass to the runner", :type => :string, :multi => true
 end
 
 require "logger"
 Floe.logger = Logger.new(STDOUT)
 
 workflow = Floe::Workflow.load(opts[:workflow], opts[:inputs], opts[:credentials])
+
+runner_klass = case opts[:runner]
+               when "docker"
+                 Floe::Workflow::Runner::Docker
+               when "podman"
+                 Floe::Workflow::Runner::Podman
+               when "kubernetes"
+                 Floe::Workflow::Runner::Kubernetes
+               else
+                 raise
+               end
+
+runner_options = opts[:runner_option].to_h { |opt| opt.split("=") }
+
+Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
 
 output = workflow.run!
 

--- a/exe/floe
+++ b/exe/floe
@@ -6,11 +6,11 @@ require "optimist"
 
 opts = Optimist.options do
   version "v#{Floe::VERSION}\n"
-  opt :workflow, "Path to your workflow json", :type => :string, :required => true
-  opt :inputs, "JSON payload to input to the workflow", :type => :string, :default => "{}"
-  opt :credentials, "JSON payload with credentials", :type => :string, :default => "{}"
-  opt :runner, "Type of runner for docker images", :type => :string, :default => "docker"
-  opt :runner_option, "Options to pass to the runner", :type => :string, :multi => true
+  opt :workflow, "Path to your workflow json",                 :type => :string, :required => true
+  opt :inputs, "JSON payload to input to the workflow",        :default => "{}"
+  opt :credentials, "JSON payload with credentials",           :default => "{}"
+  opt :docker_runner, "Type of runner for docker images",      :default => "docker"
+  opt :docker_runner_options, "Options to pass to the runner", :type => :strings
 end
 
 require "logger"
@@ -18,7 +18,7 @@ Floe.logger = Logger.new(STDOUT)
 
 workflow = Floe::Workflow.load(opts[:workflow], opts[:inputs], opts[:credentials])
 
-runner_klass = case opts[:runner]
+runner_klass = case opts[:docker_runner]
                when "docker"
                  Floe::Workflow::Runner::Docker
                when "podman"
@@ -29,7 +29,7 @@ runner_klass = case opts[:runner]
                  raise
                end
 
-runner_options = opts[:runner_option].to_h { |opt| opt.split("=") }
+runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=") }
 
 Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
 

--- a/exe/floe
+++ b/exe/floe
@@ -13,6 +13,8 @@ opts = Optimist.options do
   opt :docker_runner_options, "Options to pass to the runner", :type => :strings
 end
 
+Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.join(", ")}") unless Floe::Workflow::Runner::TYPES.include?(opts[:docker_runner])
+
 require "logger"
 Floe.logger = Logger.new(STDOUT)
 
@@ -25,8 +27,6 @@ runner_klass = case opts[:docker_runner]
                  Floe::Workflow::Runner::Podman
                when "kubernetes"
                  Floe::Workflow::Runner::Kubernetes
-               else
-                 raise
                end
 
 runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=") }

--- a/exe/floe
+++ b/exe/floe
@@ -29,7 +29,7 @@ runner_klass = case opts[:docker_runner]
                  Floe::Workflow::Runner::Kubernetes
                end
 
-runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=") }
+runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
 
 Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
 

--- a/lib/floe/workflow/runner.rb
+++ b/lib/floe/workflow/runner.rb
@@ -5,11 +5,14 @@ module Floe
     class Runner
       include Logging
 
-      class << self
-        attr_writer :docker_runner_klass
+      def initialize(_options = {})
+      end
 
-        def docker_runner_klass
-          @docker_runner_klass ||= const_get(ENV.fetch("DOCKER_RUNNER", "docker").capitalize)
+      class << self
+        attr_writer :docker_runner
+
+        def docker_runner
+          @docker_runner ||= Floe::Workflow::Runner::Docker.new
         end
 
         def for_resource(resource)
@@ -18,7 +21,7 @@ module Floe
           scheme = resource.split("://").first
           case scheme
           when "docker"
-            docker_runner_klass.new
+            docker_runner
           else
             raise "Invalid resource scheme [#{scheme}]"
           end

--- a/lib/floe/workflow/runner.rb
+++ b/lib/floe/workflow/runner.rb
@@ -5,6 +5,8 @@ module Floe
     class Runner
       include Logging
 
+      TYPES = %w[docker podman kubernetes].freeze
+
       def initialize(_options = {})
       end
 

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -6,13 +6,13 @@ module Floe
       class Kubernetes < Floe::Workflow::Runner
         attr_reader :namespace
 
-        def initialize(*)
+        def initialize(options = {})
           require "awesome_spawn"
           require "securerandom"
           require "base64"
           require "yaml"
 
-          @namespace = ENV.fetch("DOCKER_RUNNER_NAMESPACE", "default")
+          @namespace = options.fetch("namespace", "default")
 
           super
         end

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -4,7 +4,7 @@ module Floe
   class Workflow
     class Runner
       class Kubernetes < Floe::Workflow::Runner
-        attr_reader :namespace
+        attr_reader :namespace, :server, :token
 
         def initialize(options = {})
           require "awesome_spawn"
@@ -13,6 +13,9 @@ module Floe
           require "yaml"
 
           @namespace = options.fetch("namespace", "default")
+          @server    = options.fetch("server", nil)
+          @token     = options.fetch("token", nil)
+          @token   ||= File.read(options["token_file"]) if options.key?("token_file")
 
           super
         end
@@ -98,6 +101,9 @@ module Floe
         end
 
         def kubectl!(*params, **kwargs)
+          params.unshift([:token, token])   if token
+          params.unshift([:server, server]) if server
+
           AwesomeSpawn.run!("kubectl", :params => params, **kwargs)
         end
 


### PR DESCRIPTION
Add a way for the caller to initialize the docker runner and pass options.

This is going to be important for the kubernetes runner because we're going to have to pass options for authentication