### PR TITLE
Add ability to run workflows asynchronously

### DIFF
--- a/lib/floe/workflow/runner.rb
+++ b/lib/floe/workflow/runner.rb
@@ -30,7 +30,27 @@ module Floe
         end
       end
 
-      def run!(image, env = {}, secrets = {})
+      def run!(resource, env = {}, secrets = {})
+        raise NotImplementedError, "Must be implemented in a subclass"
+      end
+
+      def run_async!(_image, _env = {}, _secrets = {})
+        raise NotImplementedError, "Must be implemented in a subclass"
+      end
+
+      def running?(_ref)
+        raise NotImplementedError, "Must be implemented in a subclass"
+      end
+
+      def success?(_ref)
+        raise NotImplementedError, "Must be implemented in a subclass"
+      end
+
+      def output(_ref)
+        raise NotImplementedError, "Must be implemented in a subclass"
+      end
+
+      def cleanup(_ref, _secret)
         raise NotImplementedError, "Must be implemented in a subclass"
       end
     end

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -43,9 +43,70 @@ module Floe
           secrets_file&.close!
         end
 
+        def run_async!(resource, env = {}, secrets = {})
+          raise ArgumentError, "Invalid resource" unless resource&.start_with?("docker://")
+
+          image = resource.sub("docker://", "")
+
+          params = ["run", :detach]
+          params += [[:net, "host"]] if network == "host"
+          params += env.map { |k, v| [:e, "#{k}=#{v}"] } if env
+
+          secrets_file = nil
+
+          if secrets && !secrets.empty?
+            secrets_file = Tempfile.new
+            secrets_file.write(secrets.to_json)
+            secrets_file.flush
+
+            params << [:e, "SECRETS=/run/secrets"]
+            params << [:v, "#{secrets_file.path}:/run/secrets:z"]
+          end
+
+          params << image
+
+          logger.debug("Running docker: #{AwesomeSpawn.build_command_line("docker", params)}")
+
+          begin
+            container_id = docker!(*params).output
+          rescue
+            secrets_file&.close!
+            raise
+          end
+
+          [container_id, secrets_file]
+        end
+
+        def cleanup(container_id, secrets_file)
+          delete_container(container_id)
+          secrets_file&.close!
+        end
+
+        def running?(container_id)
+          JSON.parse(docker!("inspect", container_id).output).first.dig("State", "Running")
+        end
+
+        def success?(container_id)
+          JSON.parse(docker!("inspect", container_id).output).first.dig("State", "ExitCode") == 0
+        end
+
+        def output(container_id)
+          docker!("logs", container_id).output
+        end
+
         private
 
         attr_reader :network
+
+        def delete_container(container_id)
+          docker!("rm", container_id)
+        rescue
+          nil
+        end
+
+        def docker!(*params, **kwargs)
+          AwesomeSpawn.run!("docker", :params => params, **kwargs)
+        end
       end
     end
   end

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -83,11 +83,11 @@ module Floe
         end
 
         def running?(container_id)
-          JSON.parse(docker!("inspect", container_id).output).first.dig("State", "Running")
+          inspect_container(container_id).first.dig("State", "Running")
         end
 
         def success?(container_id)
-          JSON.parse(docker!("inspect", container_id).output).first.dig("State", "ExitCode") == 0
+          inspect_container(container_id).first.dig("State", "ExitCode") == 0
         end
 
         def output(container_id)
@@ -97,6 +97,10 @@ module Floe
         private
 
         attr_reader :network
+
+        def inspect_container(container_id)
+          JSON.parse(docker!("inspect", container_id).output)
+        end
 
         def delete_container(container_id)
           docker!("rm", container_id)

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -70,7 +70,7 @@ module Floe
           begin
             container_id = docker!(*params).output
           rescue
-            secrets_file&.close!
+            cleanup(container_id, secrets_file)
             raise
           end
 
@@ -78,7 +78,7 @@ module Floe
         end
 
         def cleanup(container_id, secrets_file)
-          delete_container(container_id)
+          delete_container(container_id) if container_id
           secrets_file&.close!
         end
 

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -46,19 +46,27 @@ module Floe
           secret = create_secret!(secrets) if secrets && !secrets.empty?
 
           begin
+            runner_context = {:container_ref => name}
+
             create_pod!(name, image, env, secret)
             loop do
               case pod_info(name).dig("status", "phase")
               when "Pending", "Running"
                 sleep(1)
               when "Succeeded"
-                return [0, output(name)]
+                runner_context[:exit_code] = 0
+                output(runner_context)
+                break
               else
-                return [1, output(name)]
+                runner_context[:exit_code] = 0
+                output(runner_context)
+                break
               end
             end
+
+            runner_context
           ensure
-            cleanup(name, secret)
+            cleanup({:container_ref => name, :secrets_ref => secret})
           end
         end
 
@@ -69,29 +77,38 @@ module Floe
           name   = pod_name(image)
           secret = create_secret!(secrets) if secrets && !secrets.empty?
 
+          runner_context = {:container_ref => name, :secrets_ref => secret}
+
           begin
             create_pod!(name, image, env, secret)
           rescue
-            cleanup(name, secret)
+            cleanup(runner_context)
             raise
           end
 
-          [name, secret]
+          runner_context
         end
 
-        def running?(pod_name)
-          %w[Pending Running].include?(pod_info(pod_name).dig("status", "phase"))
+        def status!(runner_context)
+          runner_context[:container_state] = pod_info(runner_context[:container_ref])["status"]
         end
 
-        def success?(pod_name)
-          pod_info(pod_name).dig("status", "phase") == "Succeeded"
+        def running?(runner_context)
+          %w[Pending Running].include?(runner_context.dig(:container_state, "phase"))
         end
 
-        def output(pod)
-          kubeclient.get_pod_log(pod, namespace).body
+        def success?(runner_context)
+          runner_context.dig(:container_state, "phase") == "Succeeded"
         end
 
-        def cleanup(pod, secret)
+        def output(runner_context)
+          output = kubeclient.get_pod_log(runner_context[:container_ref], namespace).body
+          runner_context[:output] = output
+        end
+
+        def cleanup(runner_context)
+          pod, secret = runner_context.values_at(:container_ref, :secrets_ref)
+
           delete_pod(pod)       if pod
           delete_secret(secret) if secret
         end

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -72,7 +72,7 @@ module Floe
           begin
             create_pod!(name, image, env, secret)
           rescue
-            delete_secret(secret) if secret
+            cleanup(name, secret)
             raise
           end
 

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -89,11 +89,11 @@ module Floe
         end
 
         def running?(container_id)
-          JSON.parse(podman!("inspect", container_id).output).first.dig("State", "Running")
+          inspect_container(container_id).first.dig("State", "Running")
         end
 
         def success?(container_id)
-          JSON.parse(podman!("inspect", container_id).output).first.dig("State", "ExitCode") == 0
+          inspect_container(container_id).first.dig("State", "ExitCode") == 0
         end
 
         def output(container_id)
@@ -101,6 +101,10 @@ module Floe
         end
 
         private
+
+        def inspect_container(container_id)
+          JSON.parse(podman!("inspect", container_id).output)
+        end
 
         def delete_container(container_id)
           podman!("rm", container_id)

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -50,7 +50,7 @@ module Floe
 
           [result.exit_status, result.output]
         ensure
-          AwesomeSpawn.run("podman", :params => ["secret", "rm", secret_guid]) if secret_guid
+          delete_secret(secret_guid) if secret_guid
         end
 
         def run_async!(resource, env = {}, secrets = {})
@@ -76,7 +76,7 @@ module Floe
           begin
             container_id = podman!(*params).output
           rescue
-            podman!("secret", "rm", secret_guid) if secret_guid
+            cleanup(container_id, secret_guid)
             raise
           end
 
@@ -84,8 +84,8 @@ module Floe
         end
 
         def cleanup(container_id, secret_guid)
-          delete_container(container_id)
-          delete_secret(secret_guid) if secret_guid
+          delete_container(container_id) if container_id
+          delete_secret(secret_guid)     if secret_guid
         end
 
         def running?(container_id)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -31,9 +31,9 @@ module Floe
           input = parameters.value(context, input) if parameters
 
           runner = Floe::Workflow::Runner.for_resource(resource)
-          _exit_status, results = runner.run!(resource, input, credentials&.value({}, workflow.credentials))
+          runner_context = runner.run!(resource, input, credentials&.value({}, workflow.credentials))
 
-          output = process_output!(input, results)
+          output = process_output!(input, runner_context[:output])
           [@end ? nil : @next, output]
         rescue => err
           retrier = self.retry.detect { |r| (r.error_equals & [err.to_s, "States.ALL"]).any? }

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -118,22 +118,25 @@ RSpec.describe Floe::Workflow::Runner::Docker do
   end
 
   describe "#cleanup" do
-    let(:secrets_file) { double("Tempfile") }
+    let(:secrets_file) { "/tmp/secretfile" }
 
     it "deletes the container and secret" do
       stub_good_run!("docker", :params => ["rm", container_id])
-      expect(secrets_file).to receive(:close!)
+      expect(File).to receive(:exist?).with(secrets_file).and_return(true)
+      expect(File).to receive(:unlink).with(secrets_file)
       subject.cleanup(container_id, secrets_file)
     end
 
     it "doesn't delete the secret_file if not passed" do
       stub_good_run!("docker", :params => ["rm", container_id])
+      expect(File).not_to receive(:unlink).with(secrets_file)
       subject.cleanup(container_id, nil)
     end
 
     it "deletes the secrets file if deleting the container fails" do
       stub_bad_run!("docker", :params => ["rm", container_id])
-      expect(secrets_file).to receive(:close!)
+      expect(File).to receive(:exist?).with(secrets_file).and_return(true)
+      expect(File).to receive(:unlink).with(secrets_file)
       subject.cleanup(container_id, secrets_file)
     end
   end

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -3,9 +3,45 @@ RSpec.describe Floe::Workflow::Runner::Docker do
 
   let(:subject)        { described_class.new(runner_options) }
   let(:runner_options) { {} }
+  let(:container_id)   { SecureRandom.hex }
 
-  let(:subject)      { described_class.new }
-  let(:container_id) { SecureRandom.hex }
+  describe "#run!" do
+    it "raises an exception without a resource" do
+      expect { subject.run!(nil) }.to raise_error(ArgumentError, "Invalid resource")
+    end
+
+    it "raises an exception for an invalid resource uri" do
+      expect { subject.run!("arn:abcd:efgh") }.to raise_error(ArgumentError, "Invalid resource")
+    end
+
+    it "calls docker run with the image name" do
+      stub_good_run!("docker", :params => ["run", :rm, "hello-world:latest"])
+
+      subject.run!("docker://hello-world:latest")
+    end
+
+    it "passes environment variables to docker run" do
+      stub_good_run!("docker", :params => ["run", :rm, [:e, "FOO=BAR"], "hello-world:latest"])
+
+      subject.run!("docker://hello-world:latest", {"FOO" => "BAR"})
+    end
+
+    it "passes a secrets volume to docker run" do
+      stub_good_run!("docker", :params => ["run", :rm, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"])
+
+      subject.run!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
+    end
+
+    context "with network=host" do
+      let(:runner_options) { {"network" => "host"} }
+
+      it "calls docker run with --net host" do
+        stub_good_run!("docker", :params => ["run", :rm, [:net, "host"], "hello-world:latest"])
+
+        subject.run!("docker://hello-world:latest")
+      end
+    end
+  end
 
   describe "#run_async!" do
     it "raises an exception without a resource" do
@@ -32,6 +68,16 @@ RSpec.describe Floe::Workflow::Runner::Docker do
       stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"], :output => container_id)
 
       subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
+    end
+
+    context "with network=host" do
+      let(:runner_options) { {"network" => "host"} }
+
+      it "calls docker run with --net host" do
+        stub_good_run!("docker", :params => ["run", :detach, [:net, "host"], "hello-world:latest"])
+
+        subject.run_async!("docker://hello-world:latest")
+      end
     end
   end
 
@@ -89,16 +135,6 @@ RSpec.describe Floe::Workflow::Runner::Docker do
       stub_bad_run!("docker", :params => ["rm", container_id])
       expect(secrets_file).to receive(:close!)
       subject.cleanup(container_id, secrets_file)
-    end
-
-    context "with network=host" do
-      let(:runner_options) { {"network" => "host"} }
-
-      it "calls docker run with --net host" do
-        stub_good_run!("docker", :params => ["run", :rm, "hello-world:latest"])
-
-        subject.run!("docker://hello-world:latest")
-      end
     end
   end
 end

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -1,39 +1,101 @@
 RSpec.describe Floe::Workflow::Runner::Docker do
+  require "securerandom"
+
   let(:subject)        { described_class.new(runner_options) }
   let(:runner_options) { {} }
 
-  describe "#run!" do
+  let(:subject)      { described_class.new }
+  let(:container_id) { SecureRandom.hex }
+
+  describe "#run_async!" do
     it "raises an exception without a resource" do
-      expect { subject.run!(nil) }.to raise_error(ArgumentError, "Invalid resource")
+      expect { subject.run_async!(nil) }.to raise_error(ArgumentError, "Invalid resource")
     end
 
     it "raises an exception for an invalid resource uri" do
-      expect { subject.run!("arn:abcd:efgh") }.to raise_error(ArgumentError, "Invalid resource")
+      expect { subject.run_async!("arn:abcd:efgh") }.to raise_error(ArgumentError, "Invalid resource")
     end
 
     it "calls docker run with the image name" do
-      stub_good_run!("docker", :params => ["run", :rm, "hello-world:latest"])
+      stub_good_run!("docker", :params => ["run", :detach, "hello-world:latest"], :output => container_id)
 
-      subject.run!("docker://hello-world:latest")
+      subject.run_async!("docker://hello-world:latest")
     end
 
     it "passes environment variables to docker run" do
-      stub_good_run!("docker", :params => ["run", :rm, [:e, "FOO=BAR"], "hello-world:latest"])
+      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], "hello-world:latest"], :output => container_id)
 
-      subject.run!("docker://hello-world:latest", {"FOO" => "BAR"})
+      subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"})
     end
 
     it "passes a secrets volume to docker run" do
-      stub_good_run!("docker", :params => ["run", :rm, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"])
+      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, "SECRETS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"], :output => container_id)
 
-      subject.run!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
+      subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
+    end
+  end
+
+  describe "#running?" do
+    it "returns true when running" do
+      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": true}}]")
+      expect(subject.running?(container_id)).to be_truthy
+    end
+
+    it "returns false when completed" do
+      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": false, \"ExitCode\": 0}}]")
+      expect(subject.running?(container_id)).to be_falsey
+    end
+  end
+
+  describe "#success?" do
+    it "returns true when successful" do
+      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": false, \"ExitCode\": 0}}]")
+      expect(subject.success?(container_id)).to be_truthy
+    end
+
+    it "returns false when unsuccessful" do
+      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": false, \"ExitCode\": 1}}]")
+      expect(subject.success?(container_id)).to be_falsey
+    end
+  end
+
+  describe "#output" do
+    it "returns log output" do
+      stub_good_run!("docker", :params => ["logs", container_id], :output => "hello, world!")
+      expect(subject.output(container_id)).to eq("hello, world!")
+    end
+
+    it "raises an exception when getting pod logs fails" do
+      stub_bad_run!("docker", :params => ["logs", container_id])
+      expect { subject.output(container_id) }.to raise_error(AwesomeSpawn::CommandResultError, /docker exit code: 1/)
+    end
+  end
+
+  describe "#cleanup" do
+    let(:secrets_file) { double("Tempfile") }
+
+    it "deletes the container and secret" do
+      stub_good_run!("docker", :params => ["rm", container_id])
+      expect(secrets_file).to receive(:close!)
+      subject.cleanup(container_id, secrets_file)
+    end
+
+    it "doesn't delete the secret_file if not passed" do
+      stub_good_run!("docker", :params => ["rm", container_id])
+      subject.cleanup(container_id, nil)
+    end
+
+    it "deletes the secrets file if deleting the container fails" do
+      stub_bad_run!("docker", :params => ["rm", container_id])
+      expect(secrets_file).to receive(:close!)
+      subject.cleanup(container_id, secrets_file)
     end
 
     context "with network=host" do
       let(:runner_options) { {"network" => "host"} }
 
       it "calls docker run with --net host" do
-        stub_good_run!("docker", :params => ["run", :rm, [:net, "host"], "hello-world:latest"])
+        stub_good_run!("docker", :params => ["run", :rm, "hello-world:latest"])
 
         subject.run!("docker://hello-world:latest")
       end

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -81,39 +81,52 @@ RSpec.describe Floe::Workflow::Runner::Docker do
     end
   end
 
+  describe "#status!" do
+    it "returns the updated container_state" do
+      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": true}}]")
+      runner_context = {:container_ref => container_id}
+
+      subject.status!(runner_context)
+
+      expect(runner_context).to include(:container_state => {"Running" => true})
+    end
+  end
+
   describe "#running?" do
     it "returns true when running" do
-      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": true}}]")
-      expect(subject.running?(container_id)).to be_truthy
+      runner_context = {:container_ref => container_id, :container_state => {"Running" => true}}
+      expect(subject.running?(runner_context)).to be_truthy
     end
 
     it "returns false when completed" do
-      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": false, \"ExitCode\": 0}}]")
-      expect(subject.running?(container_id)).to be_falsey
+      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 0}}
+      expect(subject.running?(runner_context)).to be_falsey
     end
   end
 
   describe "#success?" do
     it "returns true when successful" do
-      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": false, \"ExitCode\": 0}}]")
-      expect(subject.success?(container_id)).to be_truthy
+      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 0}}
+      expect(subject.success?(runner_context)).to be_truthy
     end
 
     it "returns false when unsuccessful" do
-      stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": false, \"ExitCode\": 1}}]")
-      expect(subject.success?(container_id)).to be_falsey
+      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 1}}
+      expect(subject.success?(runner_context)).to be_falsey
     end
   end
 
   describe "#output" do
+    let(:runner_context) { {:container_ref => container_id} }
+
     it "returns log output" do
       stub_good_run!("docker", :params => ["logs", container_id], :output => "hello, world!")
-      expect(subject.output(container_id)).to eq("hello, world!")
+      expect(subject.output(runner_context)).to eq("hello, world!")
     end
 
     it "raises an exception when getting pod logs fails" do
       stub_bad_run!("docker", :params => ["logs", container_id])
-      expect { subject.output(container_id) }.to raise_error(AwesomeSpawn::CommandResultError, /docker exit code: 1/)
+      expect { subject.output(runner_context) }.to raise_error(AwesomeSpawn::CommandResultError, /docker exit code: 1/)
     end
   end
 
@@ -124,20 +137,20 @@ RSpec.describe Floe::Workflow::Runner::Docker do
       stub_good_run!("docker", :params => ["rm", container_id])
       expect(File).to receive(:exist?).with(secrets_file).and_return(true)
       expect(File).to receive(:unlink).with(secrets_file)
-      subject.cleanup(container_id, secrets_file)
+      subject.cleanup({:container_ref => container_id, :secrets_ref => secrets_file})
     end
 
     it "doesn't delete the secret_file if not passed" do
       stub_good_run!("docker", :params => ["rm", container_id])
       expect(File).not_to receive(:unlink).with(secrets_file)
-      subject.cleanup(container_id, nil)
+      subject.cleanup({:container_ref => container_id})
     end
 
     it "deletes the secrets file if deleting the container fails" do
       stub_bad_run!("docker", :params => ["rm", container_id])
       expect(File).to receive(:exist?).with(secrets_file).and_return(true)
       expect(File).to receive(:unlink).with(secrets_file)
-      subject.cleanup(container_id, secrets_file)
+      subject.cleanup({:container_ref => container_id, :secrets_ref => secrets_file})
     end
   end
 end

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Floe::Workflow::Runner::Docker do
     end
 
     it "passes a secrets volume to docker run" do
-      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, "SECRETS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"], :output => container_id)
+      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"], :output => container_id)
 
       subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
     end

--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
     end
 
     it "cleans up secrets if running the pod fails" do
-      expect(subject).to receive(:delete_secret)
-
+      expect(kubeclient).to receive(:delete_secret)
+      expect(kubeclient).to receive(:delete_pod).and_raise(Kubeclient::HttpError.new(404, "Not Found", {}))
       expect(kubeclient).to receive(:create_secret).with(hash_including(:kind => "Secret", :type => "Opaque"))
       expect(kubeclient).to receive(:create_pod).and_raise(Kubeclient::HttpError.new(403, "Forbidden", {}))
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run!)
             .with(payload["Resource"], {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
+            .and_return(:exit_code => 0, :output => "hello, world!")
 
           subject
         end
@@ -30,6 +31,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run!)
             .with(payload["Resource"], {"bar" => "baz"}, nil)
+            .and_return(:exit_code => 0, :output => "hello, world!")
 
           subject
         end
@@ -42,6 +44,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run!)
             .with(payload["Resource"], {"var1" => "baz"}, nil)
+            .and_return(:exit_code => 0, :output => "hello, world!")
 
           subject
         end
@@ -56,7 +59,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run!)
             .with(payload["Resource"], {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
-            .and_return([0, "{\"response\":[\"192.168.1.2\"],\"exit_code\":0}"])
+            .and_return(:exit_code => 0, :output => "{\"response\":[\"192.168.1.2\"],\"exit_code\":0}")
 
           _, results = subject
 
@@ -71,7 +74,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run!)
             .with(payload["Resource"], input, nil)
-            .and_return([0, "[\"192.168.1.2\"]"])
+            .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
           _, results = subject
 
@@ -93,7 +96,7 @@ RSpec.describe Floe::Workflow::States::Task do
             expect(mock_runner)
               .to receive(:run!)
               .with(payload["Resource"], input, nil)
-              .and_return([0, "[\"192.168.1.2\"]"])
+              .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
             _, results = subject
 
@@ -112,7 +115,7 @@ RSpec.describe Floe::Workflow::States::Task do
             expect(mock_runner)
               .to receive(:run!)
               .with(payload["Resource"], input, nil)
-              .and_return([0, "[\"192.168.1.2\"]"])
+              .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
             _, results = subject
 
@@ -138,7 +141,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run!)
             .with(payload["Resource"], input, nil)
-            .and_return([0])
+            .and_return(:exit_code => 0)
 
           _, results = subject
 
@@ -162,7 +165,7 @@ RSpec.describe Floe::Workflow::States::Task do
             expect(mock_runner)
               .to receive(:run!)
               .with(payload["Resource"], input, nil)
-              .and_return([0])
+              .and_return(:exit_code => 0)
             _, results = subject
 
             expect(results).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
@@ -201,7 +204,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run!)
             .with(payload["Resource"], input, nil)
-            .and_return([0])
+            .and_return(:exit_code => 0)
           _, results = subject
 
           expect(results).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
@@ -220,7 +223,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run!)
             .with(payload["Resource"], input, nil)
-            .and_return([0])
+            .and_return(:exit_code => 0)
 
           _, results = subject
 


### PR DESCRIPTION
This adds the ability to run docker resources asynchronously by adding:
* `Floe::Workflow::Runner#run_async!`
* `Floe::Workflow::Runner#running?`
* `Floe::Workflow::Runner#success?`
* `Floe::Workflow::Runner#output`
* `Floe::Workflow::Runner#cleanup`

to the `Floe::Workflow::Runner` API