### PR TITLE
Set workflow output on completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fix State EnteredTime and FinishedTime (#59)
 
+### Added
+- Add workflow output (#57)
+
 ## [0.2.0] - 2023-07-05
 ### Added
 - Add ability to pass options to `Floe::Workflow::Runner` (#48)

--- a/exe/floe
+++ b/exe/floe
@@ -36,4 +36,4 @@ Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
 
 workflow.run!
 
-puts workflow.context.state["Output"].inspect
+puts workflow.output.inspect

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -11,7 +11,7 @@ module Floe
       end
     end
 
-    attr_reader :context, :credentials, :payload, :states, :states_by_name, :current_state, :status
+    attr_reader :context, :credentials, :output, :payload, :states, :states_by_name, :current_state, :status
 
     def initialize(payload, context = nil, credentials = {})
       payload     = JSON.parse(payload)     if payload.kind_of?(String)
@@ -58,6 +58,7 @@ module Floe
       @context["States"] << @context["State"]
 
       @status = current_state.status
+      @output = output if end?
 
       next_state_name = next_state&.name
       @current_state = next_state_name && @states_by_name[next_state_name]


### PR DESCRIPTION
When a workflow completes, set the last state's output as the workflow
output