### PR TITLE
[test] automatically add success states to payload

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,17 @@ RSpec.configure do |config|
   def make_payload(states)
     start_at ||= states.keys.first
 
+    # add extra states to make sure the payload is complete
+    next_values = []
+    states.each_value do |value|
+      next_values << value["Next"]
+      if value["Type"] == "Choice"
+        next_values << value["Default"]
+        next_values += value["Choices"].map { |choice| choice["Next"] }
+      end
+    end
+    next_values.compact.each { |next_value| states[next_value] = {"Type" => "Succeed"} if !states.key?(next_value) }
+
     {
       "Comment" => "Sample",
       "StartAt" => start_at,

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Floe::Workflow::States::Choice do
   let(:workflow) do
     make_workflow(
       ctx, {
-        "ChoiceState"      => {
+        "ChoiceState" => {
           "Type"    => "Choice",
           "Choices" => [
             {
@@ -20,10 +20,7 @@ RSpec.describe Floe::Workflow::States::Choice do
             },
           ],
           "Default" => "DefaultState"
-        },
-        "FirstMatchState"  => {"Type" => "Succeed"},
-        "SecondMatchState" => {"Type" => "Succeed"},
-        "DefaultState"     => {"Type" => "Succeed"}
+        }
       }
     )
   end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Floe::Workflow::States::Pass do
   let(:workflow) do
     make_workflow(
       ctx, {
-        "PassState"    => {
+        "PassState" => {
           "Type"       => "Pass",
           "Result"     => {
             "foo" => "bar",
@@ -13,8 +13,7 @@ RSpec.describe Floe::Workflow::States::Pass do
           },
           "ResultPath" => "$.result",
           "Next"       => "SuccessState"
-        },
-        "SuccessState" => {"Type" => "Succeed"}
+        }
       }
     )
   end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Floe::Workflow::States::Pass do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
   let(:state)    { workflow.current_state }
-  let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+  let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}}) }
 
   describe "#end?" do
     it "is non-terminal" do


### PR DESCRIPTION
To have a complete workflow, we need to provide states for each of the next values.
But lots of the time, we are not concerned with the next states, but rather the state under test.

This automatically adds the next states so the workflow is complete, but minimally defined in tests.