### PR TITLE
Fix Go marshal number into env var value

### DIFF
--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -55,7 +55,7 @@ module Floe
           container_spec = {
             "name"  => container_name(image),
             "image" => image,
-            "env"   => env.to_h.map { |k, v| {"name" => k, "value" => v} }
+            "env"   => env.to_h.map { |k, v| {"name" => k, "value" => v.to_s} }
           }
 
           spec = {"spec" => {"containers" => [container_spec]}}

--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -46,6 +46,24 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       subject.run!("docker://hello-world:latest", {"FOO" => "BAR"})
     end
 
+    it "passes integer environment variables to kubectl run as strings" do
+      stub_good_run!(
+        "kubectl",
+        :params => [
+          "run",
+          :rm,
+          :attach,
+          [:image, "hello-world:latest"],
+          [:restart, "Never"],
+          [:namespace, "default"],
+          a_string_including("hello-world-"),
+          a_string_including("\"env\":[{\"name\":\"FOO\",\"value\":\"1\"}]")
+        ]
+      )
+
+      subject.run!("docker://hello-world:latest", {"FOO" => 1})
+    end
+
     it "passes a secrets volume to kubectl run" do
       stub_good_run!("kubectl", :params => ["create", "-f", "-"], :in_data => a_string_including("kind: Secret"))
       stub_good_run!(


### PR DESCRIPTION
If the env var value is an integer Go cannot marshal a number into type
string.

```
kubectl exit code: 1 error was: error: json: cannot unmarshal number into Go struct field EnvVar.spec.containers.env.value of type string
```