### PR TITLE
Map input output

### DIFF
--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -27,6 +27,7 @@ module Floe
         @payload  = payload
         # All states must define Next or End except for Choice, Succeed, and Fail
         @end      = !!payload["End"]
+        @next     = payload["Next"]
         # All states must define a Type
         @type     = payload["Type"]
         # All states may define a Comment
@@ -44,7 +45,7 @@ module Floe
       end
 
       def status
-        end? ? "success" : "running"
+        "success"
       end
     end
   end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -40,6 +40,14 @@ module Floe
         @end
       end
 
+      def next_state
+        terminal_state? ? nil : @next
+      end
+
+      def run!(input)
+        [next_state, run_input!(input)]
+      end
+
       def context
         workflow.context
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -25,12 +25,17 @@ module Floe
         @workflow = workflow
         @name     = name
         @payload  = payload
+        # All states must define Next or End except for Choice, Succeed, and Fail
         @end      = !!payload["End"]
+        # All states must define a Type
         @type     = payload["Type"]
+        # All states may define a Comment
         @comment  = payload["Comment"]
       end
 
-      def end?
+      # https://states-language.net/#terminal-state
+      # @return [Boolean] true if there is no transition from this state
+      def terminal_state?
         @end
       end
 

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -32,6 +32,9 @@ module Floe
         @type     = payload["Type"]
         # All states may define a Comment
         @comment  = payload["Comment"]
+        # All states may define InputPath and OutputPath except for Fail
+        @input_path  = Path.new(payload.fetch("InputPath", "$"))
+        @output_path = Path.new(payload.fetch("OutputPath", "$"))
       end
 
       # https://states-language.net/#terminal-state
@@ -45,7 +48,11 @@ module Floe
       end
 
       def run!(input)
-        [next_state, run_input!(input)]
+        input = @input_path.value(context, input) if @input_path
+        output = run_input!(input)
+        output = @output_path.value(context, output) if @output_path
+
+        [next_state, output]
       end
 
       def context

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -13,8 +13,8 @@ module Floe
           @error = payload["Error"]
         end
 
-        def run!(input)
-          [nil, input]
+        def run_input!(input)
+          input
         end
 
         def terminal_state?

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -11,11 +11,14 @@ module Floe
 
           @cause = payload["Cause"]
           @error = payload["Error"]
-          @end   = true
         end
 
         def run!(input)
           [nil, input]
+        end
+
+        def terminal_state?
+          true
         end
 
         def status

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -17,12 +17,10 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
-        def run!(input)
+        def run_input!(input)
           output = input_path.value(context, input)
           output = result_path.set(output, result) if result && result_path
-          output = output_path.value(context, output)
-
-          [@next, output]
+          output_path.value(context, output)
         end
       end
     end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -4,12 +4,11 @@ module Floe
   class Workflow
     module States
       class Pass < Floe::Workflow::State
-        attr_reader :next, :result, :parameters, :input_path, :output_path, :result_path
+        attr_reader :result, :parameters, :input_path, :output_path, :result_path
 
         def initialize(workflow, name, payload)
           super
 
-          @next        = payload["Next"]
           @result      = payload["Result"]
 
           @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -4,7 +4,7 @@ module Floe
   class Workflow
     module States
       class Pass < Floe::Workflow::State
-        attr_reader :end, :next, :result, :parameters, :input_path, :output_path, :result_path
+        attr_reader :next, :result, :parameters, :input_path, :output_path, :result_path
 
         def initialize(workflow, name, payload)
           super

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -4,7 +4,7 @@ module Floe
   class Workflow
     module States
       class Pass < Floe::Workflow::State
-        attr_reader :result, :parameters, :input_path, :output_path, :result_path
+        attr_reader :result, :parameters, :result_path
 
         def initialize(workflow, name, payload)
           super
@@ -12,15 +12,11 @@ module Floe
           @result      = payload["Result"]
 
           @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
         def run_input!(input)
-          output = input_path.value(context, input)
-          output = result_path.set(output, result) if result && result_path
-          output_path.value(context, output)
+          result && result_path ? result_path.set(input, result) : input
         end
       end
     end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -10,8 +10,8 @@ module Floe
           super
         end
 
-        def run!(input)
-          [nil, input]
+        def run_input!(input)
+          input
         end
 
         def terminal_state?

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -8,12 +8,14 @@ module Floe
 
         def initialize(workflow, name, payload)
           super
-
-          @end = true
         end
 
         def run!(input)
           [nil, input]
+        end
+
+        def terminal_state?
+          true
         end
       end
     end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -4,7 +4,7 @@ module Floe
   class Workflow
     module States
       class Task < Floe::Workflow::State
-        attr_reader :credentials, :end, :heartbeat_seconds, :next, :parameters,
+        attr_reader :credentials, :heartbeat_seconds, :parameters,
                     :result_selector, :resource, :timeout_seconds, :retry, :catch,
                     :input_path, :output_path, :result_path
 
@@ -12,7 +12,6 @@ module Floe
           super
 
           @heartbeat_seconds = payload["HeartbeatSeconds"]
-          @next              = payload["Next"]
           @resource          = payload["Resource"]
           @timeout_seconds   = payload["TimeoutSeconds"]
           @retry             = payload["Retry"].to_a.map { |retrier| Retrier.new(retrier) }

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -32,7 +32,7 @@ module Floe
           _exit_status, results = runner.run!(resource, input, credentials&.value({}, workflow.credentials))
 
           output = process_output!(input, results)
-          [@next, output]
+          [next_state, output]
         rescue => err
           retrier = self.retry.detect { |r| (r.error_equals & [err.to_s, "States.ALL"]).any? }
           retry if retry!(retrier)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -44,7 +44,8 @@ module Floe
           runner = Floe::Workflow::Runner.for_resource(resource)
           _exit_status, results = runner.run!(resource, input, credentials&.value({}, workflow.credentials))
 
-          process_output!(input, results)
+          output = process_output!(input, results)
+          output_path.value(context, output)
         end
 
         private
@@ -68,7 +69,6 @@ module Floe
 
         def process_output!(output, results)
           return output if results.nil?
-          return if output_path.nil?
 
           begin
             results = JSON.parse(results)
@@ -77,8 +77,7 @@ module Floe
           end
 
           results = result_selector.value(context, results) if result_selector
-          output  = result_path.set(output, results)
-          output_path.value(context, output)
+          result_path.set(output, results)
         end
       end
     end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -15,11 +15,10 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(input)
+        def run_input!(input)
           input = input_path.value(context, input)
           sleep(seconds)
-          output = output_path.value(context, input)
-          [@next, output]
+          output_path.value(context, input)
         end
       end
     end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -4,12 +4,11 @@ module Floe
   class Workflow
     module States
       class Wait < Floe::Workflow::State
-        attr_reader :end, :next, :seconds, :input_path, :output_path
+        attr_reader :seconds, :input_path, :output_path
 
         def initialize(workflow, name, payload)
           super
 
-          @next    = payload["Next"]
           @seconds = payload["Seconds"].to_i
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -4,21 +4,17 @@ module Floe
   class Workflow
     module States
       class Wait < Floe::Workflow::State
-        attr_reader :seconds, :input_path, :output_path
+        attr_reader :seconds
 
         def initialize(workflow, name, payload)
           super
 
           @seconds = payload["Seconds"].to_i
-
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
         def run_input!(input)
-          input = input_path.value(context, input)
           sleep(seconds)
-          output_path.value(context, input)
+          input
         end
       end
     end

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -1,8 +1,14 @@
 RSpec.describe Floe::Workflow::States::Fail do
   let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:state)    { workflow.states_by_name["FailState"] }
+  let(:inputs)   { {} }
 
-  it "#end?" do
-    expect(state.end?).to be true
+  it "#terminal_state?" do
+    expect(state.terminal_state?).to be true
+  end
+
+  it "has a next of nil" do
+    next_state, _output = state.run!(inputs)
+    expect(next_state).to be nil
   end
 end

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -11,4 +11,9 @@ RSpec.describe Floe::Workflow::States::Fail do
     next_state, _output = state.run!(inputs)
     expect(next_state).to be nil
   end
+
+  it "has a next of nil" do
+    next_state, _output = state.run!(inputs)
+    expect(next_state).to be nil
+  end
 end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -1,8 +1,14 @@
 RSpec.describe Floe::Workflow::States::Succeed do
   let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:state)    { workflow.states_by_name["SuccessState"] }
+  let(:inputs)   { {} }
 
-  it "#end?" do
-    expect(state.end?).to be true
+  it "#terminal_state?" do
+    expect(state.terminal_state?).to be true
+  end
+
+  it "has a next of nil" do
+    next_state, _output = state.run!(inputs)
+    expect(next_state).to be nil
   end
 end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -11,4 +11,9 @@ RSpec.describe Floe::Workflow::States::Succeed do
     next_state, _output = state.run!(inputs)
     expect(next_state).to be nil
   end
+
+  it "has a next of nil" do
+    next_state, _output = state.run!(inputs)
+    expect(next_state).to be nil
+  end
 end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -293,15 +293,15 @@ RSpec.describe Floe::Workflow::States::Task do
     end
   end
 
-  describe "#end?" do
+  describe "#terminal_state?" do
     it "with a normal state" do
       state = workflow.states_by_name["FirstState"]
-      expect(state.end?).to be false
+      expect(state.terminal_state?).to be false
     end
 
     it "with an end state" do
       state = workflow.states_by_name["NextState"]
-      expect(state.end?).to be true
+      expect(state.terminal_state?).to be true
     end
   end
 end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -293,6 +293,18 @@ RSpec.describe Floe::Workflow::States::Task do
     end
   end
 
+  describe "#next_state" do
+    it "with a normal state" do
+      state = workflow.states_by_name["FirstState"]
+      expect(state.next_state).to be
+    end
+
+    it "with an end state" do
+      state = workflow.states_by_name["NextState"]
+      expect(state.next_state).to be_nil
+    end
+  end
+
   describe "#terminal_state?" do
     it "with a normal state" do
       state = workflow.states_by_name["FirstState"]


### PR DESCRIPTION
There is a concept of extracting data from the input context, and extracting data out of here for use in the output.

This formalizes the concept and moves into a parent class.


commits:

- [ ] https://github.com/ManageIQ/floe/pull/72 (first 5 commits)
- Introduce run_input that is basically run without the `next` part
- Introduce `MappedState` so states do not deal with mapping input and output