### PR TITLE
Workflow#quick_step

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -12,6 +12,18 @@ module Floe
         payload = path_or_io.respond_to?(:read) ? path_or_io.read : File.read(path_or_io)
         new(payload, context, credentials)
       end
+
+      # Step through the workflow for a single iteration
+      # If some steps are trivial, it may step through more than one step
+      #
+      # @param name    [String] Name of the workflow
+      # @param payload [Json String|Hash] Description of the workflow
+      # @param context [Json String|Context] Workflow input and output
+      # @param credentials [Json String|Hash] Secrets
+      # @returns updated context
+      def quick_step(_name, payload, context, credentials = {})
+        new(payload, context, credentials).step.context
+      end
     end
 
     attr_reader :context, :credentials, :payload, :states, :states_by_name, :start_at


### PR DESCRIPTION
Formalizes the api into the floe engine.

This hides the details of step, the constructor, and credentials from the workflow engine gem.

The goal of `quick_step` is just like step for now.

But the thought is it will call a single task and then quickly step through logic that doesn't require spawning out to tasks. So the trivial comparisons or status checks will not take multiple hits to the queue/database.