### PR TITLE
RunnerContext should use string keys

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -114,7 +114,7 @@ module Floe
     def step_nonblock_start
       raise "State is already running" if current_state.started?
 
-      start_time = Time.now.utc
+      start_time = Time.now.utc.iso8601
 
       context.execution["StartTime"] ||= start_time
       context.state["Guid"]            = SecureRandom.uuid
@@ -127,8 +127,12 @@ module Floe
 
     def step_nonblock_finish
       current_state.finish
-      context.state["Duration"]    = context.state["FinishedTime"] - context.state["EnteredTime"]
-      context.execution["EndTime"] = Time.now.utc if context.next_state.nil?
+
+      entered_time  = Time.parse(context.state["EnteredTime"])
+      finished_time = Time.parse(context.state["FinishedTime"])
+
+      context.state["Duration"]    = finished_time - entered_time
+      context.execution["EndTime"] = Time.now.utc.iso8601 if context.next_state.nil?
 
       logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
 

--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -26,9 +26,9 @@ module Floe
 
           output = run_container(image, env, secrets_file)
 
-          {:exit_code => 0, :output => output}
+          {"exit_code" => 0, "output" => output}
         ensure
-          cleanup({:secrets_ref => secrets_file})
+          cleanup({"secrets_ref" => secrets_file})
         end
 
         def run_async!(resource, env = {}, secrets = {})
@@ -39,12 +39,12 @@ module Floe
           runner_context = {}
 
           if secrets && !secrets.empty?
-            runner_context[:secrets_ref] = create_secret(secrets)
+            runner_context["secrets_ref"] = create_secret(secrets)
             env["_CREDENTIALS"] = "/run/secrets"
           end
 
           begin
-            runner_context[:container_ref] = run_container(image, env, runner_context[:secrets_ref], :detached => true)
+            runner_context["container_ref"] = run_container(image, env, runner_context["secrets_ref"], :detached => true)
           rescue
             cleanup(runner_context)
             raise
@@ -54,27 +54,27 @@ module Floe
         end
 
         def cleanup(runner_context)
-          container_id, secrets_file = runner_context.values_at(:container_ref, :secrets_ref)
+          container_id, secrets_file = runner_context.values_at("container_ref", "secrets_ref")
 
           delete_container(container_id) if container_id
           File.unlink(secrets_file)      if secrets_file && File.exist?(secrets_file)
         end
 
         def status!(runner_context)
-          runner_context[:container_state] = inspect_container(runner_context[:container_ref]).first&.dig("State")
+          runner_context["container_state"] = inspect_container(runner_context["container_ref"]).first&.dig("State")
         end
 
         def running?(runner_context)
-          runner_context.dig(:container_state, "Running")
+          runner_context.dig("container_state", "Running")
         end
 
         def success?(runner_context)
-          runner_context.dig(:container_state, "ExitCode") == 0
+          runner_context.dig("container_state", "ExitCode") == 0
         end
 
         def output(runner_context)
-          output = docker!("logs", runner_context[:container_ref]).output
-          runner_context[:output] = output
+          output = docker!("logs", runner_context["container_ref"]).output
+          runner_context["output"] = output
         end
 
         private

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -46,7 +46,7 @@ module Floe
           secret = create_secret!(secrets) if secrets && !secrets.empty?
 
           begin
-            runner_context = {:container_ref => name}
+            runner_context = {"container_ref" => name}
 
             create_pod!(name, image, env, secret)
             loop do
@@ -54,11 +54,11 @@ module Floe
               when "Pending", "Running"
                 sleep(1)
               when "Succeeded"
-                runner_context[:exit_code] = 0
+                runner_context["exit_code"] = 0
                 output(runner_context)
                 break
               else
-                runner_context[:exit_code] = 0
+                runner_context["exit_code"] = 0
                 output(runner_context)
                 break
               end
@@ -66,7 +66,7 @@ module Floe
 
             runner_context
           ensure
-            cleanup({:container_ref => name, :secrets_ref => secret})
+            cleanup({"container_ref" => name, "secrets_ref" => secret})
           end
         end
 
@@ -77,7 +77,7 @@ module Floe
           name   = pod_name(image)
           secret = create_secret!(secrets) if secrets && !secrets.empty?
 
-          runner_context = {:container_ref => name, :secrets_ref => secret}
+          runner_context = {"container_ref" => name, "secrets_ref" => secret}
 
           begin
             create_pod!(name, image, env, secret)
@@ -90,24 +90,24 @@ module Floe
         end
 
         def status!(runner_context)
-          runner_context[:container_state] = pod_info(runner_context[:container_ref])["status"]
+          runner_context["container_state"] = pod_info(runner_context["container_ref"])["status"]
         end
 
         def running?(runner_context)
-          %w[Pending Running].include?(runner_context.dig(:container_state, "phase"))
+          %w[Pending Running].include?(runner_context.dig("container_state", "phase"))
         end
 
         def success?(runner_context)
-          runner_context.dig(:container_state, "phase") == "Succeeded"
+          runner_context.dig("container_state", "phase") == "Succeeded"
         end
 
         def output(runner_context)
-          output = kubeclient.get_pod_log(runner_context[:container_ref], namespace).body
-          runner_context[:output] = output
+          output = kubeclient.get_pod_log(runner_context["container_ref"], namespace).body
+          runner_context["output"] = output
         end
 
         def cleanup(runner_context)
-          pod, secret = runner_context.values_at(:container_ref, :secrets_ref)
+          pod, secret = runner_context.values_at("container_ref", "secrets_ref")
 
           delete_pod(pod)       if pod
           delete_secret(secret) if secret

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -38,7 +38,7 @@ module Floe
 
           output = run_container(image, env, secret)
 
-          {:exit_code => 0, :output => output}
+          {"exit_code" => 0, :output => output}
         ensure
           delete_secret(secret) if secret
         end
@@ -56,35 +56,35 @@ module Floe
           begin
             container_id = run_container(image, env, secret_guid, :detached => true)
           rescue
-            cleanup({:container_ref => container_id, :secrets_ref => secret_guid})
+            cleanup({"container_ref" => container_id, "secrets_ref" => secret_guid})
             raise
           end
 
-          {:container_ref => container_id, :secrets_ref => secret_guid}
+          {"container_ref" => container_id, "secrets_ref" => secret_guid}
         end
 
         def cleanup(runner_context)
-          container_id, secret_guid = runner_context.values_at(:container_ref, :secrets_ref)
+          container_id, secret_guid = runner_context.values_at("container_ref", "secrets_ref")
 
           delete_container(container_id) if container_id
           delete_secret(secret_guid)     if secret_guid
         end
 
         def status!(runner_context)
-          runner_context[:container_state] = inspect_container(runner_context[:container_ref]).first&.dig("State")
+          runner_context["container_state"] = inspect_container(runner_context["container_ref"]).first&.dig("State")
         end
 
         def running?(runner_context)
-          runner_context.dig(:container_state, "Running")
+          runner_context.dig("container_state", "Running")
         end
 
         def success?(runner_context)
-          runner_context.dig(:container_state, "ExitCode") == 0
+          runner_context.dig("container_state", "ExitCode") == 0
         end
 
         def output(runner_context)
-          output = podman!("logs", runner_context[:container_ref]).output
-          runner_context[:output] = output
+          output = podman!("logs", runner_context["container_ref"]).output
+          runner_context["output"] = output
         end
 
         private

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -41,7 +41,7 @@ module Floe
       end
 
       def finish
-        context.state["FinishedTime"] ||= Time.now.utc
+        context.state["FinishedTime"] ||= Time.now.utc.iso8601
       end
 
       def context

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -26,8 +26,8 @@ module Floe
 
         def running?
           now = Time.now.utc
-          if now > (context.state["EnteredTime"] + @seconds)
-            context.state["FinishedTime"] = now
+          if now > (Time.parse(context.state["EnteredTime"]) + @seconds)
+            context.state["FinishedTime"] = now.iso8601
             false
           else
             true

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -84,40 +84,40 @@ RSpec.describe Floe::Workflow::Runner::Docker do
   describe "#status!" do
     it "returns the updated container_state" do
       stub_good_run!("docker", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": true}}]")
-      runner_context = {:container_ref => container_id}
+      runner_context = {"container_ref" => container_id}
 
       subject.status!(runner_context)
 
-      expect(runner_context).to include(:container_state => {"Running" => true})
+      expect(runner_context).to include("container_state" => {"Running" => true})
     end
   end
 
   describe "#running?" do
     it "returns true when running" do
-      runner_context = {:container_ref => container_id, :container_state => {"Running" => true}}
+      runner_context = {"container_ref" => container_id, "container_state" => {"Running" => true}}
       expect(subject.running?(runner_context)).to be_truthy
     end
 
     it "returns false when completed" do
-      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 0}}
+      runner_context = {"container_ref" => container_id, "container_state" => {"Running" => false, "ExitCode" => 0}}
       expect(subject.running?(runner_context)).to be_falsey
     end
   end
 
   describe "#success?" do
     it "returns true when successful" do
-      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 0}}
+      runner_context = {"container_ref" => container_id, "container_state" => {"Running" => false, "ExitCode" => 0}}
       expect(subject.success?(runner_context)).to be_truthy
     end
 
     it "returns false when unsuccessful" do
-      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 1}}
+      runner_context = {"container_ref" => container_id, "container_state" => {"Running" => false, "ExitCode" => 1}}
       expect(subject.success?(runner_context)).to be_falsey
     end
   end
 
   describe "#output" do
-    let(:runner_context) { {:container_ref => container_id} }
+    let(:runner_context) { {"container_ref" => container_id} }
 
     it "returns log output" do
       stub_good_run!("docker", :params => ["logs", container_id], :output => "hello, world!")
@@ -137,20 +137,20 @@ RSpec.describe Floe::Workflow::Runner::Docker do
       stub_good_run!("docker", :params => ["rm", container_id])
       expect(File).to receive(:exist?).with(secrets_file).and_return(true)
       expect(File).to receive(:unlink).with(secrets_file)
-      subject.cleanup({:container_ref => container_id, :secrets_ref => secrets_file})
+      subject.cleanup({"container_ref" => container_id, "secrets_ref" => secrets_file})
     end
 
     it "doesn't delete the secret_file if not passed" do
       stub_good_run!("docker", :params => ["rm", container_id])
       expect(File).not_to receive(:unlink).with(secrets_file)
-      subject.cleanup({:container_ref => container_id})
+      subject.cleanup({"container_ref" => container_id})
     end
 
     it "deletes the secrets file if deleting the container fails" do
       stub_bad_run!("docker", :params => ["rm", container_id])
       expect(File).to receive(:exist?).with(secrets_file).and_return(true)
       expect(File).to receive(:unlink).with(secrets_file)
-      subject.cleanup({:container_ref => container_id, :secrets_ref => secrets_file})
+      subject.cleanup({"container_ref" => container_id, "secrets_ref" => secrets_file})
     end
   end
 end

--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -290,12 +290,12 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
   end
 
   describe "#status!" do
-    let(:runner_context) { {:container_ref => "my-pod"} }
+    let(:runner_context) { {"container_ref" => "my-pod"} }
 
     it "updates the runner_context with container_state" do
       allow(kubeclient).to receive(:get_pod).and_return({"status" => {"phase" => "Pending"}})
       subject.status!(runner_context)
-      expect(runner_context).to include(:container_state => {"phase" => "Pending"})
+      expect(runner_context).to include("container_state" => {"phase" => "Pending"})
     end
 
     it "raises an exception when getting pod info fails" do
@@ -306,40 +306,40 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
   describe "#running?" do
     it "returns true when phase is Pending" do
-      runner_context = {:container_ref => "my-pod", :container_state => {"phase" => "Pending"}}
+      runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Pending"}}
       expect(subject.running?(runner_context)).to be_truthy
     end
 
     it "returns true when phase is Running" do
-      runner_context = {:container_ref => "my-pod", :container_state => {"phase" => "Running"}}
+      runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Running"}}
       expect(subject.running?(runner_context)).to be_truthy
     end
 
     it "returns false when phase is Succeeded" do
-      runner_context = {:container_ref => "my-pod", :container_state => {"phase" => "Succeeded"}}
+      runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Succeeded"}}
       expect(subject.running?(runner_context)).to be_falsey
     end
   end
 
   describe "#success?" do
     it "returns false when phase is Pending" do
-      runner_context = {:container_ref => "my-pod", :container_state => {"phase" => "Pending"}}
+      runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Pending"}}
       expect(subject.success?(runner_context)).to be_falsey
     end
 
     it "returns false when phase is Running" do
-      runner_context = {:container_ref => "my-pod", :container_state => {"phase" => "Running"}}
+      runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Running"}}
       expect(subject.success?(runner_context)).to be_falsey
     end
 
     it "returns true when phase is Succeeded" do
-      runner_context = {:container_ref => "my-pod", :container_state => {"phase" => "Succeeded"}}
+      runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Succeeded"}}
       expect(subject.success?(runner_context)).to be_truthy
     end
   end
 
   describe "#output" do
-    let(:runner_context) { {:container_ref => "my-pod"} }
+    let(:runner_context) { {"container_ref" => "my-pod"} }
 
     it "returns log output" do
       expect(kubeclient).to receive(:get_pod_log).with("my-pod", "default").and_return(RestClient::Response.new("hello, world!"))
@@ -357,21 +357,21 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       expect(kubeclient).to receive(:delete_pod).with("my-pod", "default")
       expect(kubeclient).to receive(:delete_secret).with("my-secret", "default")
 
-      subject.cleanup({:container_ref => "my-pod", :secrets_ref => "my-secret"})
+      subject.cleanup({"container_ref" => "my-pod", "secrets_ref" => "my-secret"})
     end
 
     it "doesn't delete secret if none passed in" do
       expect(kubeclient).to receive(:delete_pod).with("my-pod", "default")
       expect(kubeclient).not_to receive(:delete_secret)
 
-      subject.cleanup({:container_ref => "my-pod"})
+      subject.cleanup({"container_ref" => "my-pod"})
     end
 
     it "deletes secret if pod deletion fails" do
       expect(kubeclient).to receive(:delete_pod).with("my-pod", "default").and_raise(Kubeclient::ResourceNotFoundError.new(404, "Resource Not Found", {}))
       expect(kubeclient).to receive(:delete_secret).with("my-secret", "default")
 
-      subject.cleanup({:container_ref => "my-pod", :secrets_ref => "my-secret"})
+      subject.cleanup({"container_ref" => "my-pod", "secrets_ref" => "my-secret"})
     end
   end
 end

--- a/spec/workflow/runner/podman_spec.rb
+++ b/spec/workflow/runner/podman_spec.rb
@@ -43,43 +43,43 @@ RSpec.describe Floe::Workflow::Runner::Podman do
   end
 
   describe "#status!" do
-    let(:runner_context) { {:container_ref => container_id} }
+    let(:runner_context) { {"container_ref" => container_id} }
 
     it "returns the updated container_state" do
       stub_good_run!("podman", :params => ["inspect", container_id], :output => "[{\"State\": {\"Running\": true}}]")
 
       subject.status!(runner_context)
 
-      expect(runner_context).to include(:container_state => {"Running" => true})
+      expect(runner_context).to include("container_state" => {"Running" => true})
     end
   end
 
   describe "#running?" do
     it "retuns true when running" do
-      runner_context = {:container_ref => container_id, :container_state => {"Running" => true}}
+      runner_context = {"container_ref" => container_id, "container_state" => {"Running" => true}}
       expect(subject.running?(runner_context)).to be_truthy
     end
 
     it "retuns false when not running" do
-      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 0}}
+      runner_context = {"container_ref" => container_id, "container_state" => {"Running" => false, "ExitCode" => 0}}
       expect(subject.running?(runner_context)).to be_falsey
     end
   end
 
   describe "#success?" do
     it "retuns true when successful" do
-      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 0}}
+      runner_context = {"container_ref" => container_id, "container_state" => {"Running" => false, "ExitCode" => 0}}
       expect(subject.success?(runner_context)).to be_truthy
     end
 
     it "retuns false when not successful" do
-      runner_context = {:container_ref => container_id, :container_state => {"Running" => false, "ExitCode" => 1}}
+      runner_context = {"container_ref" => container_id, "container_state" => {"Running" => false, "ExitCode" => 1}}
       expect(subject.success?(runner_context)).to be_falsey
     end
   end
 
   describe "#output" do
-    let(:runner_context) { {:container_ref => container_id} }
+    let(:runner_context) { {"container_ref" => container_id} }
 
     it "returns log output" do
       stub_good_run!("podman", :params => ["logs", container_id], :output => "hello, world!")
@@ -92,20 +92,20 @@ RSpec.describe Floe::Workflow::Runner::Podman do
       stub_good_run!("podman", :params => ["secret", "rm", "my-secret"])
       stub_good_run!("podman", :params => ["rm", container_id])
 
-      subject.cleanup({:container_ref => container_id, :secrets_ref => "my-secret"})
+      subject.cleanup({"container_ref" => container_id, "secrets_ref" => "my-secret"})
     end
 
     it "doesn't delete the secret if one isn't passed in" do
       stub_good_run!("podman", :params => ["rm", container_id])
 
-      subject.cleanup({:container_ref => container_id})
+      subject.cleanup({"container_ref" => container_id})
     end
 
     it "deletes the secret if deleting the pod fails" do
       stub_good_run!("podman", :params => ["secret", "rm", "my-secret"])
       stub_bad_run!("podman", :params => ["rm", container_id])
 
-      subject.cleanup({:container_ref => container_id, :secrets_ref => "my-secret"})
+      subject.cleanup({"container_ref" => container_id, "secrets_ref" => "my-secret"})
     end
 
     context "with docker runner options" do

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Floe::Workflow::States::Task do
       allow(mock_runner).to receive(:status!).and_return({})
       allow(mock_runner).to receive(:running?).and_return(false)
       allow(mock_runner).to receive(:success?).and_return(success)
-      allow(mock_runner).to receive(:output).and_return(output)
+      allow(mock_runner).to receive("output").and_return(output)
       allow(mock_runner).to receive(:cleanup)
     end
 
@@ -29,7 +29,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
-            .and_return(:exit_code => 0, :output => "hello, world!")
+            .and_return("exit_code" => 0, "output" => "hello, world!")
 
           state.run!(input)
         end
@@ -42,7 +42,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], {"bar" => "baz"}, nil)
-            .and_return(:exit_code => 0, :output => "hello, world!")
+            .and_return("exit_code" => 0, "output" => "hello, world!")
 
           state.run!(input)
         end
@@ -55,7 +55,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], {"var1" => "baz"}, nil)
-            .and_return(:exit_code => 0, :output => "hello, world!")
+            .and_return("exit_code" => 0, "output" => "hello, world!")
 
           state.run!(input)
         end
@@ -70,7 +70,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
-          expect(mock_runner).to receive(:output).and_return("{\"response\":[\"192.168.1.2\"],\"exit_code\":0}")
+          expect(mock_runner).to receive("output").and_return("{\"response\":[\"192.168.1.2\"],\"exit_code\":0}")
 
           state.run!(input)
 
@@ -85,7 +85,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)
-          expect(mock_runner).to receive(:output).and_return("[\"192.168.1.2\"]")
+          expect(mock_runner).to receive("output").and_return("[\"192.168.1.2\"]")
 
           state.run!(input)
 
@@ -107,7 +107,7 @@ RSpec.describe Floe::Workflow::States::Task do
             expect(mock_runner)
               .to receive(:run_async!)
               .with(payload["Resource"], input, nil)
-            expect(mock_runner).to receive(:output).and_return("[\"192.168.1.2\"]")
+            expect(mock_runner).to receive("output").and_return("[\"192.168.1.2\"]")
 
             state.run!(input)
 
@@ -126,7 +126,7 @@ RSpec.describe Floe::Workflow::States::Task do
             expect(mock_runner)
               .to receive(:run_async!)
               .with(payload["Resource"], input, nil)
-            expect(mock_runner).to receive(:output).and_return("[\"192.168.1.2\"]")
+            expect(mock_runner).to receive("output").and_return("[\"192.168.1.2\"]")
 
             state.run!(input)
 
@@ -163,7 +163,7 @@ RSpec.describe Floe::Workflow::States::Task do
           it "resets the retrier if a different exception is raised" do
             expect(mock_runner).to receive(:running?).and_return(false)
             expect(mock_runner).to receive(:success?).and_return(false)
-            expect(mock_runner).to receive(:output).once.and_return("States.Timeout")
+            expect(mock_runner).to receive("output").once.and_return("States.Timeout")
             expect(mock_runner)
               .to receive(:run_async!)
               .twice
@@ -175,7 +175,7 @@ RSpec.describe Floe::Workflow::States::Task do
             expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
             expect(ctx.state["RetryCount"]).to eq(1)
 
-            expect(mock_runner).to receive(:output).once.and_return("Exception")
+            expect(mock_runner).to receive("output").once.and_return("Exception")
 
             state.run!(input)
 
@@ -199,7 +199,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)
-          expect(mock_runner).to receive(:output).once.and_return("Exception")
+          expect(mock_runner).to receive("output").once.and_return("Exception")
 
           expect { state.run!(input) }.to raise_error(RuntimeError, "Exception")
         end
@@ -213,8 +213,8 @@ RSpec.describe Floe::Workflow::States::Task do
             .to receive(:run_async!)
             .twice
             .with(payload["Resource"], input, nil)
-          expect(mock_runner).to receive(:output).once.and_return("ABORT!")
-          expect(mock_runner).to receive(:output).once.and_return(output)
+          expect(mock_runner).to receive("output").once.and_return("ABORT!")
+          expect(mock_runner).to receive("output").once.and_return(output)
 
           state.run!(input)
           state.run!(input)
@@ -228,7 +228,7 @@ RSpec.describe Floe::Workflow::States::Task do
         let(:success) { false }
 
         it "retry preceeds catch" do
-          expect(mock_runner).to receive(:output).once.and_return("States.Timeout")
+          expect(mock_runner).to receive("output").once.and_return("States.Timeout")
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)
@@ -241,7 +241,7 @@ RSpec.describe Floe::Workflow::States::Task do
         end
 
         it "invokes the Catch if no retriers match" do
-          expect(mock_runner).to receive(:output).once.and_return("Exception")
+          expect(mock_runner).to receive("output").once.and_return("Exception")
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)
@@ -260,7 +260,7 @@ RSpec.describe Floe::Workflow::States::Task do
         let(:payload) { {"Type" => "Task", "Resource" => "docker://hello-world:latest", "Catch" => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}]} }
 
         it "catches the exception" do
-          expect(mock_runner).to receive(:output).and_return("States.Timeout")
+          expect(mock_runner).to receive("output").and_return("States.Timeout")
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)
@@ -271,7 +271,7 @@ RSpec.describe Floe::Workflow::States::Task do
         end
 
         it "raises if the exception isn't caught" do
-          expect(mock_runner).to receive(:output).and_return("Exception")
+          expect(mock_runner).to receive("output").and_return("Exception")
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)
@@ -284,7 +284,7 @@ RSpec.describe Floe::Workflow::States::Task do
         let(:payload) { {"Type" => "Task", "Resource" => "docker://hello-world:latest", "Catch" => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}, {"ErrorEquals" => ["States.ALL"], "Next" => "FailState"}]} }
 
         it "catches a more specific exception" do
-          expect(mock_runner).to receive(:output).and_return("States.Timeout")
+          expect(mock_runner).to receive("output").and_return("States.Timeout")
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)
@@ -295,7 +295,7 @@ RSpec.describe Floe::Workflow::States::Task do
         end
 
         it "catches the exception and transits to the next state" do
-          expect(mock_runner).to receive(:output).and_return("Exception")
+          expect(mock_runner).to receive("output").and_return("Exception")
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Floe::Workflow::States::Pass do
   end
 
   describe "#running?" do
-    before { workflow.context.state["EnteredTime"] = entered_time }
+    before { workflow.context.state["EnteredTime"] = entered_time.iso8601 }
 
     context "before the sleep has finished" do
       let(:entered_time) { Time.now.utc }

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe Floe::Workflow do
       workflow.run!
 
       # state
-      expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
+      expect(Time.parse(ctx.state["EnteredTime"])).to be_within(1.second).of(now)
+      expect(Time.parse(ctx.state["FinishedTime"])).to be_within(1.second).of(now)
       expect(ctx.state["Guid"]).to be
       expect(ctx.state_name).to eq("FirstState")
       expect(ctx.input).to eq(input)
       expect(ctx.output).to eq(input)
-      expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
-      expect(ctx.state["Duration"]).to be <= 1
+      expect(ctx.state["Duration"].to_f).to be <= 1
       expect(ctx.status).to eq("success")
 
       # execution
@@ -57,13 +57,13 @@ RSpec.describe Floe::Workflow do
       workflow.run!
 
       # state
-      expect(ctx.state["EnteredTime"]).to be_within(1.second).of(now)
+      expect(Time.parse(ctx.state["EnteredTime"])).to be_within(1.second).of(now)
+      expect(Time.parse(ctx.state["FinishedTime"])).to be_within(1.second).of(now)
       expect(ctx.state["Guid"]).to be
       expect(ctx.state_name).to eq("FirstState")
       expect(ctx.input).to eq(input)
       expect(ctx.output).to eq(input)
-      expect(ctx.state["FinishedTime"]).to be_within(1.second).of(now)
-      expect(ctx.state["Duration"]).to be <= 1
+      expect(ctx.state["Duration"].to_f).to be <= 1
       expect(ctx.state["Cause"]).to eq("Bad Stuff")
       expect(ctx.state["Error"]).to eq("Issue")
       expect(ctx.status).to eq("failure")
@@ -147,7 +147,7 @@ RSpec.describe Floe::Workflow do
         workflow.run_nonblock
 
         # Mark the Wait state as having started 1 minute ago
-        ctx.state["EnteredTime"] = Time.now.utc - 60
+        ctx.state["EnteredTime"] = (Time.now.utc - 60).iso8601
 
         # step_nonblock should return 0 and mark the workflow as completed
         expect(workflow.step_nonblock).to eq(0)
@@ -182,7 +182,7 @@ RSpec.describe Floe::Workflow do
 
     context "with a state that has finished" do
       it "return 0" do
-        ctx.state["EnteredTime"] = Time.now.utc
+        ctx.state["EnteredTime"] = Time.now.utc.iso8601
         workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
         expect(workflow.current_state).to receive(:running?).and_return(false)
         expect(workflow.step_nonblock_wait).to eq(0)
@@ -191,7 +191,7 @@ RSpec.describe Floe::Workflow do
 
     context "with a state that is running" do
       it "returns Try again" do
-        ctx.state["EnteredTime"] = Time.now.utc
+        ctx.state["EnteredTime"] = Time.now.utc.iso8601
         workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest"}})
         expect(workflow.current_state).to receive(:running?).and_return(true)
         expect(workflow.step_nonblock_wait(:timeout => 0)).to eq(Errno::EAGAIN)
@@ -209,7 +209,7 @@ RSpec.describe Floe::Workflow do
 
     context "with a state that has finished" do
       it "return true" do
-        ctx.state["EnteredTime"] = Time.now.utc
+        ctx.state["EnteredTime"] = Time.now.utc.iso8601
         workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
         expect(workflow.current_state).to receive(:running?).and_return(false)
         expect(workflow.step_nonblock_ready?).to be_truthy
@@ -218,7 +218,7 @@ RSpec.describe Floe::Workflow do
 
     context "with a state that is running" do
       it "returns false" do
-        ctx.state["EnteredTime"] = Time.now.utc
+        ctx.state["EnteredTime"] = Time.now.utc.iso8601
         workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest"}})
         expect(workflow.current_state).to receive(:running?).and_return(true)
         expect(workflow.step_nonblock_ready?).to be_falsey


### PR DESCRIPTION
When serialized to a jsonb column the symbol keys are converted to string keys causing the values to appear missing when context is later deserialized