### PR TITLE
Add a watch method to Workflow::Runner for event driven updates

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -55,13 +55,7 @@ workflows =
 
 # run
 
-outstanding = workflows.dup
-until outstanding.empty?
-  ready = outstanding.select(&:step_nonblock_ready?)
-  ready.map(&:run_nonblock)
-  outstanding -= ready.select(&:end?)
-  sleep(1) if !outstanding.empty?
-end
+Floe::Workflow.wait(workflows, &:run_nonblock)
 
 # display status
 

--- a/floe.gemspec
+++ b/floe.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "awesome_spawn", "~>1.0"
+  spec.add_dependency "awesome_spawn", "~>1.6"
+  spec.add_dependency "io-wait"
   spec.add_dependency "jsonpath", "~>1.1"
   spec.add_dependency "kubeclient", "~>4.7"
   spec.add_dependency "optimist", "~>3.0"

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -20,29 +20,67 @@ module Floe
         workflows = [workflows] if workflows.kind_of?(self)
         logger.info("checking #{workflows.count} workflows...")
 
-        start = Time.now.utc
-        ready = []
+        run_until   = Time.now.utc + timeout if timeout.to_i > 0
+        ready       = []
+        queue       = Queue.new
+        wait_thread = Thread.new do
+          loop do
+            Runner.for_resource("docker").wait do |event, runner_context|
+              queue.push([event, runner_context])
+            end
+          end
+        end
 
         loop do
           ready = workflows.select(&:step_nonblock_ready?)
-          break if timeout&.zero?
-          break if timeout && Time.now.utc - start > timeout
+          break if block.nil? && !ready.empty?
 
-          unless ready.empty?
-            if block
-              ready.each(&block)
-            else
-              break
+          ready.each(&block)
+
+          # Break if all workflows are completed or we've exceeded the
+          # requested timeout
+          break if workflows.all?(&:end?)
+          break if timeout && (timeout.zero? || Time.now.utc > run_until)
+
+          # Find the earliest time that we should wakeup if no container events
+          # are caught, either a workflow in a Wait or Retry state or we've
+          # exceeded the requested timeout
+          wait_until = workflows.map(&:wait_until)
+                                .unshift(run_until)
+                                .compact
+                                .min
+
+          # If a workflow is in a waiting state wakeup the main thread when
+          # it will be done sleeping
+          if wait_until
+            sleep_thread = Thread.new do
+              sleep wait_until - Time.now.utc
+              queue.push(nil)
             end
           end
 
-          break if workflows.all?(&:end?)
+          loop do
+            # Block until an event is raised
+            event, runner_context = queue.pop
+            break if event.nil?
 
-          sleep(1)
+            # If the event is for one of our workflows set the updated runner_context
+            workflows.each do |workflow|
+              next unless workflow.context.state.dig("RunnerContext", "container_ref") == runner_context["container_ref"]
+
+              workflow.context.state["RunnerContext"] = runner_context
+            end
+
+            break if queue.empty?
+          end
+        ensure
+          sleep_thread&.kill
         end
 
         logger.info("checking #{workflows.count} workflows...Complete - #{ready.count} ready")
         ready
+      ensure
+        wait_thread&.kill
       end
     end
 
@@ -92,6 +130,14 @@ module Floe
 
     def step_nonblock_ready?
       current_state.ready?
+    end
+
+    def waiting?
+      current_state.waiting?
+    end
+
+    def wait_until
+      current_state.wait_until
     end
 
     def status

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -17,6 +17,7 @@ module Floe
       end
 
       def wait(workflows, timeout: nil)
+        workflows = [workflows] if workflows.kind_of?(self)
         logger.info("checking #{workflows.count} workflows...")
 
         start = Time.now.utc

--- a/lib/floe/workflow/runner.rb
+++ b/lib/floe/workflow/runner.rb
@@ -68,6 +68,10 @@ module Floe
       def cleanup(_runner_context)
         raise NotImplementedError, "Must be implemented in a subclass"
       end
+
+      def wait(timeout: nil, events: %i[create update delete])
+        raise NotImplementedError, "Must be implemented in a subclass"
+      end
     end
   end
 end

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -76,7 +76,7 @@ module Floe
               ref, event = parse_notice(notice)
               next unless events.include?(event)
 
-              state = inspect_container(ref).first&.dig("State")
+              state = inspect_container(ref)&.dig("State")
 
               runner_context = {"container_ref" => ref, "container_state" => state}
 
@@ -105,7 +105,7 @@ module Floe
         def status!(runner_context)
           return if runner_context.key?("Error")
 
-          runner_context["container_state"] = inspect_container(runner_context["container_ref"]).first&.dig("State")
+          runner_context["container_state"] = inspect_container(runner_context["container_ref"])&.dig("State")
         end
 
         def running?(runner_context)
@@ -174,7 +174,9 @@ module Floe
         end
 
         def inspect_container(container_id)
-          JSON.parse(docker!("inspect", container_id).output)
+          JSON.parse(docker!("inspect", container_id).output).first
+        rescue
+          nil
         end
 
         def delete_container(container_id)

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -45,6 +45,9 @@ module Floe
           delete_secret(secrets_file)    if secrets_file
         end
 
+        def wait(timeout: nil, events: %i[create update delete])
+        end
+
         def status!(runner_context)
           return if runner_context.key?("Error")
 

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -76,7 +76,11 @@ module Floe
               ref, event = parse_notice(notice)
               next unless events.include?(event)
 
-              notices << [ref, event]
+              state = inspect_container(ref).first&.dig("State")
+
+              runner_context = {"container_ref" => ref, "container_state" => state}
+
+              notices << runner_context
             end
 
             # If we're given a block yield the events otherwise return them
@@ -147,6 +151,7 @@ module Floe
         def wait_params(until_timestamp)
           params = ["events", [:format, "{{json .}}"], [:filter, "type=container"], [:since, Time.now.utc.to_i]]
           params << [:until, until_timestamp.to_i] if until_timestamp
+          params
         end
 
         def parse_notice(notice)

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -78,9 +78,7 @@ module Floe
 
               state ||= inspect_container(ref)&.dig("State")
 
-              runner_context = {"container_ref" => ref, "container_state" => state}
-
-              notices << runner_context
+              notices << {"container_ref" => ref, "container_state" => state}
             end
 
             # If we're given a block yield the events otherwise return them

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -76,7 +76,7 @@ module Floe
               event, runner_context = parse_notice(notice)
               next unless events.include?(event)
 
-              notices << runner_context
+              notices << [event, runner_context]
             end
 
             # If we're given a block yield the events otherwise return them

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -164,7 +164,7 @@ module Floe
             :create
           when "start"
             :update
-          when "die"
+          when "die", "destroy"
             :delete
           else
             :unkonwn

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -73,10 +73,10 @@ module Floe
               # always `ready?`
               break if notice.nil?
 
-              ref, event = parse_notice(notice)
+              ref, event, state = parse_notice(notice)
               next unless events.include?(event)
 
-              state = inspect_container(ref)&.dig("State")
+              state ||= inspect_container(ref)&.dig("State")
 
               runner_context = {"container_ref" => ref, "container_state" => state}
 

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -74,7 +74,7 @@ module Floe
               break if notice.nil?
 
               event, runner_context = parse_notice(notice)
-              next unless events.include?(event)
+              next if event.nil? || !events.include?(event)
 
               notices << [event, runner_context]
             end
@@ -162,6 +162,8 @@ module Floe
           runner_context = {"container_ref" => name, "container_state" => {"Running" => running, "ExitCode" => exit_code.to_i}}
 
           [event, runner_context]
+        rescue JSON::ParserError
+          []
         end
 
         def docker_event_status_to_event(status)

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -84,7 +84,8 @@ module Floe
               notices.each(&block)
             else
               # Terminate the `docker events` process before returning the events
-              Process.kill("TERM", pid) rescue Errno::ESRCH
+              sigterm(pid)
+
               return notices
             end
 
@@ -204,6 +205,12 @@ module Floe
           secrets_file.write(secrets.to_json)
           secrets_file.close
           secrets_file.path
+        end
+
+        def sigterm(pid)
+          Process.kill("TERM", pid)
+        rescue Errno::ESRCH
+          nil
         end
 
         def global_docker_options

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -150,7 +150,12 @@ module Floe
             retry_connection = false
             retry
           ensure
-            watch&.finish rescue nil
+            begin
+              watch&.finish
+            rescue
+              nil
+            end
+
             timeout_thread&.join(0)
           end
         end

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -126,7 +126,7 @@ module Floe
               yield runner_context
             else
               timeout_thread&.kill # If we break out before the timeout, kill the timeout thread
-              return runner_context
+              return [runner_context]
             end
           end
         ensure

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -102,6 +102,9 @@ module Floe
           delete_secret(secret) if secret
         end
 
+        def wait(timeout: nil, events: %i[create update delete])
+        end
+
         private
 
         attr_reader :ca_file, :kubeconfig_file, :kubeconfig_context, :namespace, :server, :token, :verify_ssl

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -53,7 +53,7 @@ module Floe
           name   = container_name(image)
           secret = create_secret!(secrets) if secrets && !secrets.empty?
 
-          runner_context = {"container_ref" => name, "secrets_ref" => secret}
+          runner_context = {"container_ref" => name, "container_state" => {"phase" => "Pending"}, "secrets_ref" => secret}
 
           begin
             create_pod!(name, image, env, secret)

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -123,10 +123,10 @@ module Floe
             runner_context = {"container_ref" => container_ref, "container_state" => container_state}
 
             if block_given?
-              yield runner_context
+              yield [event, runner_context]
             else
               timeout_thread&.kill # If we break out before the timeout, kill the timeout thread
-              return [runner_context]
+              return [[event, runner_context]]
             end
           end
         ensure

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -105,7 +105,12 @@ module Floe
         def wait(timeout: nil, events: %i[create update delete])
           watcher = kubeclient.watch_pods(:namespace => namespace)
 
-          timeout_thread = Thread.new { sleep(timeout); watcher.finish } if timeout.to_i > 0
+          if timeout.to_i > 0
+            timeout_thread = Thread.new do
+              sleep(timeout)
+              watcher.finish
+            end
+          end
 
           watcher.each do |notice|
             event = kube_notice_type_to_event(notice.type)

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -118,7 +118,7 @@ module Floe
 
             pod = notice.object
             container_ref   = pod.metadata.name
-            container_state = pod.to_h.deep_stringify_keys["status"]
+            container_state = pod.to_h[:status].deep_stringify_keys
 
             runner_context = {"container_ref" => container_ref, "container_state" => container_state}
 

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -57,7 +57,7 @@ module Floe
 
         def parse_notice(notice)
           notice = JSON.parse(notice)
-          [notice["Name"], podman_event_status_to_event(notice["Status"])]
+          [notice["ID"], podman_event_status_to_event(notice["Status"])]
         end
 
         def podman_event_status_to_event(status)

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -56,8 +56,14 @@ module Floe
         end
 
         def parse_notice(notice)
-          notice = JSON.parse(notice)
-          [notice["ID"], podman_event_status_to_event(notice["Status"])]
+          id, status, exit_code = JSON.parse(notice).values_at("ID", "Status", "ContainerExitCode")
+
+          event   = podman_event_status_to_event(status)
+          running = event != :delete
+
+          container_state = {"Running" => running, "ExitCode" => exit_code.to_i}
+
+          [id, event, container_state]
         end
 
         def podman_event_status_to_event(status)

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -55,6 +55,24 @@ module Floe
           nil
         end
 
+        def parse_notice(notice)
+          notice = JSON.parse(notice)
+          [notice["Name"], podman_event_status_to_event(notice["Status"])]
+        end
+
+        def podman_event_status_to_event(status)
+          case status
+          when "create"
+            :create
+          when "init", "start"
+            :update
+          when "died", "cleanup", "remove"
+            :delete
+          else
+            :unknown
+          end
+        end
+
         alias podman! docker!
 
         def global_docker_options

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -61,9 +61,9 @@ module Floe
           event   = podman_event_status_to_event(status)
           running = event != :delete
 
-          container_state = {"Running" => running, "ExitCode" => exit_code.to_i}
+          runner_context = {"container_ref" => id, "container_state" => {"Running" => running, "ExitCode" => exit_code.to_i}}
 
-          [id, event, container_state]
+          [event, runner_context]
         end
 
         def podman_event_status_to_event(status)

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -64,6 +64,8 @@ module Floe
           runner_context = {"container_ref" => id, "container_state" => {"Running" => running, "ExitCode" => exit_code.to_i}}
 
           [event, runner_context]
+        rescue JSON::ParserError
+          []
         end
 
         def podman_event_status_to_event(status)

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -93,6 +93,14 @@ module Floe
         context.state.key?("FinishedTime")
       end
 
+      def waiting?
+        context.state["WaitUntil"] && Time.now.utc <= Time.parse(context.state["WaitUntil"])
+      end
+
+      def wait_until
+        context.state["WaitUntil"] && Time.parse(context.state["WaitUntil"])
+      end
+
       private
 
       def wait_until!(seconds: nil, time: nil)
@@ -104,10 +112,6 @@ module Floe
           else
             time.iso8601
           end
-      end
-
-      def waiting?
-        context.state["WaitUntil"] && Time.now.utc <= Time.parse(context.state["WaitUntil"])
       end
     end
   end


### PR DESCRIPTION
Add a method for getting update driven notifications about floe events

Get all updates indefinitely:

```ruby
Floe::Workflow::Runner.docker_runner.wait { |runner_context| puts runner_context }
```

Get only create/update events for 30 seconds then break out:

```ruby
Floe::Workflow::Runner.wait(:timeout => 30, :events => %i[create update]) { |runner_context| puts runner_context }
```

TODO
- [x] Kubernetes watches
- [x] Docker events
- [x] Podman events
- [x] Return a compatible runner context from the wait
- [x] Add a way to terminate the wait loop (accept a timeout option)
- [x] Update `Floe::Workflow.wait` to use `Floe::Workflow::Runner#wait` events
- [x] Update exe/floe to use `Floe::Workflow.wait`