### PR TITLE
Remove `Success#end?` method override

### DIFF
--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -11,10 +11,7 @@ module Floe
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
-        end
-
-        def end?
-          true # TODO: Handle if this is ending a parallel or map state
+          @end         = true
         end
       end
     end


### PR DESCRIPTION
Use the `@end` instance variable rather than overriding the `#end?` method.

Follow-up to https://github.com/ManageIQ/floe/pull/62