### PR TITLE
Use the context accessor methods

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "securerandom"
 require "json"
 
 module Floe
@@ -42,6 +43,7 @@ module Floe
       input = context.state["Output"] || context.execution["Input"].dup
 
       context.state = {
+        "Guid"        => SecureRandom.uuid,
         "EnteredTime" => Time.now,
         "Input"       => input,
         "Name"        => current_state.name

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -25,6 +25,10 @@ module Floe
         @context["State"]
       end
 
+      def state=(val)
+        @context["State"] = val
+      end
+
       def states
         @context["States"]
       end


### PR DESCRIPTION
We have nice accessor methods for the context class so we should use them vs treating it like a hash