### PR TITLE
Refactor input output path handling

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -5,6 +5,8 @@ require "json"
 
 module Floe
   class Workflow
+    include Logging
+
     class << self
       def load(path_or_io, context = nil, credentials = {})
         payload = path_or_io.respond_to?(:read) ? path_or_io.read : File.read(path_or_io)
@@ -42,6 +44,8 @@ module Floe
 
       input = context.state["Output"] || context.execution["Input"].dup
 
+      logger.info("Running state: [#{current_state.name}] with input [#{input}]...")
+
       context.state = {
         "Guid"        => SecureRandom.uuid,
         "EnteredTime" => Time.now.utc,
@@ -56,6 +60,8 @@ module Floe
       context.state["FinishedTime"] = Time.now.utc
       context.state["Duration"]     = (tock - tick) / 1_000_000.0
       context.state["Output"]       = output
+
+      logger.info("Running state: [#{current_state.name}] with input [#{input}]...Complete - next state: [#{next_state}] output: [#{output}]")
 
       context.states << context.state
 

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -41,22 +41,6 @@ module Floe
       def status
         end? ? "success" : "running"
       end
-
-      def run!(input)
-        logger.info("Running state: [#{name}] with input [#{input}]")
-
-        input = input_path.value(context, input)
-
-        output, next_state = block_given? ? yield(input) : input
-        next_state ||= payload["Next"] unless end?
-
-        output ||= input
-        output   = output_path&.value(context, output)
-
-        logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state}] output: [#{output}]")
-
-        [next_state, output]
-      end
     end
   end
 end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -16,13 +16,12 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(*)
-          super do |input|
-            output     = input
-            next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default
+        def run!(input)
+          input      = input_path.value(context, input)
+          next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default
+          output     = output_path.value(context, input)
 
-            [output, next_state]
-          end
+          [next_state, output]
         end
       end
     end

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -15,14 +15,7 @@ module Floe
         end
 
         def run!(input)
-          logger.info("Running state: [#{name}] with input [#{input}]")
-
-          next_state = nil
-          output     = input
-
-          logger.info("Running state: [#{name}] with input [#{input}]...Complete - next state: [#{next_state&.name}]")
-
-          [next_state, output]
+          [nil, input]
         end
 
         def status

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -18,12 +18,12 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
-        def run!(*)
-          super do |input|
-            output = input
-            output = result_path.set(output, result) if result && result_path
-            output
-          end
+        def run!(input)
+          output = input_path.value(context, input)
+          output = result_path.set(output, result) if result && result_path
+          output = output_path.value(context, output)
+
+          [@next, output]
         end
       end
     end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -9,9 +9,11 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
-          @end         = true
+          @end = true
+        end
+
+        def run!(input)
+          [nil, input]
         end
       end
     end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -16,11 +16,11 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(*)
-          super do
-            sleep(seconds)
-            nil
-          end
+        def run!(input)
+          input = input_path.value(context, input)
+          sleep(seconds)
+          output = output_path.value(context, input)
+          [@next, output]
         end
       end
     end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
           next_state, _ = subject
 
-          expect(next_state.name).to eq("FailState")
+          expect(next_state).to eq("FailState")
         end
       end
     end
@@ -252,7 +252,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
           next_state, _ = subject
 
-          expect(next_state.name).to eq("FirstState")
+          expect(next_state).to eq("FirstState")
         end
 
         it "raises if the exception isn't caught" do
@@ -276,7 +276,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
           next_state, _ = subject
 
-          expect(next_state.name).to eq("FirstState")
+          expect(next_state).to eq("FirstState")
         end
 
         it "catches the exception and transits to the next state" do
@@ -287,7 +287,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
           next_state, _ = subject
 
-          expect(next_state.name).to eq("FailState")
+          expect(next_state).to eq("FailState")
         end
       end
     end


### PR DESCRIPTION
The base `State#run!` method tried to reduce code duplication by unifying input_path and output_path handling, however not all states have input_path and output_path defined so these states had to override the whole run! method.

Depends on:
- [x] https://github.com/ManageIQ/floe/pull/66