### PR TITLE
Minor tweak to `Fail#end?`

### DIFF
--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -11,6 +11,7 @@ module Floe
 
           @cause = payload["Cause"]
           @error = payload["Error"]
+          @end   = true
         end
 
         def run!(input)
@@ -22,10 +23,6 @@ module Floe
           logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state&.name}]")
 
           [next_state, output]
-        end
-
-        def end?
-          true
         end
 
         def status


### PR DESCRIPTION
`@end` is read from the ASL config file.
For `Fail`, this is also hard coded, but not in the ASL file.

After this, we hardcode the value