### PR TITLE
don't pick up real KUBECONFIG for tests

### DIFF
--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe Floe::Workflow::Runner::Kubernetes do
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('KUBECONFIG', nil).and_return(nil)
+  end
+
   let(:subject)        { described_class.new(runner_options) }
   let(:runner_options) { {"server" => "https://kubernetes.local:6443", "token" => "my-token"} }
 


### PR DESCRIPTION
This was failing for me since I have a `KUBECONFIG` defined

It was picking up my real kubernetes file and I was getting strange errors like:

```
     Failure/Error: context = kubeconfig&.context(kubeconfig_context)

     KeyError:
       Unknown context foo
     # /Users/kbrock/.gem/ruby/3.0.6/gems/kubeclient-4.11.0/lib/kubeclient/config.rb:119:in `fetch_context'
     # /Users/kbrock/.gem/ruby/3.0.6/gems/kubeclient-4.11.0/lib/kubeclient/config.rb:47:in `context'
     # ./lib/floe/workflow/runner/kubernetes.rb:198:in `kubeclient'
```