### PR TITLE
State tests

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -90,7 +90,7 @@ module Floe
     end
 
     def step_nonblock_ready?
-      !current_state.started? || !current_state.running?
+      current_state.ready?
     end
 
     def status

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -46,7 +46,10 @@ module Floe
       @states         = payload["States"].to_a.map { |name, state| State.build!(self, name, state) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
 
-      context.state["Name"] ||= start_at
+      unless context.state.key?("Name")
+        context.state["Name"] = start_at
+        context.state["Input"] = context.execution["Input"].dup
+      end
     rescue JSON::ParserError => err
       raise Floe::InvalidWorkflowError, err.message
     end
@@ -114,7 +117,6 @@ module Floe
       start_time = Time.now.utc
 
       context.execution["StartTime"] ||= start_time
-      context.state["Input"]         ||= context.execution["Input"].dup
       context.state["Guid"]            = SecureRandom.uuid
       context.state["EnteredTime"]     = start_time
 

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -52,6 +52,10 @@ module Floe
         context.state.key?("EnteredTime")
       end
 
+      def ready?
+        !started? || !running?
+      end
+
       def finished?
         context.state.key?("FinishedTime")
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,22 @@ RSpec.configure do |config|
   end
   config.include AwesomeSpawn::SpecHelper, :uses_awesome_spawn => true
   config.before(:each, :uses_awesome_spawn) { disable_spawning }
+
+  # factory methods
+
+  def make_workflow(ctx, payload, creds: {})
+    Floe::Workflow.new(make_payload(payload), ctx, creds)
+  end
+
+  def make_payload(states)
+    start_at ||= states.keys.first
+
+    {
+      "Comment" => "Sample",
+      "StartAt" => start_at,
+      "States"  => states
+    }
+  end
 end
 
 require "floe"

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -1,36 +1,59 @@
 RSpec.describe Floe::Workflow::States::Choice do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
-  let(:state)    { workflow.states_by_name["ChoiceState"] }
-  let(:inputs)   { {} }
+  let(:input)    { {} }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:state)    { workflow.current_state }
+  let(:workflow) do
+    make_workflow(
+      ctx, {
+        "ChoiceState"      => {
+          "Type"    => "Choice",
+          "Choices" => [
+            {
+              "Variable"      => "$.foo",
+              "NumericEquals" => 1,
+              "Next"          => "FirstMatchState"
+            },
+            {
+              "Variable"      => "$.foo",
+              "NumericEquals" => 2,
+              "Next"          => "SecondMatchState"
+            },
+          ],
+          "Default" => "DefaultState"
+        },
+        "FirstMatchState"  => {"Type" => "Succeed"},
+        "SecondMatchState" => {"Type" => "Succeed"},
+        "DefaultState"     => {"Type" => "Succeed"}
+      }
+    )
+  end
 
   it "#end?" do
     expect(state.end?).to eq(false)
   end
 
   describe "#run!" do
-    let(:subject) { state.run!(inputs) }
-
     context "with a missing variable" do
       it "raises an exception" do
-        expect { subject }.to raise_error(RuntimeError, "No such variable [$.foo]")
+        expect { state.run!(input) }.to raise_error(RuntimeError, "No such variable [$.foo]")
       end
     end
 
     context "with an input value matching a condition" do
-      let(:inputs) { {"foo" => 1} }
+      let(:input) { {"foo" => 1} }
 
       it "returns the next state" do
-        next_state, = subject
-        expect(next_state).to eq("FirstMatchState")
+        state.run!(input)
+        expect(ctx.next_state).to eq("FirstMatchState")
       end
     end
 
     context "with an input value not matching any condition" do
-      let(:inputs) { {"foo" => 4} }
+      let(:input) { {"foo" => 4} }
 
       it "returns the default state" do
-        next_state, = subject
-        expect(next_state).to eq("FailState")
+        state.run!(input)
+        expect(ctx.next_state).to eq("DefaultState")
       end
     end
   end

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -1,13 +1,27 @@
 RSpec.describe Floe::Workflow::States::Fail do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
-  let(:state)    { workflow.states_by_name["FailState"] }
+  let(:input)    { {} }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:state)    { workflow.current_state }
+  let(:workflow) do
+    make_workflow(
+      ctx, {
+        "FailState" => {
+          "Type"  => "Fail",
+          "Error" => "FailStateError",
+          "Cause" => "No Matches!"
+        }
+      }
+    )
+  end
 
   it "#end?" do
     expect(state.end?).to be true
   end
 
   it "#run!" do
-    next_state, _output = state.run!({})
-    expect(next_state).to eq(nil)
+    state.run!(input)
+    expect(ctx.next_state).to eq(nil)
+    expect(ctx.state["Error"]).to eq("FailStateError")
+    expect(ctx.state["Cause"]).to eq("No Matches!")
   end
 end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -1,19 +1,35 @@
 RSpec.describe Floe::Workflow::States::Pass do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
-  let(:state)    { workflow.states_by_name["PassState"] }
+  let(:input)    { {} }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:state)    { workflow.current_state }
+  let(:workflow) do
+    make_workflow(
+      ctx, {
+        "PassState"    => {
+          "Type"       => "Pass",
+          "Result"     => {
+            "foo" => "bar",
+            "bar" => "baz"
+          },
+          "ResultPath" => "$.result",
+          "Next"       => "SuccessState"
+        },
+        "SuccessState" => {"Type" => "Succeed"}
+      }
+    )
+  end
 
   describe "#end?" do
     it "is non-terminal" do
       expect(state.end?).to eq(false)
     end
-    # TODO: test @end
   end
 
   describe "#run!" do
     it "sets the result to the result path" do
-      next_state, output = state.run!({})
-      expect(output["result"]).to include(state.result)
-      expect(next_state).to eq("WaitState")
+      state.run!(ctx.input)
+      expect(ctx.output["result"]).to include({"foo" => "bar", "bar" => "baz"})
+      expect(ctx.next_state).to eq("SuccessState")
     end
   end
 end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::States::Succeed do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
-  let(:state)    { workflow.states_by_name["SuccessState"] }
+  let(:input)    { {} }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:state)    { workflow.current_state }
+  let(:workflow) { make_workflow(ctx, {"SuccessState" => {"Type" => "Succeed"}}) }
 
   it "#end?" do
     expect(state.end?).to be true
@@ -8,8 +10,8 @@ RSpec.describe Floe::Workflow::States::Succeed do
 
   describe "#run!" do
     it "has no next" do
-      next_state, _output = state.run!({})
-      expect(next_state).to be_nil
+      state.run!(input)
+      expect(ctx.next_state).to eq(nil)
     end
   end
 end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::States::Pass do
-  let(:workflow) { Floe::Workflow.load(GEM_ROOT.join("examples/workflow.asl")) }
-  let(:state)    { workflow.states_by_name["WaitState"] }
+  let(:input)    { {} }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:state)    { workflow.current_state }
+  let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
   describe "#end?" do
     it "is non-terminal" do
@@ -12,7 +14,7 @@ RSpec.describe Floe::Workflow::States::Pass do
     it "transitions to the next state" do
       state.start({})
 
-      expect(workflow.context.next_state).to eq("NextState")
+      expect(workflow.context.next_state).to eq("SuccessState")
     end
   end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Floe::Workflow do
       expect(context.running?).to eq(false)
       expect(context.ended?).to eq(false)
     end
+
+    # I would prefer this not be here, but it is, so lets test it
+    it "sets context to proper start_at" do
+      make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      expect(context.state_name).to eq("FirstState")
+      expect(context.input).to eq(input)
+    end
   end
 
   describe "#run!" do

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -1,50 +1,50 @@
 require 'active_support/time'
 
 RSpec.describe Floe::Workflow do
-  let(:now)     { Time.now.utc }
-  let(:input)   { {"input" => "value"}.freeze }
-  let(:context) { Floe::Workflow::Context.new(:input => input) }
+  let(:now)   { Time.now.utc }
+  let(:input) { {"input" => "value"}.freeze }
+  let(:ctx)   { Floe::Workflow::Context.new(:input => input) }
 
   describe "#new" do
     it "sets initial state" do
-      workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
 
       expect(workflow.status).to eq("pending")
       expect(workflow.end?).to eq(false)
 
-      expect(context.status).to eq("pending")
-      expect(context.started?).to eq(false)
-      expect(context.running?).to eq(false)
-      expect(context.ended?).to eq(false)
+      expect(ctx.status).to eq("pending")
+      expect(ctx.started?).to eq(false)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(false)
     end
 
     # I would prefer this not be here, but it is, so lets test it
     it "sets context to proper start_at" do
-      make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
-      expect(context.state_name).to eq("FirstState")
-      expect(context.input).to eq(input)
+      make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
+      expect(ctx.state_name).to eq("FirstState")
+      expect(ctx.input).to eq(input)
     end
   end
 
   describe "#run!" do
     it "sets execution variables for success" do
-      workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
       workflow.run!
 
       # state
-      expect(context.state["EnteredTime"]).to be_within(1.second).of(now)
-      expect(context.state["Guid"]).to be
-      expect(context.state_name).to eq("FirstState")
-      expect(context.input).to eq(input)
-      expect(context.output).to eq(input)
-      expect(context.state["FinishedTime"]).to be_within(1.second).of(now)
-      expect(context.state["Duration"]).to be <= 1
-      expect(context.status).to eq("success")
+      expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
+      expect(ctx.state["Guid"]).to be
+      expect(ctx.state_name).to eq("FirstState")
+      expect(ctx.input).to eq(input)
+      expect(ctx.output).to eq(input)
+      expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
+      expect(ctx.state["Duration"]).to be <= 1
+      expect(ctx.status).to eq("success")
 
       # execution
-      expect(context.started?).to eq(true)
-      expect(context.running?).to eq(false)
-      expect(context.ended?).to eq(true)
+      expect(ctx.started?).to eq(true)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(true)
 
       # final results
       expect(workflow.output).to eq(input)
@@ -53,25 +53,25 @@ RSpec.describe Floe::Workflow do
     end
 
     it "sets execution variables for failure" do
-      workflow = make_workflow(input, {"FirstState" => {"Type" => "Fail", "Cause" => "Bad Stuff", "Error" => "Issue"}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Fail", "Cause" => "Bad Stuff", "Error" => "Issue"}})
       workflow.run!
 
       # state
-      expect(context.state["EnteredTime"]).to be_within(1.second).of(now)
-      expect(context.state["Guid"]).to be
-      expect(context.state_name).to eq("FirstState")
-      expect(context.input).to eq(input)
-      expect(context.output).to eq(input)
-      expect(context.state["FinishedTime"]).to be_within(1.second).of(now)
-      expect(context.state["Duration"]).to be <= 1
-      expect(context.state["Cause"]).to eq("Bad Stuff")
-      expect(context.state["Error"]).to eq("Issue")
-      expect(context.status).to eq("failure")
+      expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
+      expect(ctx.state["Guid"]).to be
+      expect(ctx.state_name).to eq("FirstState")
+      expect(ctx.input).to eq(input)
+      expect(ctx.output).to eq(input)
+      expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
+      expect(ctx.state["Duration"]).to be <= 1
+      expect(ctx.state["Cause"]).to eq("Bad Stuff")
+      expect(ctx.state["Error"]).to eq("Issue")
+      expect(ctx.status).to eq("failure")
 
       # execution
-      expect(context.started?).to eq(true)
-      expect(context.running?).to eq(false)
-      expect(context.ended?).to eq(true)
+      expect(ctx.started?).to eq(true)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(true)
 
       # final results
       expect(workflow.output).to eq(input)
@@ -82,49 +82,49 @@ RSpec.describe Floe::Workflow do
 
   describe "#run_nonblock" do
     it "starts the first state" do
-      workflow = make_workflow(input, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
       workflow.run_nonblock
 
-      expect(context.started?).to eq(true)
+      expect(ctx.started?).to eq(true)
     end
 
     it "doesn't wait for the state to finish" do
-      workflow = make_workflow(input, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
       workflow.run_nonblock
 
-      expect(context.running?).to eq(true)
-      expect(context.ended?).to   eq(false)
+      expect(ctx.running?).to eq(true)
+      expect(ctx.ended?).to   eq(false)
     end
   end
 
   describe "#step" do
     it "runs a success step" do
-      workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
 
       expect(workflow.status).to eq("pending")
       expect(workflow.end?).to eq(false)
-      expect(context.status).to eq("pending")
-      expect(context.started?).to eq(false)
-      expect(context.running?).to eq(false)
-      expect(context.ended?).to eq(false)
+      expect(ctx.status).to eq("pending")
+      expect(ctx.started?).to eq(false)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(false)
 
       workflow.step
 
       expect(workflow.output).to eq(input)
       expect(workflow.status).to eq("success")
       expect(workflow.end?).to eq(true)
-      expect(context.output).to eq(input)
-      expect(context.status).to eq("success")
-      expect(context.started?).to eq(true)
-      expect(context.running?).to eq(false)
-      expect(context.ended?).to eq(true)
+      expect(ctx.output).to eq(input)
+      expect(ctx.status).to eq("success")
+      expect(ctx.started?).to eq(true)
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to eq(true)
     end
   end
 
   describe "#step_nonblock" do
     context "with a workflow that hasn't started yet" do
       it "starts the first step" do
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
         workflow.step_nonblock
 
         expect(workflow.status).to eq("running")
@@ -134,20 +134,20 @@ RSpec.describe Floe::Workflow do
 
     context "with a running state" do
       it "returns Try again" do
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
         expect(workflow.step_nonblock).to eq(Errno::EAGAIN)
       end
     end
 
     context "with a state that has finished" do
       it "completes the final tasks for a state" do
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
 
         # Start the workflow
         workflow.run_nonblock
 
         # Mark the Wait state as having started 1 minute ago
-        context.state["EnteredTime"] = Time.now.utc - 60
+        ctx.state["EnteredTime"] = Time.now.utc - 60
 
         # step_nonblock should return 0 and mark the workflow as completed
         expect(workflow.step_nonblock).to eq(0)
@@ -155,18 +155,18 @@ RSpec.describe Floe::Workflow do
         expect(workflow.output).to eq(input)
         expect(workflow.status).to eq("success")
         expect(workflow.end?).to eq(true)
-        expect(context.output).to eq(input)
-        expect(context.status).to eq("success")
-        expect(context.started?).to eq(true)
-        expect(context.running?).to eq(false)
-        expect(context.ended?).to eq(true)
+        expect(ctx.output).to eq(input)
+        expect(ctx.status).to eq("success")
+        expect(ctx.started?).to eq(true)
+        expect(ctx.running?).to eq(false)
+        expect(ctx.ended?).to eq(true)
       end
     end
 
     it "return Operation not permitted if workflow has ended" do
-      workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
 
-      context.execution["EndTime"] = Time.now.utc
+      ctx.execution["EndTime"] = Time.now.utc
 
       expect(workflow.step_nonblock).to eq(Errno::EPERM)
     end
@@ -175,15 +175,15 @@ RSpec.describe Floe::Workflow do
   describe "#step_nonblock_wait" do
     context "with a state that hasn't started yet" do
       it "returns 0" do
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
         expect(workflow.step_nonblock_wait).to eq(0)
       end
     end
 
     context "with a state that has finished" do
       it "return 0" do
-        context.state["EnteredTime"] = Time.now.utc
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+        ctx.state["EnteredTime"] = Time.now.utc
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
         expect(workflow.current_state).to receive(:running?).and_return(false)
         expect(workflow.step_nonblock_wait).to eq(0)
       end
@@ -191,8 +191,8 @@ RSpec.describe Floe::Workflow do
 
     context "with a state that is running" do
       it "returns Try again" do
-        context.state["EnteredTime"] = Time.now.utc
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest"}})
+        ctx.state["EnteredTime"] = Time.now.utc
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest"}})
         expect(workflow.current_state).to receive(:running?).and_return(true)
         expect(workflow.step_nonblock_wait(:timeout => 0)).to eq(Errno::EAGAIN)
       end
@@ -202,15 +202,15 @@ RSpec.describe Floe::Workflow do
   describe "#step_nonblock_ready?" do
     context "with a state that hasn't started yet" do
       it "returns true" do
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
         expect(workflow.step_nonblock_ready?).to be_truthy
       end
     end
 
     context "with a state that has finished" do
       it "return true" do
-        context.state["EnteredTime"] = Time.now.utc
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Succeed"}})
+        ctx.state["EnteredTime"] = Time.now.utc
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
         expect(workflow.current_state).to receive(:running?).and_return(false)
         expect(workflow.step_nonblock_ready?).to be_truthy
       end
@@ -218,27 +218,11 @@ RSpec.describe Floe::Workflow do
 
     context "with a state that is running" do
       it "returns false" do
-        context.state["EnteredTime"] = Time.now.utc
-        workflow = make_workflow(input, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest"}})
+        ctx.state["EnteredTime"] = Time.now.utc
+        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest"}})
         expect(workflow.current_state).to receive(:running?).and_return(true)
         expect(workflow.step_nonblock_ready?).to be_falsey
       end
     end
-  end
-
-  private
-
-  def make_workflow(input, payload, creds: {})
-    Floe::Workflow.new(make_payload(payload), context, creds)
-  end
-
-  def make_payload(states)
-    start_at ||= states.keys.first
-
-    {
-      "Comment" => "Sample",
-      "StartAt" => start_at,
-      "States"  => states
-    }
   end
 end


### PR DESCRIPTION
- Move the intialization start_at/input to a single spot of code.
- tests now consolidated to a common pattern.
- State#step_nonblock_ready?

Code no longer pays attention to `State#run` return value