### PR TITLE
Move state from workflow into context

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -14,7 +14,7 @@ module Floe
       end
     end
 
-    attr_reader :context, :credentials, :output, :payload, :states, :states_by_name, :current_state, :status
+    attr_reader :context, :credentials, :output, :payload, :states, :states_by_name, :current_state, :status, :start_at
 
     def initialize(payload, context = nil, credentials = {})
       payload     = JSON.parse(payload)     if payload.kind_of?(String)
@@ -24,10 +24,10 @@ module Floe
       @payload     = payload
       @context     = context
       @credentials = credentials
+      @start_at    = payload["StartAt"]
 
       @states         = payload["States"].to_a.map { |name, state| State.build!(self, name, state) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
-      start_at        = @payload["StartAt"]
 
       context.state["Name"] ||= start_at
 

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -57,6 +57,7 @@ module Floe
       context.state["FinishedTime"] = Time.now.utc
       context.state["Duration"]     = tock - tick
       context.state["Output"]       = output
+      context.execution["EndTime"]  = Time.now.utc if next_state.nil?
 
       logger.info("Running state: [#{current_state.name}] with input [#{context["Input"]}]...Complete - next state: [#{next_state}] output: [#{output}]")
 
@@ -79,7 +80,7 @@ module Floe
     end
 
     def end?
-      current_state.nil?
+      !!context.execution["EndTime"]
     end
   end
 end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -14,7 +14,7 @@ module Floe
       end
     end
 
-    attr_reader :context, :credentials, :payload, :states, :states_by_name, :current_state, :start_at
+    attr_reader :context, :credentials, :payload, :states, :states_by_name, :start_at
 
     def initialize(payload, context = nil, credentials = {})
       payload     = JSON.parse(payload)     if payload.kind_of?(String)
@@ -30,9 +30,6 @@ module Floe
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
 
       context.state["Name"] ||= start_at
-
-      current_state_name = context.state["Name"]
-      @current_state     = @states_by_name[current_state_name]
     rescue JSON::ParserError => err
       raise Floe::InvalidWorkflowError, err.message
     end
@@ -43,26 +40,26 @@ module Floe
       context.state["Guid"]    = SecureRandom.uuid
       context.state["Input"] ||= context.execution["Input"].dup
 
-      logger.info("Running state: [#{current_state.name}] with input [#{context.state["Input"]}]...")
+      logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...")
 
       context.state["EnteredTime"] = Time.now.utc
 
+      current_state = @states_by_name[context.state_name]
       tick = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      next_state, output = current_state.run!(context.state["Input"])
+      next_state, output = current_state.run!(context.input)
       tock = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       context.state["FinishedTime"] = Time.now.utc
       context.state["Duration"]     = tock - tick
       context.state["Output"]       = output
+      context.state["NextState"]    = next_state
       context.state["Error"]        = current_state.error if current_state.respond_to?(:error)
       context.state["Cause"]        = current_state.cause if current_state.respond_to?(:cause)
       context.execution["EndTime"]  = Time.now.utc if next_state.nil?
 
-      logger.info("Running state: [#{current_state.name}] with input [#{context["Input"]}]...Complete - next state: [#{next_state}] output: [#{output}]")
+      logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
 
       context.state_history << context.state
-
-      @current_state = next_state && @states_by_name[next_state]
 
       context.state = {"Name" => next_state, "Input" => output} unless end?
 

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -21,8 +21,36 @@ module Floe
         @context["Execution"]
       end
 
+      def started?
+        execution.key?("StartTime")
+      end
+
+      def running?
+        started? && !ended?
+      end
+
+      def ended?
+        execution.key?("EndTime")
+      end
+
       def state
         @context["State"]
+      end
+
+      def output
+        state["Output"]
+      end
+
+      def status
+        if !started?
+          "pending"
+        elsif running?
+          "running"
+        elsif state["Error"]
+          "failure"
+        else
+          "success"
+        end
       end
 
       def state=(val)

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -37,8 +37,20 @@ module Floe
         @context["State"]
       end
 
+      def input
+        state["Input"]
+      end
+
       def output
         state["Output"]
+      end
+
+      def state_name
+        state["Name"]
+      end
+
+      def next_state
+        state["NextState"]
       end
 
       def status

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -24,10 +24,6 @@ module Floe
           [next_state, output]
         end
 
-        def status
-          "running"
-        end
-
         def end?
           false
         end

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -17,10 +17,6 @@ module Floe
           [nil, input]
         end
 
-        def status
-          "errored"
-        end
-
         def end?
           true
         end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -27,10 +27,6 @@ module Floe
           [@end ? nil : @next, output]
         end
 
-        def status
-          @end ? "success" : "running"
-        end
-
         def end?
           @end
         end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -14,10 +14,6 @@ module Floe
           [nil, input]
         end
 
-        def status
-          "success"
-        end
-
         def end?
           true
         end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -45,10 +45,6 @@ module Floe
           [catcher.next, output]
         end
 
-        def status
-          @end ? "success" : "running"
-        end
-
         def end?
           @end
         end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -24,10 +24,6 @@ module Floe
           [@end ? nil : @next, output]
         end
 
-        def status
-          @end ? "success" : "running"
-        end
-
         def end?
           @end
         end

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Floe::Workflow::Context do
+  describe "#new" do
+    let(:input) { {"x" => "y"}.freeze }
+
+    it "sets input" do
+      ctx = described_class.new(:input => input)
+      expect(ctx.execution["Input"]).to eq(input)
+    end
+  end
+end

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -58,6 +58,13 @@ RSpec.describe Floe::Workflow::Context do
     end
   end
 
+  describe "#input" do
+    it "started" do
+      ctx.state["Input"] = input
+      expect(ctx.input).to eq(input)
+    end
+  end
+
   describe "#output" do
     it "new context" do
       expect(ctx.output).to eq(nil)
@@ -66,6 +73,23 @@ RSpec.describe Floe::Workflow::Context do
     it "ended" do
       ctx.state["Output"] = input.dup
       expect(ctx.output).to eq(input)
+    end
+  end
+
+  describe "#state_name" do
+    it "first context" do
+      ctx.state["Name"] = "FirstState"
+
+      expect(ctx.state_name).to eq("FirstState")
+    end
+  end
+
+  describe "#next_state" do
+    it "first context" do
+      ctx.state["Name"] = "FirstState"
+      ctx.state["NextState"] = "MiddleState"
+
+      expect(ctx.next_state).to eq("MiddleState")
     end
   end
 

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -1,10 +1,99 @@
 RSpec.describe Floe::Workflow::Context do
-  describe "#new" do
-    let(:input) { {"x" => "y"}.freeze }
+  let(:ctx) { described_class.new(:input => input) }
+  let(:input) { {"x" => "y"}.freeze }
 
+  describe "#new" do
     it "sets input" do
-      ctx = described_class.new(:input => input)
       expect(ctx.execution["Input"]).to eq(input)
+    end
+  end
+
+  describe "#started?" do
+    it "new context" do
+      expect(ctx.started?).to eq(false)
+    end
+
+    it "started" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+
+      expect(ctx.started?).to eq(true)
+    end
+  end
+
+  describe "#running?" do
+    it "new context" do
+      expect(ctx.running?).to eq(false)
+    end
+
+    it "running" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+
+      expect(ctx.running?).to eq(true)
+    end
+
+    it "ended" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+      ctx.execution["EndTime"] ||= Time.now.utc
+
+      expect(ctx.running?).to eq(false)
+    end
+  end
+
+  describe "#ended?" do
+    it "new context" do
+      expect(ctx.ended?).to eq(false)
+    end
+
+    it "started" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+
+      expect(ctx.ended?).to eq(false)
+    end
+
+    it "ended" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+      ctx.execution["EndTime"] ||= Time.now.utc
+
+      expect(ctx.ended?).to eq(true)
+    end
+  end
+
+  describe "#output" do
+    it "new context" do
+      expect(ctx.output).to eq(nil)
+    end
+
+    it "ended" do
+      ctx.state["Output"] = input.dup
+      expect(ctx.output).to eq(input)
+    end
+  end
+
+  describe "#status" do
+    it "new context" do
+      expect(ctx.status).to eq("pending")
+    end
+
+    it "started" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+
+      expect(ctx.status).to eq("running")
+    end
+
+    it "ended with success" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+      ctx.execution["EndTime"] ||= Time.now.utc
+
+      expect(ctx.status).to eq("success")
+    end
+
+    it "ended with error" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+      ctx.execution["EndTime"] ||= Time.now.utc
+      ctx.state["Cause"] = "issue"
+      ctx.state["Error"] = "error"
+
+      expect(ctx.status).to eq("failure")
     end
   end
 end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -34,8 +34,4 @@ RSpec.describe Floe::Workflow::States::Choice do
       end
     end
   end
-
-  it "#status" do
-    expect(state.status).to eq("running")
-  end
 end

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -10,8 +10,4 @@ RSpec.describe Floe::Workflow::States::Fail do
     next_state, _output = state.run!({})
     expect(next_state).to eq(nil)
   end
-
-  it "#status" do
-    expect(state.status).to eq("errored")
-  end
 end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -16,11 +16,4 @@ RSpec.describe Floe::Workflow::States::Pass do
       expect(next_state).to eq("WaitState")
     end
   end
-
-  describe "#status" do
-    it "is non-terminal" do
-      expect(state.status).to eq("running")
-    end
-    # TODO: test @end
-  end
 end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -12,8 +12,4 @@ RSpec.describe Floe::Workflow::States::Succeed do
       expect(next_state).to be_nil
     end
   end
-
-  it "#status" do
-    expect(state.status).to eq("success")
-  end
 end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -304,16 +304,4 @@ RSpec.describe Floe::Workflow::States::Task do
       expect(state.end?).to be true
     end
   end
-
-  describe "#status" do
-    it "with a normal state" do
-      state = workflow.states_by_name["FirstState"]
-      expect(state.status).to eq("running")
-    end
-
-    it "with an end state" do
-      state = workflow.states_by_name["NextState"]
-      expect(state.status).to eq("success")
-    end
-  end
 end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -23,10 +23,4 @@ RSpec.describe Floe::Workflow::States::Pass do
       expect(next_state).to eq("NextState")
     end
   end
-
-  describe "#status" do
-    it "is non-terminal" do
-      expect(state.status).to eq("running")
-    end
-  end
 end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -1,0 +1,78 @@
+require 'active_support/time'
+
+RSpec.describe Floe::Workflow do
+  let(:now) { Time.now.utc }
+
+  describe "#new" do
+    it "sets initial state" do
+      input = {"input" => "value"}.freeze
+
+      workflow, _ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+
+      expect(workflow.status).to eq("pending")
+      expect(workflow.end?).to eq(false)
+    end
+  end
+
+  describe "#run!" do
+    let(:input) { {"input" => "value"}.freeze }
+
+    it "sets execution variables for success" do
+      workflow, ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      workflow.run!
+
+      # state
+      expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
+      expect(ctx.state["Guid"]).to be
+      expect(ctx.state["Name"]).to eq("FirstState")
+      expect(ctx.state["Input"]).to eq(input)
+      expect(ctx.state["Output"]).to eq(input)
+      expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
+      expect(ctx.state["Duration"]).to be <= 1
+
+      # execution
+      expect(ctx.execution["StartTime"]).to be_within(1.second).of(now)
+      # expect(ctx.execution["EndTime"]).to be_within(1.second).of(now)
+
+      # final results
+      expect(workflow.output).to eq(input)
+      expect(workflow.status).to eq("success")
+      expect(workflow.end?).to eq(true)
+    end
+  end
+
+  describe "#step" do
+    it "runs a step" do
+      input = {"input" => "value"}.freeze
+
+      workflow, _ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+
+      expect(workflow.status).to eq("pending")
+      expect(workflow.end?).to eq(false)
+
+      workflow.step
+
+      expect(workflow.output).to eq(input)
+      expect(workflow.status).to eq("success")
+      expect(workflow.end?).to eq(true)
+    end
+  end
+
+  private
+
+  def make_workflow(input, payload, creds: {})
+    context = Floe::Workflow::Context.new(:input => input)
+    workflow = Floe::Workflow.new(make_payload(payload), context, creds)
+    [workflow, context]
+  end
+
+  def make_payload(states)
+    start_at ||= states.keys.first
+
+    {
+      "Comment" => "Sample",
+      "StartAt" => start_at,
+      "States"  => states
+    }
+  end
+end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Floe::Workflow do
       # state
       expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
       expect(ctx.state["Guid"]).to be
-      expect(ctx.state["Name"]).to eq("FirstState")
-      expect(ctx.state["Input"]).to eq(input)
+      expect(ctx.state_name).to eq("FirstState")
+      expect(ctx.input).to eq(input)
       expect(ctx.output).to eq(input)
       expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
       expect(ctx.state["Duration"]).to be <= 1
@@ -54,8 +54,8 @@ RSpec.describe Floe::Workflow do
       # state
       expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
       expect(ctx.state["Guid"]).to be
-      expect(ctx.state["Name"]).to eq("FirstState")
-      expect(ctx.state["Input"]).to eq(input)
+      expect(ctx.state_name).to eq("FirstState")
+      expect(ctx.input).to eq(input)
       expect(ctx.output).to eq(input)
       expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
       expect(ctx.state["Duration"]).to be <= 1


### PR DESCRIPTION
References:
- Extracted from #67
- built upon (to remove codeclimate / failing build) #89

Goal
====

Move the runtime variables from `Workflow` to `Context`. So context will hold all the stateful data. No more methods in workflow that hold some context state.

Tangible goal:

- We can test the various `State` implementations without a `Workflow` instance.
- `State#run` will fully change the context and 

Additions
=======

- Added `NextState`, `Error`, and `Cause` to `Context`. Now errors are exposed.
- Added `context.execution["EndTime"]` and use that for determining `end?` (couldn't find the exact value for that variable)

Changes
=======

- Move hardcoded `State#status` methods to dynamic `Context#status`.
- Definition of `status "pending"` changed a little: it asks "Have I started" instead of "Is my state the starting state".
- Definition of `status "success"` changed a little: it asks "Have I **finished** without error" rather than looking at (`State#next` / `Context#next_state`).

Introduce Facade
=========

I introduced facade `quick_step`. This simplifies the caller in manageiq-provider-workflow's [workflow_instance.rb]:

```ruby
context = Workflow.quick_step(name, payload, context, creds)
update!(:context => context.to_h, :status => context.status, :output => context.output)
```

It is no secret from #67 , that I would like to pass the `context` into `step!` and feel that we could introduce a more sophisticated `step` method - which we can discuss elsewhere.

[workflow_instance.rb]: https://github.com/ManageIQ/manageiq-providers-workflows/blob/3a0900d3435875abd2d8dc9b2e29dcb57d374ecc/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb#L71-L74