### PR TITLE
require time

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -32,6 +32,7 @@ require_relative "floe/workflow/states/task"
 require_relative "floe/workflow/states/wait"
 
 require "jsonpath"
+require "time"
 
 module Floe
   class Error < StandardError; end


### PR DESCRIPTION
typically, time will have been included.
I ran into some cases where floe was throwing errors putting this require here to ensure time is loaded

example of the error
(sorry for generic reproducer - haven't nailed down exactly when this happens)

```
$ ruby -e 'puts Time.now.iso8601'
-e:1:in `<main>': undefined method `iso8601' for 2023-09-26 22:30:29.85905 -0400:Time (NoMethodError)

puts Time.now.iso8601
             ^^^^^^^^
```