### PR TITLE
Combine stdout and stderr for podman/docker

### DIFF
--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -73,7 +73,7 @@ module Floe
         end
 
         def output(runner_context)
-          output = docker!("logs", runner_context["container_ref"]).output
+          output = docker!("logs", runner_context["container_ref"], :combined_output => true).output
           runner_context["output"] = output
         end
 

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -83,7 +83,7 @@ module Floe
         end
 
         def output(runner_context)
-          output = podman!("logs", runner_context["container_ref"]).output
+          output = podman!("logs", runner_context["container_ref"], :combined_output => true).output
           runner_context["output"] = output
         end
 

--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -120,12 +120,12 @@ RSpec.describe Floe::Workflow::Runner::Docker do
     let(:runner_context) { {"container_ref" => container_id} }
 
     it "returns log output" do
-      stub_good_run!("docker", :params => ["logs", container_id], :output => "hello, world!")
+      stub_good_run!("docker", :params => ["logs", container_id], :combined_output => true, :output => "hello, world!")
       expect(subject.output(runner_context)).to eq("hello, world!")
     end
 
     it "raises an exception when getting pod logs fails" do
-      stub_bad_run!("docker", :params => ["logs", container_id])
+      stub_bad_run!("docker", :params => ["logs", container_id], :combined_output => true)
       expect { subject.output(runner_context) }.to raise_error(AwesomeSpawn::CommandResultError, /docker exit code: 1/)
     end
   end

--- a/spec/workflow/runner/podman_spec.rb
+++ b/spec/workflow/runner/podman_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Floe::Workflow::Runner::Podman do
     let(:runner_context) { {"container_ref" => container_id} }
 
     it "returns log output" do
-      stub_good_run!("podman", :params => ["logs", container_id], :output => "hello, world!")
+      stub_good_run!("podman", :params => ["logs", container_id], :combined_output => true, :output => "hello, world!")
       expect(subject.output(runner_context)).to eq("hello, world!")
     end
   end


### PR DESCRIPTION
The `docker logs` command was returning errors in stderr which meant
that the awesome_spawn result object had them in `#error` not `#output`.

When a container failed this meant it had no output and we would raise
an empty string which made it impossible to see why the container
failed.