### PR TITLE
Refactor input/output path handling

### DIFF
--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -45,27 +45,18 @@ module Floe
       def run!(input)
         logger.info("Running state: [#{name}] with input [#{input}]")
 
-        input = process_input(input)
-
         output     = execute!(input)
         next_state = workflow.states_by_name[@next] unless end?
-
-        output ||= input
-        output   = output_path&.value(context, output)
 
         logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state&.name}] output: [#{output}]")
 
         [next_state, output]
       end
 
-      def execute!(input)
-        input
-      end
-
       private
 
-      def process_input(input)
-        input_path.value(context, input)
+      def execute!(*)
+        raise NotImplementedError, "Must be implemented in a subclass"
       end
     end
   end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -45,9 +45,9 @@ module Floe
       def run!(input)
         logger.info("Running state: [#{name}] with input [#{input}]")
 
-        input = input_path.value(context, input)
+        input = process_input(input)
 
-        output     = block_given? ? yield(input) : input
+        output     = execute!(input)
         next_state = workflow.states_by_name[@next] unless end?
 
         output ||= input
@@ -56,6 +56,16 @@ module Floe
         logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state&.name}] output: [#{output}]")
 
         [next_state, output]
+      end
+
+      def execute!(input)
+        input
+      end
+
+      private
+
+      def process_input(input)
+        input_path.value(context, input)
       end
     end
   end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -47,8 +47,8 @@ module Floe
 
         input = input_path.value(context, input)
 
-        output, next_state = block_given? ? yield(input) : input
-        next_state ||= workflow.states_by_name[payload["Next"]] unless end?
+        output     = block_given? ? yield(input) : input
+        next_state = workflow.states_by_name[@next] unless end?
 
         output ||= input
         output   = output_path&.value(context, output)

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -16,9 +16,14 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
+        private
+
         def execute!(input)
+          input = input_path.value(context, input)
+
           @next = choices.detect { |choice| choice.true?(context, input) }&.next || default
-          input
+
+          output_path&.value(context, input)
         end
       end
     end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -16,11 +16,9 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(*)
-          super do |input|
-            @next = choices.detect { |choice| choice.true?(context, input) }&.next || default
-            input
-          end
+        def execute!(input)
+          @next = choices.detect { |choice| choice.true?(context, input) }&.next || default
+          input
         end
       end
     end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -18,12 +18,8 @@ module Floe
 
         def run!(*)
           super do |input|
-            next_state_name = choices.detect { |choice| choice.true?(context, input) }&.next || default
-            next_state      = workflow.states_by_name[next_state_name]
-
-            output = input
-
-            [output, next_state]
+            @next = choices.detect { |choice| choice.true?(context, input) }&.next || default
+            input
           end
         end
       end

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -13,23 +13,18 @@ module Floe
           @error = payload["Error"]
         end
 
-        def run!(input)
-          logger.info("Running state: [#{name}] with input [#{input}]")
-
-          next_state = nil
-          output     = input
-
-          logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state&.name}]")
-
-          [next_state, output]
-        end
-
         def end?
           true
         end
 
         def status
           "errored"
+        end
+
+        private
+
+        def execute!(_)
+          nil
         end
       end
     end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -18,8 +18,12 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
+        private
+
         def execute!(input)
-          result_path.set(input, result) if result && result_path
+          input  = input_path.value(context, input)
+          output = result_path.set(input, result) if result && result_path
+          output_path&.value(context, output)
         end
       end
     end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -20,9 +20,7 @@ module Floe
 
         def run!(*)
           super do |input|
-            output = input
-            output = result_path.set(output, result) if result && result_path
-            output
+            result_path.set(input, result) if result && result_path
           end
         end
       end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -18,10 +18,8 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
-        def run!(*)
-          super do |input|
-            result_path.set(input, result) if result && result_path
-          end
+        def execute!(input)
+          result_path.set(input, result) if result && result_path
         end
       end
     end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -4,15 +4,6 @@ module Floe
   class Workflow
     module States
       class Succeed < Floe::Workflow::State
-        attr_reader :input_path, :output_path
-
-        def initialize(workflow, name, payload)
-          super
-
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
-        end
-
         def end?
           true # TODO: Handle if this is ending a parallel or map state
         end
@@ -20,8 +11,7 @@ module Floe
         private
 
         def execute!(input)
-          input = input_path.value(context, input)
-          output_path&.value(context, input)
+          input
         end
       end
     end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -16,6 +16,13 @@ module Floe
         def end?
           true # TODO: Handle if this is ending a parallel or map state
         end
+
+        private
+
+        def execute!(input)
+          input = input_path.value(context, input)
+          output_path&.value(context, input)
+        end
       end
     end
   end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -41,7 +41,8 @@ module Floe
             catcher = self.catch.detect { |c| (c.error_equals & [err.to_s, "States.ALL"]).any? }
             raise if catcher.nil?
 
-            [output, workflow.states_by_name[catcher.next]]
+            @next = catcher.next
+            output
           end
         end
 

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -25,7 +25,12 @@ module Floe
           @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
         end
 
+        private
+
         def execute!(input)
+          input = input_path.value(context, input)
+          input = parameters.value(context, input) if parameters
+
           runner = Floe::Workflow::Runner.for_resource(resource)
           _exit_status, results = runner.run!(resource, input, credentials&.value({}, workflow.credentials))
 
@@ -40,14 +45,6 @@ module Floe
 
           @next = catcher.next
           output
-        end
-
-        private
-
-        def process_input(input)
-          input = super(input)
-          input = parameters.value(context, input) if parameters
-          input
         end
 
         def retry!(retrier)
@@ -78,7 +75,9 @@ module Floe
           end
 
           results = result_selector.value(context, results) if result_selector
-          result_path.set(output, results)
+          output = result_path.set(output, results)
+
+          output_path&.value(context, output)
         end
       end
     end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -16,9 +16,14 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
+        private
+
         def execute!(input)
+          input = input_path.value(context, input)
+
           sleep(seconds)
-          input
+
+          output_path&.value(context, input)
         end
       end
     end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -16,11 +16,9 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(*)
-          super do
-            sleep(seconds)
-            nil
-          end
+        def execute!(input)
+          sleep(seconds)
+          input
         end
       end
     end


### PR DESCRIPTION
Process input/output in child classes only since not all states have input_path or output_path properties.
I initially handled this in the base class to reduce duplication but since not all state types have this concept it is error prone and there isn't _that_ much duplication anyway