### PR TITLE
Move workflow#step into State#run

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -119,18 +119,6 @@ module Floe
 
     def step_nonblock_finish
       current_state.finish
-
-      entered_time  = Time.parse(context.state["EnteredTime"])
-      finished_time = Time.parse(context.state["FinishedTime"])
-
-      context.state["Duration"]    = finished_time - entered_time
-      context.execution["EndTime"] = Time.now.utc.iso8601 if context.next_state.nil?
-
-      logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
-
-      context.state_history << context.state
-
-      0
     end
 
     def step_next

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -114,17 +114,7 @@ module Floe
     private
 
     def step_nonblock_start
-      raise "State is already running" if current_state.started?
-
-      start_time = Time.now.utc.iso8601
-
-      context.execution["StartTime"] ||= start_time
-      context.state["Guid"]            = SecureRandom.uuid
-      context.state["EnteredTime"]     = start_time
-
-      logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...")
-
-      current_state.start(context.state["Input"])
+      current_state.start(context.input)
     end
 
     def step_nonblock_finish

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -72,6 +72,8 @@ module Floe
     def step_nonblock
       return Errno::EPERM if end?
 
+      step_next
+
       step_nonblock_start unless current_state.started?
       return Errno::EAGAIN unless step_nonblock_ready?
 
@@ -138,9 +140,11 @@ module Floe
 
       context.state_history << context.state
 
-      context.state = {"Name" => context.next_state, "Input" => context.output} unless end?
-
       0
+    end
+
+    def step_next
+      context.state = {"Name" => context.next_state, "Input" => context.output} if context.next_state
     end
   end
 end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -47,7 +47,19 @@ module Floe
       end
 
       def finish
-        context.state["FinishedTime"] ||= Time.now.utc.iso8601
+        finished_time     = Time.now.utc
+        finished_time_iso = finished_time.iso8601
+        entered_time      = Time.parse(context.state["EnteredTime"])
+
+        context.state["FinishedTime"] ||= finished_time_iso
+        context.state["Duration"]       = finished_time - entered_time
+        context.execution["EndTime"]    = finished_time_iso if context.next_state.nil?
+
+        logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
+
+        context.state_history << context.state
+
+        0
       end
 
       def context

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -29,11 +29,8 @@ module Floe
         @comment  = payload["Comment"]
       end
 
-      def run!(input)
-        start(input)
-        sleep(1) while running?
-        finish
-        [context.next_state, context.output]
+      def run!(_input = nil)
+        run_wait until run_nonblock! == 0
       end
 
       def run_wait(timeout: 5)

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -37,7 +37,13 @@ module Floe
       end
 
       def start(_input)
-        raise NotImpelmentedError
+        start_time = Time.now.utc.iso8601
+
+        context.execution["StartTime"] ||= start_time
+        context.state["Guid"]            = SecureRandom.uuid
+        context.state["EnteredTime"]     = start_time
+
+        logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...")
       end
 
       def finish

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -36,6 +36,24 @@ module Floe
         [context.next_state, context.output]
       end
 
+      def run_wait(timeout: 5)
+        start = Time.now.utc
+
+        loop do
+          return 0             if ready?
+          return Errno::EAGAIN if timeout.zero? || Time.now.utc - start > timeout
+
+          sleep(1)
+        end
+      end
+
+      def run_nonblock!
+        start(context.input) unless started?
+        return Errno::EAGAIN unless ready?
+
+        finish
+      end
+
       def start(_input)
         start_time = Time.now.utc.iso8601
 

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -17,6 +17,7 @@ module Floe
         end
 
         def start(input)
+          super
           input      = input_path.value(context, input)
           next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default
           output     = output_path.value(context, input)

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -14,6 +14,7 @@ module Floe
         end
 
         def start(input)
+          super
           context.state["Error"] = error
           context.state["Cause"] = cause
           context.next_state     = nil

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -20,6 +20,7 @@ module Floe
         end
 
         def start(input)
+          super
           output = input_path.value(context, input)
           output = result_path.set(output, result) if result && result_path
           output = output_path.value(context, output)

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -11,6 +11,7 @@ module Floe
         end
 
         def start(input)
+          super
           context.next_state = nil
           context.output     = input
         end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -28,6 +28,7 @@ module Floe
         end
 
         def start(input)
+          super
           input = input_path.value(context, input)
           input = parameters.value(context, input) if parameters
 

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -41,8 +41,6 @@ module Floe
         end
 
         def finish
-          super
-
           results = runner.output(context.state["RunnerContext"])
 
           if success?
@@ -51,6 +49,8 @@ module Floe
           else
             retry_state!(results) || catch_error!(results)
           end
+
+          super
         ensure
           runner.cleanup(context.state["RunnerContext"])
         end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -18,6 +18,7 @@ module Floe
         end
 
         def start(input)
+          super
           input = input_path.value(context, input)
 
           context.output     = output_path.value(context, input)

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -166,7 +166,6 @@ RSpec.describe Floe::Workflow::States::Task do
             expect(mock_runner).to receive("output").once.and_return("States.Timeout")
             expect(mock_runner)
               .to receive(:run_async!)
-              .twice
               .with(payload["Resource"], input, nil)
 
             state.run!(input)
@@ -188,7 +187,6 @@ RSpec.describe Floe::Workflow::States::Task do
         it "raises if the number of retries is greater than MaxAttempts" do
           expect(mock_runner)
             .to receive(:run_async!)
-            .twice
             .with(payload["Resource"], input, nil)
 
           state.run!(input)
@@ -211,7 +209,6 @@ RSpec.describe Floe::Workflow::States::Task do
         it "retries if any error is raised" do
           expect(mock_runner)
             .to receive(:run_async!)
-            .twice
             .with(payload["Resource"], input, nil)
           expect(mock_runner).to receive("output").once.and_return("ABORT!")
           expect(mock_runner).to receive("output").once.and_return(output)


### PR DESCRIPTION
## Overview

Move `Workflow#step_nonblock` to `State#run_nonblock` and related variables.
`State` now owns the complete run cycle.

## Details

- This is mostly moving code and not changing anything.
- `State#run` (blocking) is the only change, and you will recognize that code as the standard `wait until run` style.
- Step through commits. none of them seem to do anything

## Side effects

- State#run! now ignores `input`
- State#run! now returns the block status (0) instead of the `output, next_state`
- State#start is no longer abstract (sorry)
- Setting `next_state` at the beginning of the `step` loop rather than the end