### PR TITLE
Rename Context["States"] to "StateHistory"

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -60,7 +60,7 @@ module Floe
 
       logger.info("Running state: [#{current_state.name}] with input [#{context["Input"]}]...Complete - next state: [#{next_state}] output: [#{output}]")
 
-      context.states << context.state
+      context.state_history << context.state
 
       @status        = current_state.status
       @current_state = next_state && @states_by_name[next_state]

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -11,7 +11,7 @@ module Floe
             "Input" => input
           },
           "State"        => {},
-          "States"       => [],
+          "StateHistory" => [],
           "StateMachine" => {},
           "Task"         => {}
         }
@@ -29,8 +29,8 @@ module Floe
         @context["State"] = val
       end
 
-      def states
-        @context["States"]
+      def state_history
+        @context["StateHistory"]
       end
 
       def state_machine


### PR DESCRIPTION
Clear up any confusion that the `States` section of the `Context` contains active states running in parallel, it containes the history of states which have been run.