### PR TITLE
Add a nonblocking workflow step function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add Workflow.wait, Workflow#step_nonblock, Workflow#step_nonblock_wait ([#92])(https://github.com/ManageIQ/floe/pull/92)
 
 ## [0.3.1] - 2023-08-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,19 +81,14 @@ would block will return `Errno::EAGAIN`.
 require 'floe'
 
 workflow = Floe::Workflow.load("workflow.asl")
-workflow.run_async!
 
-until workflow.end?
-  loop while workflow.step_nonblock == 0 # Step through the workflow while it would not block
-  break
-end
+# Step through the workflow while it would not block
+workflow.run_nonblock
 
 # Go off and do some other task
 
-until workflow.end?
-  loop while workflow.step_nonblock == 0 # Continue stepping until the workflow is finished
-  break
-end
+# Continue stepping until the workflow is finished
+workflow.run_nonblock
 ```
 
 You can also use the `Floe::Workflow.wait` class method to wait on multiple workflows

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bundle exec ruby exe/floe --workflow my-workflow.asl --credentials='{"roleArn": 
 ```ruby
 require 'floe'
 
-workflow = Floe::Workflow.load(File.read("workflow.asl"))
+workflow = Floe::Workflow.load("workflow.asl")
 workflow.run!
 ```
 
@@ -68,8 +68,54 @@ Floe::Workflow::Runner.docker_runner = Floe::Workflow::Runner::Podman.new
 # Or
 Floe::Workflow::Runner.docker_runner = Floe::Workflow::Runner::Kubernetes.new("namespace" => "default", "server" => "https://k8s.example.com:6443", "token" => "my-token")
 
-workflow = Floe::Workflow.load(File.read("workflow.asl"))
+workflow = Floe::Workflow.load("workflow.asl")
 workflow.run!
+```
+
+### Non-Blocking Workflow Execution
+
+It is also possible to step through a workflow without blocking, and any state which
+would block will return `Errno::EAGAIN`.
+
+```ruby
+require 'floe'
+
+workflow = Floe::Workflow.load("workflow.asl")
+workflow.run_async!
+
+until workflow.end?
+  loop while workflow.step_nonblock == 0 # Step through the workflow while it would not block
+  break
+end
+
+# Go off and do some other task
+
+until workflow.end?
+  loop while workflow.step_nonblock == 0 # Continue stepping until the workflow is finished
+  break
+end
+```
+
+You can also use the `Floe::Workflow.wait` class method to wait on multiple workflows
+and return all that are ready to be stepped through.
+
+```ruby
+require 'floe'
+
+workflow1 = Floe::Workflow.load("workflow1.asl")
+workflow2 = Floe::Workflow.load("workflow2.asl")
+
+running_workflows = [workflow1, workflow2]
+until running_workflows.empty?
+  # Wait for any of the running workflows to be ready (up to the timeout)
+  ready_workflows = Floe::Workflow.wait(running_workflows)
+  # Step through the ready workflows until they would block
+  ready_workflows.each do |workflow|
+    loop while workflow.step_nonblock == 0
+  end
+  # Remove any finished workflows from the list of running_workflows
+  running_workflows.reject!(&:end?)
+end
 ```
 
 ### Docker Runner Options

--- a/exe/floe
+++ b/exe/floe
@@ -18,9 +18,6 @@ Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.joi
 require "logger"
 Floe.logger = Logger.new($stdout)
 
-context = Floe::Workflow::Context.new(input: opts[:input])
-workflow = Floe::Workflow.load(opts[:workflow], context, opts[:credentials])
-
 runner_klass = case opts[:docker_runner]
                when "docker"
                  Floe::Workflow::Runner::Docker
@@ -33,6 +30,9 @@ runner_klass = case opts[:docker_runner]
 runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
 
 Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
+
+context = Floe::Workflow::Context.new(input: opts[:input])
+workflow = Floe::Workflow.load(opts[:workflow], context, opts[:credentials])
 
 workflow.run!
 

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -126,12 +126,9 @@ module Floe
     end
 
     def step_nonblock_finish
-      current_state.finish_async
-      context.state["FinishedTime"] = Time.now.utc
-      context.state["Duration"]     = context.state["FinishedTime"] - context.state["EnteredTime"]
-      context.state["Error"]        = current_state.error if current_state.respond_to?(:error)
-      context.state["Cause"]        = current_state.cause if current_state.respond_to?(:cause)
-      context.execution["EndTime"]  = Time.now.utc if context.next_state.nil?
+      current_state.finish
+      context.state["Duration"]    = context.state["FinishedTime"] - context.state["EnteredTime"]
+      context.execution["EndTime"] = Time.now.utc if context.next_state.nil?
 
       logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
 

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -52,7 +52,7 @@ module Floe
     end
 
     def step
-      loop until step_nonblock == 0
+      step_nonblock_wait until step_nonblock == 0
       self
     end
 
@@ -71,10 +71,14 @@ module Floe
     end
 
     def step_nonblock_wait(timeout: 5)
-      return 0 if step_nonblock_ready?
+      start = Time.now.utc
 
-      sleep(timeout) unless timeout.zero?
-      Errno::EAGAIN
+      loop do
+        return 0             if step_nonblock_ready?
+        return Errno::EAGAIN if timeout.zero? || Time.now.utc - start > timeout
+
+        sleep(1)
+      end
     end
 
     def step_nonblock_ready?

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -16,9 +16,16 @@ module Floe
       def wait(workflows, timeout: 5)
         logger.info("checking #{workflows.count} workflows...")
 
-        ready = workflows.select(&:step_nonblock_ready?)
+        start = Time.now.utc
+        ready = []
 
-        sleep(timeout) if ready.empty?
+        loop do
+          ready = workflows.select(&:step_nonblock_ready?)
+          break if timeout.zero? || Time.now.utc - start > timeout || !ready.empty?
+
+          sleep(1)
+        end
+
         logger.info("checking #{workflows.count} workflows...Complete - #{ready.count} ready")
         ready
       end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -34,43 +34,74 @@ module Floe
       raise Floe::InvalidWorkflowError, err.message
     end
 
-    def step
-      context.execution["StartTime"] ||= Time.now.utc
-
-      context.state["Guid"]    = SecureRandom.uuid
-      context.state["Input"] ||= context.execution["Input"].dup
-
-      logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...")
-
-      context.state["EnteredTime"] = Time.now.utc
-
-      current_state = @states_by_name[context.state_name]
-      tick = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      next_state, output = current_state.run!(context.input)
-      tock = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-      context.state["FinishedTime"] = Time.now.utc
-      context.state["Duration"]     = tock - tick
-      context.state["Output"]       = output
-      context.state["NextState"]    = next_state
-      context.state["Error"]        = current_state.error if current_state.respond_to?(:error)
-      context.state["Cause"]        = current_state.cause if current_state.respond_to?(:cause)
-      context.execution["EndTime"]  = Time.now.utc if next_state.nil?
-
-      logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
-
-      context.state_history << context.state
-
-      context.state = {"Name" => next_state, "Input" => output} unless end?
-
-      self
-    end
-
     def run!
       until end?
         step
       end
       self
+    end
+
+    def step
+      loop until step_nonblock == 0
+      self
+    end
+
+    def run_async!
+      step_nonblock(:timeout => 0)
+      self
+    end
+
+    def step_nonblock(timeout: 5)
+      return Errno::EPERM if end?
+      step_nonblock_submit unless current_state.started?
+
+      result = step_nonblock_wait(:timeout => timeout)
+      return result if result == Errno::EAGAIN
+
+      step_nonblock_finish
+    end
+
+    def step_nonblock_submit
+      raise "State is already running" if current_state.started?
+
+      start_time = Time.now.utc
+
+      context.execution["StartTime"] ||= start_time
+      context.state["Input"]         ||= context.execution["Input"].dup
+      context.state["Guid"]            = SecureRandom.uuid
+      context.state["EnteredTime"]     = start_time
+
+      logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...")
+
+      current_state.run_async!(context.state["Input"])
+    end
+
+    def step_nonblock_wait(timeout: 5)
+      return 0 if step_nonblock_ready?
+
+      sleep(timeout)
+      Errno::EAGAIN
+    end
+
+    def step_nonblock_ready?
+      !current_state.started? || !current_state.running?
+    end
+
+    def step_nonblock_finish
+      current_state.finish_async
+      context.state["FinishedTime"] = Time.now.utc
+      context.state["Duration"]     = context.state["FinishedTime"] - context.state["EnteredTime"]
+      context.state["Error"]        = current_state.error if current_state.respond_to?(:error)
+      context.state["Cause"]        = current_state.cause if current_state.respond_to?(:cause)
+      context.execution["EndTime"]  = Time.now.utc if context.next_state.nil?
+
+      logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
+
+      context.state_history << context.state
+
+      context.state = {"Name" => context.next_state, "Input" => context.output} unless end?
+
+      0
     end
 
     def status
@@ -83,6 +114,10 @@ module Floe
 
     def end?
       context.ended?
+    end
+
+    def current_state
+      @states_by_name[context.state_name]
     end
   end
 end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -52,9 +52,7 @@ module Floe
     end
 
     def run!
-      until end?
-        step
-      end
+      step until end?
       self
     end
 
@@ -63,8 +61,8 @@ module Floe
       self
     end
 
-    def run_async!
-      step_nonblock
+    def run_nonblock
+      loop while step_nonblock == 0 && !end?
       self
     end
 

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -69,7 +69,7 @@ module Floe
     def step_nonblock
       return Errno::EPERM if end?
 
-      step_nonblock_submit unless current_state.started?
+      step_nonblock_start unless current_state.started?
       return Errno::EAGAIN unless step_nonblock_ready?
 
       step_nonblock_finish
@@ -108,7 +108,7 @@ module Floe
 
     private
 
-    def step_nonblock_submit
+    def step_nonblock_start
       raise "State is already running" if current_state.started?
 
       start_time = Time.now.utc
@@ -120,7 +120,7 @@ module Floe
 
       logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...")
 
-      current_state.run_async!(context.state["Input"])
+      current_state.start(context.state["Input"])
     end
 
     def step_nonblock_finish

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -45,12 +45,20 @@ module Floe
         state["Output"]
       end
 
+      def output=(val)
+        state["Output"] = val
+      end
+
       def state_name
         state["Name"]
       end
 
       def next_state
         state["NextState"]
+      end
+
+      def next_state=(val)
+        state["NextState"] = val
       end
 
       def status

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -32,7 +32,7 @@ module Floe
       def run!(input)
         run_async!(input)
         sleep(1) while running?
-        finish_async
+        finish
         [context.next_state, context.output]
       end
 
@@ -40,7 +40,8 @@ module Floe
         raise NotImpelmentedError
       end
 
-      def finish_async
+      def finish
+        context.state["FinishedTime"] ||= Time.now.utc
       end
 
       def context

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -30,13 +30,13 @@ module Floe
       end
 
       def run!(input)
-        run_async!(input)
+        start(input)
         sleep(1) while running?
         finish
         [context.next_state, context.output]
       end
 
-      def run_async!(*)
+      def start(_input)
         raise NotImpelmentedError
       end
 

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -29,8 +29,30 @@ module Floe
         @comment  = payload["Comment"]
       end
 
+      def run!(input)
+        run_async!(input)
+        sleep(1) while running?
+        finish_async
+        [context.next_state, context.output]
+      end
+
+      def run_async!(*)
+        raise NotImpelmentedError
+      end
+
+      def finish_async
+      end
+
       def context
         workflow.context
+      end
+
+      def started?
+        context.state.key?("EnteredTime")
+      end
+
+      def finished?
+        context.state.key?("FinishedTime")
       end
     end
   end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -16,7 +16,7 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run_async!(input)
+        def start(input)
           input      = input_path.value(context, input)
           next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default
           output     = output_path.value(context, input)

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -16,12 +16,17 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(input)
+        def run_async!(input)
           input      = input_path.value(context, input)
           next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default
           output     = output_path.value(context, input)
 
-          [next_state, output]
+          context.next_state = next_state
+          context.output     = output
+        end
+
+        def running?
+          false
         end
 
         def end?

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -18,6 +18,13 @@ module Floe
           context.output     = input
         end
 
+        def finish
+          super
+
+          context.state["Error"] = error
+          context.state["Cause"] = cause
+        end
+
         def running?
           false
         end

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -13,7 +13,7 @@ module Floe
           @error = payload["Error"]
         end
 
-        def run_async!(input)
+        def start(input)
           context.state["Error"] = error
           context.state["Cause"] = cause
           context.next_state     = nil

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -13,8 +13,13 @@ module Floe
           @error = payload["Error"]
         end
 
-        def run!(input)
-          [nil, input]
+        def run_async!(input)
+          context.next_state = nil
+          context.output     = input
+        end
+
+        def running?
+          false
         end
 
         def end?

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -14,15 +14,10 @@ module Floe
         end
 
         def run_async!(input)
-          context.next_state = nil
-          context.output     = input
-        end
-
-        def finish
-          super
-
           context.state["Error"] = error
           context.state["Cause"] = cause
+          context.next_state     = nil
+          context.output         = input
         end
 
         def running?

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -19,7 +19,7 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
-        def run_async!(input)
+        def start(input)
           output = input_path.value(context, input)
           output = result_path.set(output, result) if result && result_path
           output = output_path.value(context, output)

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -19,12 +19,17 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
-        def run!(input)
+        def run_async!(input)
           output = input_path.value(context, input)
           output = result_path.set(output, result) if result && result_path
           output = output_path.value(context, output)
 
-          [@end ? nil : @next, output]
+          context.next_state = end? ? nil : @next
+          context.output     = output
+        end
+
+        def running?
+          false
         end
 
         def end?

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -10,7 +10,7 @@ module Floe
           super
         end
 
-        def run_async!(input)
+        def start(input)
           context.next_state = nil
           context.output     = input
         end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -10,8 +10,13 @@ module Floe
           super
         end
 
-        def run!(input)
-          [nil, input]
+        def run_async!(input)
+          context.next_state = nil
+          context.output     = input
+        end
+
+        def running?
+          false
         end
 
         def end?

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -58,7 +58,9 @@ module Floe
           @end ? "success" : "running"
         end
 
-        def finish_async
+        def finish
+          super
+
           input = context.state["Input"]
           input = input_path.value(context, input)
           input = parameters.value(context, input) if parameters

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -27,7 +27,7 @@ module Floe
           @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
         end
 
-        def run_async!(input)
+        def start(input)
           input = input_path.value(context, input)
           input = parameters.value(context, input) if parameters
 

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -17,7 +17,7 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run_async!(input)
+        def start(input)
           input = input_path.value(context, input)
 
           context.output     = output_path.value(context, input)

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -17,11 +17,21 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def run!(input)
+        def run_async!(input)
           input = input_path.value(context, input)
-          sleep(seconds)
-          output = output_path.value(context, input)
-          [@end ? nil : @next, output]
+
+          context.output     = output_path.value(context, input)
+          context.next_state = end? ? nil : @next
+        end
+
+        def running?
+          now = Time.now.utc
+          if now > (context.state["EnteredTime"] + @seconds)
+            context.state["FinishedTime"] = now
+            false
+          else
+            true
+          end
         end
 
         def end?

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -8,19 +8,31 @@ RSpec.describe Floe::Workflow::States::Pass do
     end
   end
 
-  describe "#run!" do
-    it "sleeps for the requested amount of time" do
-      expect(state).to receive(:sleep).with(state.seconds)
+  describe "#run_async!" do
+    it "transitions to the next state" do
+      state.run_async!({})
 
-      state.run!({})
+      expect(workflow.context.next_state).to eq("NextState")
+    end
+  end
+
+  describe "#running?" do
+    before { workflow.context.state["EnteredTime"] = entered_time }
+
+    context "before the sleep has finished" do
+      let(:entered_time) { Time.now.utc }
+
+      it "returns true" do
+        expect(state.running?).to be_truthy
+      end
     end
 
-    it "transitions to the next state" do
-      # skip the actual sleep
-      expect(state).to receive(:sleep).with(state.seconds)
+    context "after the sleep has finished" do
+      let(:entered_time) { Time.now.utc - 10 }
 
-      next_state, _output = state.run!({})
-      expect(next_state).to eq("NextState")
+      it "returns false" do
+        expect(state.running?).to be_falsey
+      end
     end
   end
 end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Floe::Workflow::States::Pass do
     end
   end
 
-  describe "#run_async!" do
+  describe "#start" do
     it "transitions to the next state" do
-      state.run_async!({})
+      state.start({})
 
       expect(workflow.context.next_state).to eq("NextState")
     end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -1,12 +1,11 @@
 require 'active_support/time'
 
 RSpec.describe Floe::Workflow do
-  let(:now) { Time.now.utc }
+  let(:now)   { Time.now.utc }
+  let(:input) { {"input" => "value"}.freeze }
 
   describe "#new" do
     it "sets initial state" do
-      input = {"input" => "value"}.freeze
-
       workflow, ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
 
       expect(workflow.status).to eq("pending")
@@ -20,7 +19,7 @@ RSpec.describe Floe::Workflow do
   end
 
   describe "#run!" do
-    let(:input) { {"input" => "value"}.freeze }
+
 
     it "sets execution variables for success" do
       workflow, ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
@@ -77,7 +76,6 @@ RSpec.describe Floe::Workflow do
 
   describe "#step" do
     it "runs a success step" do
-      input = {"input" => "value"}.freeze
 
       workflow, ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -73,17 +73,17 @@ RSpec.describe Floe::Workflow do
     end
   end
 
-  describe "#run_async!" do
+  describe "#run_nonblock" do
     it "starts the first state" do
       workflow = make_workflow(input, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
-      workflow.run_async!
+      workflow.run_nonblock
 
       expect(context.started?).to eq(true)
     end
 
     it "doesn't wait for the state to finish" do
       workflow = make_workflow(input, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
-      workflow.run_async!
+      workflow.run_nonblock
 
       expect(context.running?).to eq(true)
       expect(context.ended?).to   eq(false)
@@ -137,7 +137,7 @@ RSpec.describe Floe::Workflow do
         workflow = make_workflow(input, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
 
         # Start the workflow
-        workflow.run_async!
+        workflow.run_nonblock
 
         # Mark the Wait state as having started 1 minute ago
         context.state["EnteredTime"] = Time.now.utc - 60

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -1,44 +1,43 @@
 require 'active_support/time'
 
 RSpec.describe Floe::Workflow do
-  let(:now)   { Time.now.utc }
-  let(:input) { {"input" => "value"}.freeze }
+  let(:now)     { Time.now.utc }
+  let(:input)   { {"input" => "value"}.freeze }
+  let(:context) { Floe::Workflow::Context.new(:input => input) }
 
   describe "#new" do
     it "sets initial state" do
-      workflow, ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
 
       expect(workflow.status).to eq("pending")
       expect(workflow.end?).to eq(false)
 
-      expect(ctx.status).to eq("pending")
-      expect(ctx.started?).to eq(false)
-      expect(ctx.running?).to eq(false)
-      expect(ctx.ended?).to eq(false)
+      expect(context.status).to eq("pending")
+      expect(context.started?).to eq(false)
+      expect(context.running?).to eq(false)
+      expect(context.ended?).to eq(false)
     end
   end
 
   describe "#run!" do
-
-
     it "sets execution variables for success" do
-      workflow, ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
       workflow.run!
 
       # state
-      expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
-      expect(ctx.state["Guid"]).to be
-      expect(ctx.state_name).to eq("FirstState")
-      expect(ctx.input).to eq(input)
-      expect(ctx.output).to eq(input)
-      expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
-      expect(ctx.state["Duration"]).to be <= 1
-      expect(ctx.status).to eq("success")
+      expect(context.state["EnteredTime"]).to be_within(1.second).of(now)
+      expect(context.state["Guid"]).to be
+      expect(context.state_name).to eq("FirstState")
+      expect(context.input).to eq(input)
+      expect(context.output).to eq(input)
+      expect(context.state["FinishedTime"]).to be_within(1.second).of(now)
+      expect(context.state["Duration"]).to be <= 1
+      expect(context.status).to eq("success")
 
       # execution
-      expect(ctx.started?).to eq(true)
-      expect(ctx.running?).to eq(false)
-      expect(ctx.ended?).to eq(true)
+      expect(context.started?).to eq(true)
+      expect(context.running?).to eq(false)
+      expect(context.ended?).to eq(true)
 
       # final results
       expect(workflow.output).to eq(input)
@@ -47,25 +46,25 @@ RSpec.describe Floe::Workflow do
     end
 
     it "sets execution variables for failure" do
-      workflow, ctx = make_workflow(input, {"FirstState" => {"Type" => "Fail", "Cause" => "Bad Stuff", "Error" => "Issue"}})
+      workflow = make_workflow(input, {"FirstState" => {"Type" => "Fail", "Cause" => "Bad Stuff", "Error" => "Issue"}})
       workflow.run!
 
       # state
-      expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
-      expect(ctx.state["Guid"]).to be
-      expect(ctx.state_name).to eq("FirstState")
-      expect(ctx.input).to eq(input)
-      expect(ctx.output).to eq(input)
-      expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
-      expect(ctx.state["Duration"]).to be <= 1
-      expect(ctx.state["Cause"]).to eq("Bad Stuff")
-      expect(ctx.state["Error"]).to eq("Issue")
-      expect(ctx.status).to eq("failure")
+      expect(context.state["EnteredTime"]).to be_within(1.second).of(now)
+      expect(context.state["Guid"]).to be
+      expect(context.state_name).to eq("FirstState")
+      expect(context.input).to eq(input)
+      expect(context.output).to eq(input)
+      expect(context.state["FinishedTime"]).to be_within(1.second).of(now)
+      expect(context.state["Duration"]).to be <= 1
+      expect(context.state["Cause"]).to eq("Bad Stuff")
+      expect(context.state["Error"]).to eq("Issue")
+      expect(context.status).to eq("failure")
 
       # execution
-      expect(ctx.started?).to eq(true)
-      expect(ctx.running?).to eq(false)
-      expect(ctx.ended?).to eq(true)
+      expect(context.started?).to eq(true)
+      expect(context.running?).to eq(false)
+      expect(context.ended?).to eq(true)
 
       # final results
       expect(workflow.output).to eq(input)
@@ -77,34 +76,32 @@ RSpec.describe Floe::Workflow do
   describe "#step" do
     it "runs a success step" do
 
-      workflow, ctx = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
 
       expect(workflow.status).to eq("pending")
       expect(workflow.end?).to eq(false)
-      expect(ctx.status).to eq("pending")
-      expect(ctx.started?).to eq(false)
-      expect(ctx.running?).to eq(false)
-      expect(ctx.ended?).to eq(false)
+      expect(context.status).to eq("pending")
+      expect(context.started?).to eq(false)
+      expect(context.running?).to eq(false)
+      expect(context.ended?).to eq(false)
 
       workflow.step
 
       expect(workflow.output).to eq(input)
       expect(workflow.status).to eq("success")
       expect(workflow.end?).to eq(true)
-      expect(ctx.output).to eq(input)
-      expect(ctx.status).to eq("success")
-      expect(ctx.started?).to eq(true)
-      expect(ctx.running?).to eq(false)
-      expect(ctx.ended?).to eq(true)
+      expect(context.output).to eq(input)
+      expect(context.status).to eq("success")
+      expect(context.started?).to eq(true)
+      expect(context.running?).to eq(false)
+      expect(context.ended?).to eq(true)
     end
   end
 
   private
 
   def make_workflow(input, payload, creds: {})
-    context = Floe::Workflow::Context.new(:input => input)
-    workflow = Floe::Workflow.new(make_payload(payload), context, creds)
-    [workflow, context]
+    Floe::Workflow.new(make_payload(payload), context, creds)
   end
 
   def make_payload(states)

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Floe::Workflow do
     context "with a state that is running" do
       it "returns Try again" do
         context.state["EnteredTime"] = Time.now.utc
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Task"}})
+        workflow = make_workflow(input, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest"}})
         expect(workflow.current_state).to receive(:running?).and_return(true)
         expect(workflow.step_nonblock_wait(:timeout => 0)).to eq(Errno::EAGAIN)
       end
@@ -212,7 +212,7 @@ RSpec.describe Floe::Workflow do
     context "with a state that is running" do
       it "returns false" do
         context.state["EnteredTime"] = Time.now.utc
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Task"}})
+        workflow = make_workflow(input, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest"}})
         expect(workflow.current_state).to receive(:running?).and_return(true)
         expect(workflow.step_nonblock_ready?).to be_falsey
       end


### PR DESCRIPTION
Add a non-blocking way to step through a workflow.  If a state doesn't won't block then it behaves exactly the same (e.g. choice, pass, etc...).  If a state would block then `step_nonblock` will return `Errno::EAGAIN` allowing the caller to break out and move on to other work.  Calling `step_nonblock` again once the task is complete will finish the rest of the work and cleanup from the run.

Future TODO:
- [ ] Add an event-driven `Workflow#wait` method (e.g. using k8s watches) https://github.com/ManageIQ/floe/pull/95
- [ ] Add a class-level `Workflow.wait` that can wait for multiple workflows

Depends on:
- [x] https://github.com/ManageIQ/floe/pull/52