### PR TITLE
Fix k8s runner creating secret without credentials

### DIFF
--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -25,7 +25,7 @@ module Floe
 
           image     = resource.sub("docker://", "")
           name      = pod_name(image)
-          secret    = create_secret!(secrets) unless secrets&.empty?
+          secret    = create_secret!(secrets) if secrets && !secrets.empty?
           overrides = pod_spec(image, env, secret)
 
           result = kubectl_run!(image, name, overrides)

--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -28,6 +28,25 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       subject.run!("docker://hello-world:latest")
     end
 
+    it "doesn't create a secret if Credentials is nil" do
+      expect(subject).not_to receive(:create_secret!)
+      stub_good_run!(
+        "kubectl",
+        :params => [
+          "run",
+          :rm,
+          :attach,
+          [:image, "hello-world:latest"],
+          [:restart, "Never"],
+          [:namespace, "default"],
+          a_string_including("hello-world-"),
+          a_string_including("--overrides")
+        ]
+      )
+
+      subject.run!("docker://hello-world:latest", {}, nil)
+    end
+
     it "passes environment variables to kubectl run" do
       stub_good_run!(
         "kubectl",


### PR DESCRIPTION
If there is no Credentials section in the ASL file `secrets` was `nil`
and `unless secrets&.empty?` was `nil` rather than `true`