### PR TITLE
move end out of the root state node

### DIFF
--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -25,21 +25,12 @@ module Floe
         @workflow = workflow
         @name     = name
         @payload  = payload
-        @end      = !!payload["End"]
         @type     = payload["Type"]
         @comment  = payload["Comment"]
       end
 
-      def end?
-        @end
-      end
-
       def context
         workflow.context
-      end
-
-      def status
-        end? ? "success" : "running"
       end
     end
   end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -23,6 +23,14 @@ module Floe
 
           [next_state, output]
         end
+
+        def status
+          "running"
+        end
+
+        def end?
+          false
+        end
       end
     end
   end

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -11,7 +11,6 @@ module Floe
 
           @cause = payload["Cause"]
           @error = payload["Error"]
-          @end   = true
         end
 
         def run!(input)
@@ -20,6 +19,10 @@ module Floe
 
         def status
           "errored"
+        end
+
+        def end?
+          true
         end
       end
     end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -10,6 +10,7 @@ module Floe
           super
 
           @next        = payload["Next"]
+          @end         = !!payload["End"]
           @result      = payload["Result"]
 
           @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]
@@ -23,7 +24,15 @@ module Floe
           output = result_path.set(output, result) if result && result_path
           output = output_path.value(context, output)
 
-          [@next, output]
+          [@end ? nil : @next, output]
+        end
+
+        def status
+          @end ? "success" : "running"
+        end
+
+        def end?
+          @end
         end
       end
     end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -8,12 +8,18 @@ module Floe
 
         def initialize(workflow, name, payload)
           super
-
-          @end = true
         end
 
         def run!(input)
           [nil, input]
+        end
+
+        def status
+          "success"
+        end
+
+        def end?
+          true
         end
       end
     end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -10,6 +10,7 @@ module Floe
           super
 
           @next    = payload["Next"]
+          @end     = !!payload["End"]
           @seconds = payload["Seconds"].to_i
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))
@@ -20,7 +21,15 @@ module Floe
           input = input_path.value(context, input)
           sleep(seconds)
           output = output_path.value(context, input)
-          [@next, output]
+          [@end ? nil : @next, output]
+        end
+
+        def status
+          @end ? "success" : "running"
+        end
+
+        def end?
+          @end
         end
       end
     end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -3,6 +3,10 @@ RSpec.describe Floe::Workflow::States::Choice do
   let(:state)    { workflow.states_by_name["ChoiceState"] }
   let(:inputs)   { {} }
 
+  it "#end?" do
+    expect(state.end?).to eq(false)
+  end
+
   describe "#run!" do
     let(:subject) { state.run!(inputs) }
 
@@ -29,5 +33,9 @@ RSpec.describe Floe::Workflow::States::Choice do
         expect(next_state).to eq("FailState")
       end
     end
+  end
+
+  it "#status" do
+    expect(state.status).to eq("running")
   end
 end

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -5,4 +5,13 @@ RSpec.describe Floe::Workflow::States::Fail do
   it "#end?" do
     expect(state.end?).to be true
   end
+
+  it "#run!" do
+    next_state, _output = state.run!({})
+    expect(next_state).to eq(nil)
+  end
+
+  it "#status" do
+    expect(state.status).to eq("errored")
+  end
 end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -2,10 +2,25 @@ RSpec.describe Floe::Workflow::States::Pass do
   let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:state)    { workflow.states_by_name["PassState"] }
 
+  describe "#end?" do
+    it "is non-terminal" do
+      expect(state.end?).to eq(false)
+    end
+    # TODO: test @end
+  end
+
   describe "#run!" do
     it "sets the result to the result path" do
-      _, output = state.run!({})
+      next_state, output = state.run!({})
       expect(output["result"]).to include(state.result)
+      expect(next_state).to eq("WaitState")
     end
+  end
+
+  describe "#status" do
+    it "is non-terminal" do
+      expect(state.status).to eq("running")
+    end
+    # TODO: test @end
   end
 end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -5,4 +5,15 @@ RSpec.describe Floe::Workflow::States::Succeed do
   it "#end?" do
     expect(state.end?).to be true
   end
+
+  describe "#run!" do
+    it "has no next" do
+      next_state, _output = state.run!({})
+      expect(next_state).to be_nil
+    end
+  end
+
+  it "#status" do
+    expect(state.status).to eq("success")
+  end
 end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -304,4 +304,16 @@ RSpec.describe Floe::Workflow::States::Task do
       expect(state.end?).to be true
     end
   end
+
+  describe "#status" do
+    it "with a normal state" do
+      state = workflow.states_by_name["FirstState"]
+      expect(state.status).to eq("running")
+    end
+
+    it "with an end state" do
+      state = workflow.states_by_name["NextState"]
+      expect(state.status).to eq("success")
+    end
+  end
 end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -2,11 +2,31 @@ RSpec.describe Floe::Workflow::States::Pass do
   let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
   let(:state)    { workflow.states_by_name["WaitState"] }
 
+  describe "#end?" do
+    it "is non-terminal" do
+      expect(state.end?).to eq(false)
+    end
+  end
+
   describe "#run!" do
     it "sleeps for the requested amount of time" do
       expect(state).to receive(:sleep).with(state.seconds)
 
       state.run!({})
+    end
+
+    it "transitions to the next state" do
+      # skip the actual sleep
+      expect(state).to receive(:sleep).with(state.seconds)
+
+      next_state, _output = state.run!({})
+      expect(next_state).to eq("NextState")
+    end
+  end
+
+  describe "#status" do
+    it "is non-terminal" do
+      expect(state.status).to eq("running")
     end
   end
 end


### PR DESCRIPTION
Goal is to have only valid parameters in each state node.

- Fixed the next state return values when end is nil
  Probably not necessary since next and end should not be defined in the same node.

---

Goal was to keep the code as close to the original, just moving `@end` into every node where it was valid and removing the `@end = true` since I think you said you didn't like that.

possibilities
- change `s/@end \? nil : @next/@next/g` -- both will not be defined on the same node.
- `s/end?/terminal_state?/g`