### PR TITLE
Add --network=host option to Docker/Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ workflow.run!
 
 ### Docker Runner Options
 
+#### Docker
+
+Options supported by the Docker docker runner are:
+
+* `network` - What docker to connect the container to, defaults to `"bridge"`.  If you need access to host resources for development you can pass `network=host`.
+
+#### Podman
+
+Options supported by the podman docker runner are:
+
+* `network` - What docker to connect the container to, defaults to `"bridge"`.  If you need access to host resources for development you can pass `network=host`.
+
 #### Kubernetes
 
 Options supported by the kubernetes docker runner are:

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -4,11 +4,13 @@ module Floe
   class Workflow
     class Runner
       class Docker < Floe::Workflow::Runner
-        def initialize(*)
+        def initialize(options = {})
           require "awesome_spawn"
           require "tempfile"
 
           super
+
+          @network = options.fetch("network", "bridge")
         end
 
         def run!(resource, env = {}, secrets = {})
@@ -16,7 +18,8 @@ module Floe
 
           image = resource.sub("docker://", "")
 
-          params = ["run", :rm, [:net, "host"]]
+          params  = ["run", :rm]
+          params += [[:net, "host"]] if network == "host"
           params += env.map { |k, v| [:e, "#{k}=#{v}"] } if env
 
           secrets_file = nil
@@ -39,6 +42,10 @@ module Floe
         ensure
           secrets_file&.close!
         end
+
+        private
+
+        attr_reader :network
       end
     end
   end

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Floe::Workflow::Runner::Docker do
-  let(:subject) { described_class.new }
+  let(:subject)        { described_class.new(runner_options) }
+  let(:runner_options) { {} }
 
   describe "#run!" do
     it "raises an exception without a resource" do
@@ -11,21 +12,31 @@ RSpec.describe Floe::Workflow::Runner::Docker do
     end
 
     it "calls docker run with the image name" do
-      stub_good_run!("docker", :params => ["run", :rm, [:net, "host"], "hello-world:latest"])
+      stub_good_run!("docker", :params => ["run", :rm, "hello-world:latest"])
 
       subject.run!("docker://hello-world:latest")
     end
 
     it "passes environment variables to docker run" do
-      stub_good_run!("docker", :params => ["run", :rm, [:net, "host"], [:e, "FOO=BAR"], "hello-world:latest"])
+      stub_good_run!("docker", :params => ["run", :rm, [:e, "FOO=BAR"], "hello-world:latest"])
 
       subject.run!("docker://hello-world:latest", {"FOO" => "BAR"})
     end
 
     it "passes a secrets volume to docker run" do
-      stub_good_run!("docker", :params => ["run", :rm, [:net, "host"], [:e, "FOO=BAR"], [:e, "SECRETS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"])
+      stub_good_run!("docker", :params => ["run", :rm, [:e, "FOO=BAR"], [:e, "SECRETS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"])
 
       subject.run!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
+    end
+
+    context "with network=host" do
+      let(:runner_options) { {"network" => "host"} }
+
+      it "calls docker run with --net host" do
+        stub_good_run!("docker", :params => ["run", :rm, [:net, "host"], "hello-world:latest"])
+
+        subject.run!("docker://hello-world:latest")
+      end
     end
   end
 end

--- a/spec/workflow/runner/podman_spec.rb
+++ b/spec/workflow/runner/podman_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Floe::Workflow::Runner::Podman do
-  let(:subject) { described_class.new }
+  let(:subject)        { described_class.new(runner_options) }
+  let(:runner_options) { {} }
 
   describe "#run!" do
     it "raises an exception without a resource" do
@@ -28,6 +29,16 @@ RSpec.describe Floe::Workflow::Runner::Podman do
       stub_good_run("podman", :params => ["secret", "rm", anything])
 
       subject.run!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
+    end
+
+    context "with network=host" do
+      let(:runner_options) { {"network" => "host"} }
+
+      it "calls docker run with --net host" do
+        stub_good_run!("podman", :params => ["run", :rm, [:net, "host"], "hello-world:latest"])
+
+        subject.run!("docker://hello-world:latest")
+      end
     end
   end
 end


### PR DESCRIPTION
This aides in local development by allowing your floe containers to be
able to hit host resources via `localhost` while defaulting to the more
secure bridge network by default.

Fixes https://github.com/ManageIQ/floe/issues/77