### PR TITLE
Context state run

### DIFF
--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -65,8 +65,28 @@ module Floe
         end
       end
 
-      def state=(val)
-        @context["State"] = val
+      def start_next_state!(name = state["NextState"], input = state["Output"], init: false)
+        if init == true || state_name.nil?
+          execution["StartTime"] = Time.now.utc
+          input = execution["Input"]
+        end
+        @context["State"] = {
+          "Name"  => name,
+          "Input" => input.dup,
+          "Guid"  => SecureRandom.uuid
+        }
+
+        self
+      end
+
+      def end_state!(output, next_state = nil, cause: nil, error: nil)
+        state["Output"]      = output
+        state["NextState"]   = next_state
+        state["Error"]       = error if error
+        state["Cause"]       = cause if cause
+        execution["EndTime"] = Time.now.utc unless next_state
+
+        self
       end
 
       def state_history

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -1,14 +1,15 @@
 RSpec.describe Floe::Workflow::States::Choice do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("ChoiceState") }
   let(:state)    { workflow.states_by_name["ChoiceState"] }
-  let(:inputs)   { {} }
+  let(:input)    { {} }
 
   it "#end?" do
     expect(state.end?).to eq(false)
   end
 
   describe "#run!" do
-    let(:subject) { state.run!(inputs) }
+    let(:subject) { state.run!(ctx.input) }
 
     context "with a missing variable" do
       it "raises an exception" do
@@ -17,7 +18,7 @@ RSpec.describe Floe::Workflow::States::Choice do
     end
 
     context "with an input value matching a condition" do
-      let(:inputs) { {"foo" => 1} }
+      let(:input) { {"foo" => 1} }
 
       it "returns the next state" do
         next_state, = subject
@@ -26,7 +27,7 @@ RSpec.describe Floe::Workflow::States::Choice do
     end
 
     context "with an input value not matching any condition" do
-      let(:inputs) { {"foo" => 4} }
+      let(:input) { {"foo" => 4} }
 
       it "returns the default state" do
         next_state, = subject

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -1,13 +1,15 @@
 RSpec.describe Floe::Workflow::States::Fail do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => {}).start_next_state!("FailState") }
   let(:state)    { workflow.states_by_name["FailState"] }
+  let(:input)    { {} }
 
   it "#end?" do
     expect(state.end?).to be true
   end
 
   it "#run!" do
-    next_state, _output = state.run!({})
+    next_state, _output = state.run!(ctx.input)
     expect(next_state).to eq(nil)
   end
 end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::States::Pass do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("PassState") }
   let(:state)    { workflow.states_by_name["PassState"] }
+  let(:input)    { {} }
 
   describe "#end?" do
     it "is non-terminal" do
@@ -11,7 +13,7 @@ RSpec.describe Floe::Workflow::States::Pass do
 
   describe "#run!" do
     it "sets the result to the result path" do
-      next_state, output = state.run!({})
+      next_state, output = state.run!(ctx.input)
       expect(output["result"]).to include(state.result)
       expect(next_state).to eq("WaitState")
     end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::States::Succeed do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => {}).start_next_state!("SuccessState") }
   let(:state)    { workflow.states_by_name["SuccessState"] }
+  let(:input)    { {} }
 
   it "#end?" do
     expect(state.end?).to be true
@@ -8,7 +10,7 @@ RSpec.describe Floe::Workflow::States::Succeed do
 
   describe "#run!" do
     it "has no next" do
-      next_state, _output = state.run!({})
+      next_state, _output = state.run!(ctx.input)
       expect(next_state).to be_nil
     end
   end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -1,12 +1,13 @@
 RSpec.describe Floe::Workflow::States::Task do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("Task") }
   let(:input)    { {} }
 
   describe "#run" do
     let(:mock_runner) { double("Floe::Workflow::Runner") }
     let(:input)       { {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}} }
     let(:state)       { described_class.new(workflow, "Task", payload) }
-    let(:subject)     { state.run!(input) }
+    let(:subject)     { state.run!(ctx.input) }
 
     before { allow(Floe::Workflow::Runner).to receive(:for_resource).and_return(mock_runner) }
 

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::States::Pass do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
+  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl"), ctx) }
+  let(:ctx)      { Floe::Workflow::Context.new(nil, :input => input).start_next_state!("WaitState") }
   let(:state)    { workflow.states_by_name["WaitState"] }
+  let(:input)    { {} }
 
   describe "#end?" do
     it "is non-terminal" do
@@ -12,14 +14,14 @@ RSpec.describe Floe::Workflow::States::Pass do
     it "sleeps for the requested amount of time" do
       expect(state).to receive(:sleep).with(state.seconds)
 
-      state.run!({})
+      state.run!(ctx.input)
     end
 
     it "transitions to the next state" do
       # skip the actual sleep
       expect(state).to receive(:sleep).with(state.seconds)
 
-      next_state, _output = state.run!({})
+      next_state, _output = state.run!(ctx.input)
       expect(next_state).to eq("NextState")
     end
   end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -99,6 +99,42 @@ RSpec.describe Floe::Workflow do
       expect(ctx.running?).to eq(false)
       expect(ctx.ended?).to eq(true)
     end
+
+    it "steps" do
+      input = {"input" => "value"}.freeze
+      workflow, ctx = make_workflow(
+        input, {
+          "FirstState"  => {"Type" => "Pass", "Next" => "SecondState"},
+          "SecondState" => {"Type" => "Succeed"}
+        }
+      )
+
+      expect(ctx.status).to eq("pending")
+      expect(ctx.started?).to eq(false)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(false)
+
+      workflow.step
+
+      expect(ctx.status).to eq("running")
+
+      # execution
+      expect(ctx.started?).to eq(true)
+      expect(ctx.running?).to eq(true)
+      expect(ctx.ended?).to eq(false)
+
+      # second step
+
+      workflow.step
+
+      expect(ctx.state_name).to eq("SecondState")
+      expect(ctx.status).to eq("success")
+
+      # execution
+      expect(ctx.started?).to eq(true)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(true)
+    end
   end
 
   private


### PR DESCRIPTION
Extracted from https://github.com/ManageIQ/floe/pull/67

- `Workflow#run` handles contexts not yet run, not completed, completed/waiting to run next state, and completed/finished
  - no longer modify `context` in `Workflow#initialize`
  - no longer auto advance to the next state
- Context helper methods for setting at beginning and end.
- `State#run` changes context. (currently ignoring `_input` parameter)

I did not remove `context`/`workflow` from `State#initialize`. This left the input for `run()` a little in limbo.