### PR TITLE
CLOCK_MONOTONIC cannot be used to get wall time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix State EnteredTime and FinishedTime (#59)
 
 ## [0.2.0] - 2023-07-05
 ### Added

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -41,18 +41,19 @@ module Floe
 
       input = @context["State"]["Output"] || @context["Execution"]["Input"].dup
 
+      @context["State"] = {
+        "EnteredTime" => Time.now,
+        "Input"       => input,
+        "Name"        => current_state.name
+      }
+
       tick = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       next_state, output = current_state.run!(input)
       tock = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-      @context["State"] = {
-        "EnteredTime"  => tick,
-        "FinishedTime" => tock,
-        "Duration"     => tock - tick,
-        "Output"       => output,
-        "Name"         => next_state&.name,
-        "Input"        => output
-      }
+      @context["State"]["FinishedTime"] = Time.now
+      @context["State"]["Duration"]     = (tock - tick) / 1_000_000.0
+      @context["State"]["Output"]       = output
 
       @context["States"] << @context["State"]
 


### PR DESCRIPTION
`CLOCK_MONOTONIC` cannot be used to get the wall time, it is only useful for comparing to other CLOCK_MONOTONIC values.