### PR TITLE
[WIP] Put all state into context

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -18,8 +18,8 @@ Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.joi
 require "logger"
 Floe.logger = Logger.new($stdout)
 
-context = Floe::Workflow::Context.new(input: opts[:input])
-workflow = Floe::Workflow.load(opts[:workflow], context, opts[:credentials])
+context = Floe::Workflow::Context.new(:input => opts[:input])
+workflow = Floe::Workflow.load(opts[:workflow], opts[:credentials])
 
 runner_klass = case opts[:docker_runner]
                when "docker"
@@ -34,6 +34,6 @@ runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
 
 Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
 
-workflow.run!
+workflow.run!(context)
 
-puts workflow.output.inspect
+puts context.output.inspect

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -45,16 +45,11 @@ module Floe
 
       current_state = @states_by_name[context.state_name]
       tick = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      next_state, output = current_state.run!(context.input)
+      current_state.run!(context.input)
       tock = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       context.state["FinishedTime"] = Time.now.utc
       context.state["Duration"]     = tock - tick
-      if current_state.respond_to?(:error)
-        context.end_state!(output, :error => current_state.error, :cause => current_state.cause)
-      else
-        context.end_state!(output, next_state)
-      end
 
       logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
 

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -43,7 +43,7 @@ module Floe
 
       current_state = @states_by_name[context.state_name]
       tick = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      current_state.run!(context.input)
+      current_state.run!(context)
       tock = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       context.state["FinishedTime"] = Time.now.utc

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -10,21 +10,22 @@ module Floe
     class << self
       def load(path_or_io, credentials = {})
         payload = path_or_io.respond_to?(:read) ? path_or_io.read : File.read(path_or_io)
-        new(payload, credentials)
+        new("workflow", payload, credentials)
       end
     end
 
     attr_reader :context, :credentials, :payload, :states, :states_by_name, :start_at
 
-    def initialize(payload, credentials = {})
+    def initialize(name, payload, credentials = {})
       payload     = JSON.parse(payload)     if payload.kind_of?(String)
       credentials = JSON.parse(credentials) if credentials.kind_of?(String)
 
+      @name        = name
       @payload     = payload
       @credentials = credentials
       @start_at    = payload["StartAt"]
 
-      @states         = payload["States"].to_a.map { |name, state| State.build!(self, name, state) }
+      @states         = payload["States"].to_a.map { |state_name, state| State.build!(state_name, state, credentials) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
     rescue JSON::ParserError => err
       raise Floe::InvalidWorkflowError, err.message

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -65,8 +65,28 @@ module Floe
         end
       end
 
-      def state=(val)
-        @context["State"] = val
+      def start_next_state!(name = state["NextState"], input = state["Output"], init: false)
+        if init == true || state_name.nil?
+          execution["StartTime"] = Time.now.utc
+          input = execution["Input"]
+        end
+        @context["State"] = {
+          "Name"  => name,
+          "Input" => input.dup,
+          "Guid"  => SecureRandom.uuid
+        }
+
+        self
+      end
+
+      def end_state!(output, next_state = nil, cause: nil, error: nil)
+        state["Output"]      = output
+        state["NextState"]   = next_state
+        state["Error"]       = error if error
+        state["Cause"]       = cause if cause
+        execution["EndTime"] = Time.now.utc unless next_state
+
+        self
       end
 
       def state_history

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -6,7 +6,7 @@ module Floe
       include Logging
 
       class << self
-        def build!(workflow, name, payload)
+        def build!(name, payload, credentials = nil)
           state_type = payload["Type"]
 
           begin
@@ -15,14 +15,13 @@ module Floe
             raise Floe::InvalidWorkflowError, "Invalid state type: [#{state_type}]"
           end
 
-          klass.new(workflow, name, payload)
+          klass.new(name, payload, credentials)
         end
       end
 
-      attr_reader :workflow, :comment, :name, :type, :payload
+      attr_reader :comment, :name, :type, :payload
 
-      def initialize(workflow, name, payload)
-        @workflow = workflow
+      def initialize(name, payload, _credentials = nil)
         @name     = name
         @payload  = payload
         @type     = payload["Type"]

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -28,10 +28,6 @@ module Floe
         @type     = payload["Type"]
         @comment  = payload["Comment"]
       end
-
-      def context
-        workflow.context
-      end
     end
   end
 end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -16,7 +16,7 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(_input)
+        def run!(context)
           input      = input_path.value(context, context.input)
           # NOTE: context.input != input
           next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -6,7 +6,7 @@ module Floe
       class Choice < Floe::Workflow::State
         attr_reader :choices, :default, :input_path, :output_path
 
-        def initialize(workflow, name, payload)
+        def initialize(name, payload, _credentials = nil)
           super
 
           @choices = payload["Choices"].map { |choice| ChoiceRule.build(choice) }

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -16,12 +16,13 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(input)
-          input      = input_path.value(context, input)
+        def run!(_input)
+          input      = input_path.value(context, context.input)
+          # NOTE: context.input != input
           next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default
           output     = output_path.value(context, input)
 
-          [next_state, output]
+          context.end_state!(output, next_state)
         end
 
         def end?

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -6,7 +6,7 @@ module Floe
       class Fail < Floe::Workflow::State
         attr_reader :cause, :error
 
-        def initialize(workflow, name, payload)
+        def initialize(name, payload, _credentials = nil)
           super
 
           @cause = payload["Cause"]

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -13,7 +13,7 @@ module Floe
           @error = payload["Error"]
         end
 
-        def run!(_input)
+        def run!(context)
           context.end_state!(context.input, :error => @error, :cause => @cause)
         end
 

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -13,8 +13,8 @@ module Floe
           @error = payload["Error"]
         end
 
-        def run!(input)
-          [nil, input]
+        def run!(_input)
+          context.end_state!(context.input, :error => @error, :cause => @cause)
         end
 
         def end?

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -19,7 +19,7 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
-        def run!(_input)
+        def run!(context)
           output = input_path.value(context, context.input)
           output = result_path.set(output, result) if result && result_path
           output = output_path.value(context, output)

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -19,12 +19,12 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
-        def run!(input)
-          output = input_path.value(context, input)
+        def run!(_input)
+          output = input_path.value(context, context.input)
           output = result_path.set(output, result) if result && result_path
           output = output_path.value(context, output)
 
-          [@end ? nil : @next, output]
+          context.end_state!(output, @next)
         end
 
         def end?

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -6,7 +6,7 @@ module Floe
       class Pass < Floe::Workflow::State
         attr_reader :end, :next, :result, :parameters, :input_path, :output_path, :result_path
 
-        def initialize(workflow, name, payload)
+        def initialize(name, payload, _credentials = nil)
           super
 
           @next        = payload["Next"]

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -21,7 +21,7 @@ module Floe
 
         def run!(context)
           output = input_path.value(context, context.input)
-          output = result_path.set(output, result) if result && result_path
+          output = result_path.set(output, result) if result
           output = output_path.value(context, output)
 
           context.end_state!(output, @next)

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -10,8 +10,8 @@ module Floe
           super
         end
 
-        def run!(input)
-          [nil, input]
+        def run!(_input)
+          context.end_state!(context.input)
         end
 
         def end?

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -10,7 +10,7 @@ module Floe
           super
         end
 
-        def run!(_input)
+        def run!(context)
           context.end_state!(context.input)
         end
 

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -6,10 +6,6 @@ module Floe
       class Succeed < Floe::Workflow::State
         attr_reader :input_path, :output_path
 
-        def initialize(workflow, name, payload)
-          super
-        end
-
         def run!(context)
           context.end_state!(context.input)
         end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -8,7 +8,7 @@ module Floe
                     :result_selector, :resource, :timeout_seconds, :retry, :catch,
                     :input_path, :output_path, :result_path
 
-        def initialize(workflow, name, payload)
+        def initialize(name, payload, credentials = nil)
           super
 
           @heartbeat_seconds = payload["HeartbeatSeconds"]
@@ -23,7 +23,7 @@ module Floe
           @result_path       = ReferencePath.new(payload.fetch("ResultPath", "$"))
           @parameters        = PayloadTemplate.new(payload["Parameters"])     if payload["Parameters"]
           @result_selector   = PayloadTemplate.new(payload["ResultSelector"]) if payload["ResultSelector"]
-          @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
+          @credentials       = payload["Credentials"] ? PayloadTemplate.new(payload["Credentials"]) : credentials
         end
 
         def run!(context)

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -6,7 +6,7 @@ module Floe
       class Wait < Floe::Workflow::State
         attr_reader :end, :next, :seconds, :input_path, :output_path
 
-        def initialize(workflow, name, payload)
+        def initialize(name, payload, _credentials = nil)
           super
 
           @next    = payload["Next"]

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -17,7 +17,7 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(_input)
+        def run!(context)
           input = input_path.value(context, context.input)
           sleep(seconds)
           output = output_path.value(context, input)

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -17,11 +17,11 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(input)
-          input = input_path.value(context, input)
+        def run!(_input)
+          input = input_path.value(context, context.input)
           sleep(seconds)
           output = output_path.value(context, input)
-          [@end ? nil : @next, output]
+          context.end_state!(output, @next)
         end
 
         def end?

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -1,14 +1,15 @@
 RSpec.describe Floe::Workflow::States::Choice do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("ChoiceState") }
   let(:state)    { workflow.states_by_name["ChoiceState"] }
-  let(:inputs)   { {} }
+  let(:input)    { {} }
 
   it "#end?" do
     expect(state.end?).to eq(false)
   end
 
   describe "#run!" do
-    let(:subject) { state.run!(inputs) }
+    let(:subject) { state.run!(ctx.input) }
 
     context "with a missing variable" do
       it "raises an exception" do
@@ -17,7 +18,7 @@ RSpec.describe Floe::Workflow::States::Choice do
     end
 
     context "with an input value matching a condition" do
-      let(:inputs) { {"foo" => 1} }
+      let(:input) { {"foo" => 1} }
 
       it "returns the next state" do
         next_state, = subject
@@ -26,7 +27,7 @@ RSpec.describe Floe::Workflow::States::Choice do
     end
 
     context "with an input value not matching any condition" do
-      let(:inputs) { {"foo" => 4} }
+      let(:input) { {"foo" => 4} }
 
       it "returns the default state" do
         next_state, = subject

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -9,11 +9,9 @@ RSpec.describe Floe::Workflow::States::Choice do
   end
 
   describe "#run!" do
-    let(:subject) { state.run!(ctx.input) }
-
     context "with a missing variable" do
       it "raises an exception" do
-        expect { subject }.to raise_error(RuntimeError, "No such variable [$.foo]")
+        expect { state.run!(ctx.input) }.to raise_error(RuntimeError, "No such variable [$.foo]")
       end
     end
 
@@ -21,8 +19,9 @@ RSpec.describe Floe::Workflow::States::Choice do
       let(:input) { {"foo" => 1} }
 
       it "returns the next state" do
-        next_state, = subject
-        expect(next_state).to eq("FirstMatchState")
+        state.run!(ctx.input)
+        expect(ctx.next_state).to eq("FirstMatchState")
+        expect(ctx.status).to eq("running")
       end
     end
 
@@ -30,8 +29,9 @@ RSpec.describe Floe::Workflow::States::Choice do
       let(:input) { {"foo" => 4} }
 
       it "returns the default state" do
-        next_state, = subject
-        expect(next_state).to eq("FailState")
+        state.run!(ctx.input)
+        expect(ctx.next_state).to eq("FailState")
+        expect(ctx.status).to eq("running")
       end
     end
   end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Floe::Workflow::States::Choice do
   describe "#run!" do
     context "with a missing variable" do
       it "raises an exception" do
-        expect { state.run!(ctx.input) }.to raise_error(RuntimeError, "No such variable [$.foo]")
+        expect { state.run!(ctx) }.to raise_error(RuntimeError, "No such variable [$.foo]")
       end
     end
 
@@ -19,7 +19,7 @@ RSpec.describe Floe::Workflow::States::Choice do
       let(:input) { {"foo" => 1} }
 
       it "returns the next state" do
-        state.run!(ctx.input)
+        state.run!(ctx)
         expect(ctx.next_state).to eq("FirstMatchState")
         expect(ctx.status).to eq("running")
       end
@@ -29,7 +29,7 @@ RSpec.describe Floe::Workflow::States::Choice do
       let(:input) { {"foo" => 4} }
 
       it "returns the default state" do
-        state.run!(ctx.input)
+        state.run!(ctx)
         expect(ctx.next_state).to eq("FailState")
         expect(ctx.status).to eq("running")
       end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Floe::Workflow::States::Choice do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("ChoiceState") }
   let(:state)    { workflow.states_by_name["ChoiceState"] }
   let(:input)    { {} }

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe Floe::Workflow::States::Fail do
   end
 
   it "#run!" do
-    next_state, _output = state.run!(ctx.input)
-    expect(next_state).to eq(nil)
+    state.run!(ctx.input)
+    ctx.next_state
+    ctx.status
+    expect(ctx.next_state).to eq(nil)
+    expect(ctx.status).to eq("failure")
   end
 end

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Floe::Workflow::States::Fail do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:ctx)      { Floe::Workflow::Context.new(nil, :input => {}).start_next_state!("FailState") }
   let(:state)    { workflow.states_by_name["FailState"] }
   let(:input)    { {} }

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Floe::Workflow::States::Fail do
   end
 
   it "#run!" do
-    state.run!(ctx.input)
+    state.run!(ctx)
     ctx.next_state
     ctx.status
     expect(ctx.next_state).to eq(nil)

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -1,13 +1,15 @@
 RSpec.describe Floe::Workflow::States::Fail do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => {}).start_next_state!("FailState") }
   let(:state)    { workflow.states_by_name["FailState"] }
+  let(:input)    { {} }
 
   it "#end?" do
     expect(state.end?).to be true
   end
 
   it "#run!" do
-    next_state, _output = state.run!({})
+    next_state, _output = state.run!(ctx.input)
     expect(next_state).to eq(nil)
   end
 end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::States::Pass do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("PassState") }
   let(:state)    { workflow.states_by_name["PassState"] }
+  let(:input)    { {} }
 
   describe "#end?" do
     it "is non-terminal" do
@@ -11,7 +13,7 @@ RSpec.describe Floe::Workflow::States::Pass do
 
   describe "#run!" do
     it "sets the result to the result path" do
-      next_state, output = state.run!({})
+      next_state, output = state.run!(ctx.input)
       expect(output["result"]).to include(state.result)
       expect(next_state).to eq("WaitState")
     end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Floe::Workflow::States::Pass do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("PassState") }
   let(:state)    { workflow.states_by_name["PassState"] }
   let(:input)    { {} }

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -13,9 +13,10 @@ RSpec.describe Floe::Workflow::States::Pass do
 
   describe "#run!" do
     it "sets the result to the result path" do
-      next_state, output = state.run!(ctx.input)
-      expect(output["result"]).to include(state.result)
-      expect(next_state).to eq("WaitState")
+      state.run!(ctx)
+      expect(ctx.output["result"]).to include(state.result)
+      expect(ctx.next_state).to eq("WaitState")
+      expect(ctx.status).to eq("running")
     end
   end
 end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe Floe::Workflow::States::Succeed do
 
   describe "#run!" do
     it "has no next" do
-      next_state, _output = state.run!(ctx.input)
-      expect(next_state).to be_nil
+      state.run!(ctx)
+      expect(ctx.next_state).to be_nil
+      expect(ctx.status).to eq("success")
     end
   end
 end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::States::Succeed do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => {}).start_next_state!("SuccessState") }
   let(:state)    { workflow.states_by_name["SuccessState"] }
+  let(:input)    { {} }
 
   it "#end?" do
     expect(state.end?).to be true
@@ -8,7 +10,7 @@ RSpec.describe Floe::Workflow::States::Succeed do
 
   describe "#run!" do
     it "has no next" do
-      next_state, _output = state.run!({})
+      next_state, _output = state.run!(ctx.input)
       expect(next_state).to be_nil
     end
   end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Floe::Workflow::States::Succeed do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:ctx)      { Floe::Workflow::Context.new(nil, :input => {}).start_next_state!("SuccessState") }
   let(:state)    { workflow.states_by_name["SuccessState"] }
   let(:input)    { {} }

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Floe::Workflow::States::Task do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("Task") }
   let(:input)    { {} }
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Floe::Workflow::States::Task do
   describe "#run" do
     let(:mock_runner) { double("Floe::Workflow::Runner") }
     let(:input)       { {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}} }
-    let(:state)       { described_class.new(workflow, "Task", payload) }
+    let(:state)       { described_class.new("Task", payload, nil) }
 
     before { allow(Floe::Workflow::Runner).to receive(:for_resource).and_return(mock_runner) }
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -1,12 +1,13 @@
 RSpec.describe Floe::Workflow::States::Task do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("Task") }
   let(:input)    { {} }
 
   describe "#run" do
     let(:mock_runner) { double("Floe::Workflow::Runner") }
     let(:input)       { {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}} }
     let(:state)       { described_class.new(workflow, "Task", payload) }
-    let(:subject)     { state.run!(input) }
+    let(:subject)     { state.run!(ctx.input) }
 
     before { allow(Floe::Workflow::Runner).to receive(:for_resource).and_return(mock_runner) }
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
             .and_return(:exit_code => 0, :output => "hello, world!")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
         end
       end
 
@@ -33,7 +33,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], {"bar" => "baz"}, nil)
             .and_return(:exit_code => 0, :output => "hello, world!")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
         end
       end
 
@@ -46,7 +46,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], {"var1" => "baz"}, nil)
             .and_return(:exit_code => 0, :output => "hello, world!")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
         end
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
             .and_return(:exit_code => 0, :output => "{\"response\":[\"192.168.1.2\"],\"exit_code\":0}")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.output).to eq("foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}, "ip_addrs" => ["192.168.1.2"])
         end
@@ -76,7 +76,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.output).to eq(
             "foo"      => {"bar" => "baz"},
@@ -98,7 +98,7 @@ RSpec.describe Floe::Workflow::States::Task do
               .with(payload["Resource"], input, nil)
               .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
-            state.run!(ctx.input)
+            state.run!(ctx)
 
             expect(ctx.output).to eq(
               "foo"  => {"bar" => "baz"},
@@ -117,7 +117,7 @@ RSpec.describe Floe::Workflow::States::Task do
               .with(payload["Resource"], input, nil)
               .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
-            state.run!(ctx.input)
+            state.run!(ctx)
 
             expect(ctx.output).to eq("ip_addrs" => ["192.168.1.2"])
           end
@@ -143,7 +143,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_return(:exit_code => 0)
 
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
         end
@@ -166,7 +166,7 @@ RSpec.describe Floe::Workflow::States::Task do
               .to receive(:run!)
               .with(payload["Resource"], input, nil)
               .and_return(:exit_code => 0)
-            state.run!(ctx.input)
+            state.run!(ctx)
 
             expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
           end
@@ -179,7 +179,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "States.Timeout")
 
-          expect { state.run!(ctx.input) }.to raise_error(RuntimeError, "States.Timeout")
+          expect { state.run!(ctx) }.to raise_error(RuntimeError, "States.Timeout")
         end
 
         it "raises if the exception isn't caught" do
@@ -188,7 +188,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "Exception")
 
-          expect { state.run!(ctx.input) }.to raise_error(RuntimeError, "Exception")
+          expect { state.run!(ctx) }.to raise_error(RuntimeError, "Exception")
         end
       end
 
@@ -205,7 +205,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .to receive(:run!)
             .with(payload["Resource"], input, nil)
             .and_return(:exit_code => 0)
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
         end
@@ -225,7 +225,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_return(:exit_code => 0)
 
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
         end
@@ -236,7 +236,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "Exception")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.next_state).to eq("FailState")
         end
@@ -253,7 +253,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "States.Timeout")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.next_state).to eq("FirstState")
           expect(ctx.status).to eq("running")
@@ -265,7 +265,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "Exception")
 
-          expect { state.run!(ctx.input) }.to raise_error(RuntimeError, "Exception")
+          expect { state.run!(ctx) }.to raise_error(RuntimeError, "Exception")
         end
       end
 
@@ -278,7 +278,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "States.Timeout")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.next_state).to eq("FirstState")
         end
@@ -289,7 +289,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "Exception")
 
-          state.run!(ctx.input)
+          state.run!(ctx)
 
           expect(ctx.next_state).to eq("FailState")
         end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Floe::Workflow::States::Task do
     let(:mock_runner) { double("Floe::Workflow::Runner") }
     let(:input)       { {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}} }
     let(:state)       { described_class.new(workflow, "Task", payload) }
-    let(:subject)     { state.run!(ctx.input) }
 
     before { allow(Floe::Workflow::Runner).to receive(:for_resource).and_return(mock_runner) }
 
@@ -21,7 +20,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
             .and_return(:exit_code => 0, :output => "hello, world!")
 
-          subject
+          state.run!(ctx.input)
         end
       end
 
@@ -34,7 +33,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], {"bar" => "baz"}, nil)
             .and_return(:exit_code => 0, :output => "hello, world!")
 
-          subject
+          state.run!(ctx.input)
         end
       end
 
@@ -47,7 +46,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], {"var1" => "baz"}, nil)
             .and_return(:exit_code => 0, :output => "hello, world!")
 
-          subject
+          state.run!(ctx.input)
         end
       end
     end
@@ -62,9 +61,9 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
             .and_return(:exit_code => 0, :output => "{\"response\":[\"192.168.1.2\"],\"exit_code\":0}")
 
-          _, results = subject
+          state.run!(ctx.input)
 
-          expect(results).to eq("foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}, "ip_addrs" => ["192.168.1.2"])
+          expect(ctx.output).to eq("foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}, "ip_addrs" => ["192.168.1.2"])
         end
       end
 
@@ -77,9 +76,9 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
-          _, results = subject
+          state.run!(ctx.input)
 
-          expect(results).to eq(
+          expect(ctx.output).to eq(
             "foo"      => {"bar" => "baz"},
             "bar"      => {"baz" => "foo"},
             "ip_addrs" => ["192.168.1.2"]
@@ -99,9 +98,9 @@ RSpec.describe Floe::Workflow::States::Task do
               .with(payload["Resource"], input, nil)
               .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
-            _, results = subject
+            state.run!(ctx.input)
 
-            expect(results).to eq(
+            expect(ctx.output).to eq(
               "foo"  => {"bar" => "baz"},
               "bar"  => {"baz" => "foo"},
               "data" => {"ip_addrs" => ["192.168.1.2"]}
@@ -118,9 +117,9 @@ RSpec.describe Floe::Workflow::States::Task do
               .with(payload["Resource"], input, nil)
               .and_return(:exit_code => 0, :output => "[\"192.168.1.2\"]")
 
-            _, results = subject
+            state.run!(ctx.input)
 
-            expect(results).to eq("ip_addrs" => ["192.168.1.2"])
+            expect(ctx.output).to eq("ip_addrs" => ["192.168.1.2"])
           end
         end
       end
@@ -144,9 +143,9 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_return(:exit_code => 0)
 
-          _, results = subject
+          state.run!(ctx.input)
 
-          expect(results).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
+          expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
         end
 
         context "with multiple retriers" do
@@ -167,9 +166,9 @@ RSpec.describe Floe::Workflow::States::Task do
               .to receive(:run!)
               .with(payload["Resource"], input, nil)
               .and_return(:exit_code => 0)
-            _, results = subject
+            state.run!(ctx.input)
 
-            expect(results).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
+            expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
           end
         end
 
@@ -180,7 +179,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "States.Timeout")
 
-          expect { subject }.to raise_error(RuntimeError, "States.Timeout")
+          expect { state.run!(ctx.input) }.to raise_error(RuntimeError, "States.Timeout")
         end
 
         it "raises if the exception isn't caught" do
@@ -189,7 +188,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "Exception")
 
-          expect { subject }.to raise_error(RuntimeError, "Exception")
+          expect { state.run!(ctx.input) }.to raise_error(RuntimeError, "Exception")
         end
       end
 
@@ -206,9 +205,9 @@ RSpec.describe Floe::Workflow::States::Task do
             .to receive(:run!)
             .with(payload["Resource"], input, nil)
             .and_return(:exit_code => 0)
-          _, results = subject
+          state.run!(ctx.input)
 
-          expect(results).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
+          expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
         end
       end
 
@@ -226,9 +225,9 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_return(:exit_code => 0)
 
-          _, results = subject
+          state.run!(ctx.input)
 
-          expect(results).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
+          expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
         end
 
         it "invokes the Catch if no retriers match" do
@@ -237,9 +236,9 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "Exception")
 
-          next_state, _ = subject
+          state.run!(ctx.input)
 
-          expect(next_state).to eq("FailState")
+          expect(ctx.next_state).to eq("FailState")
         end
       end
     end
@@ -254,9 +253,10 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "States.Timeout")
 
-          next_state, _ = subject
+          state.run!(ctx.input)
 
-          expect(next_state).to eq("FirstState")
+          expect(ctx.next_state).to eq("FirstState")
+          expect(ctx.status).to eq("running")
         end
 
         it "raises if the exception isn't caught" do
@@ -265,7 +265,7 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "Exception")
 
-          expect { subject }.to raise_error(RuntimeError, "Exception")
+          expect { state.run!(ctx.input) }.to raise_error(RuntimeError, "Exception")
         end
       end
 
@@ -278,9 +278,9 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "States.Timeout")
 
-          next_state, _ = subject
+          state.run!(ctx.input)
 
-          expect(next_state).to eq("FirstState")
+          expect(ctx.next_state).to eq("FirstState")
         end
 
         it "catches the exception and transits to the next state" do
@@ -289,9 +289,9 @@ RSpec.describe Floe::Workflow::States::Task do
             .with(payload["Resource"], input, nil)
             .and_raise(RuntimeError, "Exception")
 
-          next_state, _ = subject
+          state.run!(ctx.input)
 
-          expect(next_state).to eq("FailState")
+          expect(ctx.next_state).to eq("FailState")
         end
       end
     end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -21,8 +21,10 @@ RSpec.describe Floe::Workflow::States::Pass do
       # skip the actual sleep
       expect(state).to receive(:sleep).with(state.seconds)
 
-      next_state, _output = state.run!(ctx.input)
-      expect(next_state).to eq("NextState")
+      state.run!(ctx.input)
+
+      expect(ctx.next_state).to eq("NextState")
+      expect(ctx.status).to eq("running")
     end
   end
 end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Floe::Workflow::States::Pass do
     it "sleeps for the requested amount of time" do
       expect(state).to receive(:sleep).with(state.seconds)
 
-      state.run!(ctx.input)
+      state.run!(ctx)
     end
 
     it "transitions to the next state" do
       # skip the actual sleep
       expect(state).to receive(:sleep).with(state.seconds)
 
-      state.run!(ctx.input)
+      state.run!(ctx)
 
       expect(ctx.next_state).to eq("NextState")
       expect(ctx.status).to eq("running")

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Floe::Workflow::States::Pass do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+ let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("WaitState") }
   let(:state)    { workflow.states_by_name["WaitState"] }
   let(:input)    { {} }

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::States::Pass do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("WaitState") }
   let(:state)    { workflow.states_by_name["WaitState"] }
+  let(:input)    { {} }
 
   describe "#end?" do
     it "is non-terminal" do
@@ -12,14 +14,14 @@ RSpec.describe Floe::Workflow::States::Pass do
     it "sleeps for the requested amount of time" do
       expect(state).to receive(:sleep).with(state.seconds)
 
-      state.run!({})
+      state.run!(ctx.input)
     end
 
     it "transitions to the next state" do
       # skip the actual sleep
       expect(state).to receive(:sleep).with(state.seconds)
 
-      next_state, _output = state.run!({})
+      next_state, _output = state.run!(ctx.input)
       expect(next_state).to eq("NextState")
     end
   end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Floe::Workflow do
 
   def make_workflow(input, payload, creds: {})
     context = Floe::Workflow::Context.new(:input => input)
-    workflow = Floe::Workflow.new(make_payload(payload), creds)
+    workflow = Floe::Workflow.new("workflow", make_payload(payload), creds)
     [workflow, context]
   end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -99,6 +99,42 @@ RSpec.describe Floe::Workflow do
       expect(ctx.running?).to eq(false)
       expect(ctx.ended?).to eq(true)
     end
+
+    it "steps" do
+      input = {"input" => "value"}.freeze
+      workflow, ctx = make_workflow(
+        input, {
+          "FirstState"  => {"Type" => "Pass", "Next" => "SecondState"},
+          "SecondState" => {"Type" => "Succeed"}
+        }
+      )
+
+      expect(ctx.status).to eq("pending")
+      expect(ctx.started?).to eq(false)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(false)
+
+      workflow.step
+
+      expect(ctx.status).to eq("running")
+
+      # execution
+      expect(ctx.started?).to eq(true)
+      expect(ctx.running?).to eq(true)
+      expect(ctx.ended?).to eq(false)
+
+      # second step
+
+      workflow.step
+
+      expect(ctx.state_name).to eq("SecondState")
+      expect(ctx.status).to eq("success")
+
+      # execution
+      expect(ctx.started?).to eq(true)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(true)
+    end
   end
 
   private


### PR DESCRIPTION
- [x] Built upon #85
- [ ] Build upon #94

## High level

Move runtime state from workflow and into the context.

Breaking changes:

- `State#run!(context)` takes a context
- `Workflow.run!(context)` takes a context
- `Workflow.new` takes a name and not a context
- `Workflow#status` is dropped. use `Context#status` instead.
- `Workflow#output` is dropped. use `Context#output` instead. (Note: `output` always has a value)
- `Workflow#end?` is dropped. Use `Context#ended?` instead (or probably `Context#running?`

## Future goals

- Move tests away from a single workflow fixture and defining the payload in the specs themselves.
- Better test retry logic. Worried input will get botched
- Better test `try` / `catch` logic.
- Better test `input_path`/`output_path`. Ensure `context#input` is not used when it should be using the input from the `input_path`
- Better test `Workflow.run!`. It is mostly stubbed.

## Unsure

- Are `credential` considered runtime or configuration data.
- Who is responsible for timing a state? (`start_state` / `end_state`?)
- `start_state` and `end_state` possibly started to get too much logic. Not sure who owns the concept of `start_at` and initializing the workflow. Thinking this in terms of a unit test helps a little.
- Not sure who owns the concept of completing a workflow.
- Can you call `Workflow#step` on a workflow that is not initialized?
- What does it look like
