### PR TITLE
[test] test Runner#run_async! and not Runner#run!

### DIFF
--- a/spec/workflow/runner/docker_spec.rb
+++ b/spec/workflow/runner/docker_spec.rb
@@ -5,44 +5,6 @@ RSpec.describe Floe::Workflow::Runner::Docker do
   let(:runner_options) { {} }
   let(:container_id)   { SecureRandom.hex }
 
-  describe "#run!" do
-    it "raises an exception without a resource" do
-      expect { subject.run!(nil) }.to raise_error(ArgumentError, "Invalid resource")
-    end
-
-    it "raises an exception for an invalid resource uri" do
-      expect { subject.run!("arn:abcd:efgh") }.to raise_error(ArgumentError, "Invalid resource")
-    end
-
-    it "calls docker run with the image name" do
-      stub_good_run!("docker", :params => ["run", :rm, "hello-world:latest"])
-
-      subject.run!("docker://hello-world:latest")
-    end
-
-    it "passes environment variables to docker run" do
-      stub_good_run!("docker", :params => ["run", :rm, [:e, "FOO=BAR"], "hello-world:latest"])
-
-      subject.run!("docker://hello-world:latest", {"FOO" => "BAR"})
-    end
-
-    it "passes a secrets volume to docker run" do
-      stub_good_run!("docker", :params => ["run", :rm, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:v, a_string_including(":/run/secrets")], "hello-world:latest"])
-
-      subject.run!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
-    end
-
-    context "with network=host" do
-      let(:runner_options) { {"network" => "host"} }
-
-      it "calls docker run with --net host" do
-        stub_good_run!("docker", :params => ["run", :rm, [:net, "host"], "hello-world:latest"])
-
-        subject.run!("docker://hello-world:latest")
-      end
-    end
-  end
-
   describe "#run_async!" do
     it "raises an exception without a resource" do
       expect { subject.run_async!(nil) }.to raise_error(ArgumentError, "Invalid resource")

--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -26,12 +26,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
     it "calls kubectl run with the image name" do
       expected_pod_spec = hash_including(:kind => "Pod", :apiVersion => "v1", :metadata => {:name => a_string_including("hello-world-"), :namespace => "default"})
-
-      expect(kubeclient).to receive(:create_pod).with(expected_pod_spec)
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Running"}})
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Succeeded"}})
-      expect(kubeclient).to receive(:get_pod_log).with(a_string_including("hello-world-"), "default").and_return(RestClient::Response.new("hello, world!"))
-      expect(kubeclient).to receive(:delete_pod).with(a_string_including("hello-world-"), "default")
+      stub_kubernetes_run(:spec => expected_pod_spec, :status => 2)
 
       expect(subject).to receive(:sleep).with(1)
       subject.run!("docker://hello-world:latest")
@@ -41,11 +36,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       expected_pod_spec = hash_including(:kind => "Pod", :apiVersion => "v1", :metadata => {:name => a_string_including("hello-world-"), :namespace => "default"})
 
       expect(subject).not_to receive(:create_secret!)
-      expect(kubeclient).to receive(:create_pod).with(expected_pod_spec)
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Running"}})
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Succeeded"}})
-      expect(kubeclient).to receive(:get_pod_log).with(a_string_including("hello-world-"), "default").and_return(RestClient::Response.new("hello, world!"))
-      expect(kubeclient).to receive(:delete_pod).with(a_string_including("hello-world-"), "default")
+      stub_kubernetes_run(:spec => expected_pod_spec, :status => 2)
 
       expect(subject).to receive(:sleep).with(1)
       subject.run!("docker://hello-world:latest", {}, nil)
@@ -58,11 +49,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
         )
       )
 
-      expect(kubeclient).to receive(:create_pod).with(expected_pod_spec)
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Running"}})
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Succeeded"}})
-      expect(kubeclient).to receive(:get_pod_log).with(a_string_including("hello-world-"), "default").and_return(RestClient::Response.new("hello, world!"))
-      expect(kubeclient).to receive(:delete_pod).with(a_string_including("hello-world-"), "default")
+      stub_kubernetes_run(:spec => expected_pod_spec, :status => 2)
 
       expect(subject).to receive(:sleep).with(1)
       subject.run!("docker://hello-world:latest", {"FOO" => "BAR"})
@@ -75,11 +62,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
         )
       )
 
-      expect(kubeclient).to receive(:create_pod).with(expected_pod_spec)
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Running"}})
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Succeeded"}})
-      expect(kubeclient).to receive(:get_pod_log).with(a_string_including("hello-world-"), "default").and_return(RestClient::Response.new("hello, world!"))
-      expect(kubeclient).to receive(:delete_pod).with(a_string_including("hello-world-"), "default")
+      stub_kubernetes_run(:spec => expected_pod_spec, :status => 2)
 
       expect(subject).to receive(:sleep).with(1)
       subject.run!("docker://hello-world:latest", {"FOO" => 1})
@@ -111,11 +94,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       )
 
       expect(kubeclient).to receive(:create_secret).with(hash_including(:kind => "Secret", :type => "Opaque"))
-      expect(kubeclient).to receive(:create_pod).with(expected_pod_spec)
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Running"}})
-      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), "default").and_return({"status" => {"phase" => "Succeeded"}})
-      expect(kubeclient).to receive(:get_pod_log).with(a_string_including("hello-world-"), "default").and_return(RestClient::Response.new("hello, world!"))
-      expect(kubeclient).to receive(:delete_pod).with(a_string_including("hello-world-"), "default")
+      stub_kubernetes_run(:spec => expected_pod_spec, :status => 2)
       expect(kubeclient).to receive(:delete_secret).with(anything, "default")
 
       expect(subject).to receive(:sleep).with(1)
@@ -123,10 +102,9 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
     end
 
     it "cleans up secrets if running the pod fails" do
-      expect(kubeclient).to receive(:delete_secret)
-      expect(kubeclient).to receive(:delete_pod).and_raise(Kubeclient::HttpError.new(404, "Not Found", {}))
       expect(kubeclient).to receive(:create_secret).with(hash_including(:kind => "Secret", :type => "Opaque"))
-      expect(kubeclient).to receive(:create_pod).and_raise(Kubeclient::HttpError.new(403, "Forbidden", {}))
+      stub_kubernetes_bad_run
+      expect(kubeclient).to receive(:delete_secret)
 
       expect { subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"}) }.to raise_error(Kubeclient::HttpError, /Forbidden/)
     end
@@ -138,11 +116,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       it "calls kubectl run with the image name" do
         expected_pod_spec = hash_including(:kind => "Pod", :apiVersion => "v1", :metadata => {:name => a_string_including("hello-world-"), :namespace => namespace})
 
-        expect(kubeclient).to receive(:create_pod).with(expected_pod_spec)
-        expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), namespace).and_return({"status" => {"phase" => "Running"}})
-        expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), namespace).and_return({"status" => {"phase" => "Succeeded"}})
-        expect(kubeclient).to receive(:get_pod_log).with(a_string_including("hello-world-"), namespace).and_return(RestClient::Response.new("hello, world!"))
-        expect(kubeclient).to receive(:delete_pod).with(a_string_including("hello-world-"), namespace)
+        stub_kubernetes_run(:spec => expected_pod_spec, :namespace => namespace, :status => 2)
 
         expect(subject).to receive(:sleep).with(1)
         subject.run!("docker://hello-world:latest")
@@ -158,7 +132,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       end
 
       it "raises an exception" do
-        expect { subject.run!("docker://hello-world:latest") }.to raise_error(ArgumentError, /Missing connections options/)
+        expect { subject.run_async!("docker://hello-world:latest") }.to raise_error(ArgumentError, /Missing connections options/)
       end
     end
 
@@ -203,11 +177,6 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
         allow(File).to receive(:exist?).with(kubeconfig_path).and_return(true)
         allow(File).to receive(:read).with(kubeconfig_path).and_return(kubeconfig)
-
-        allow(kubeclient).to receive(:create_pod)
-        allow(kubeclient).to receive(:get_pod).and_return({"status" => {"phase" => "Succeeded"}})
-        allow(kubeclient).to receive(:get_pod_log).and_return(RestClient::Response.new("hello, world!"))
-        allow(kubeclient).to receive(:delete_pod)
       end
 
       context "with no runner options passed" do
@@ -215,6 +184,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
         it "uses the kubeconfig values" do
           expect(Kubeclient::Client).to receive(:new).with("https://kubernetes.local:6443", "v1", :ssl_options => {:verify_ssl => OpenSSL::SSL::VERIFY_PEER}, :auth_options => {:bearer_token => "my-token"}).and_return(kubeclient)
+          stub_kubernetes_run(:status => 1)
 
           subject.run!("docker://hello-world:latest")
         end
@@ -225,6 +195,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
         it "prefers the provided options values over the kubeconfig file" do
           expect(Kubeclient::Client).to receive(:new).with("https://my-other-kubernetes.local:6443", "v1", :ssl_options => {:verify_ssl => OpenSSL::SSL::VERIFY_PEER}, :auth_options => {:bearer_token => "my-other-token"})
+          stub_kubernetes_run(:status => 1)
 
           subject.run!("docker://hello-world:latest")
         end
@@ -236,6 +207,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
         it "uses the kubeconfig values" do
           expect(Kubeclient::Client).to receive(:new).with("https://kubernetes.local:6443", "v1", :ssl_options => {:verify_ssl => OpenSSL::SSL::VERIFY_PEER}, :auth_options => {:bearer_token => "my-token"})
+          stub_kubernetes_run(:status => 1)
 
           subject.run!("docker://hello-world:latest")
         end
@@ -246,6 +218,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
         it "uses the values from the kubeconfig context" do
           expect(Kubeclient::Client).to receive(:new).with("https://kubernetes.local:6443", "v1", :ssl_options => {:verify_ssl => OpenSSL::SSL::VERIFY_PEER}, :auth_options => {:bearer_token => "foo"})
+          stub_kubernetes_run(:status => 1)
 
           subject.run!("docker://hello-world:latest")
         end
@@ -258,11 +231,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
       it "calls kubectl run with the image name" do
         expect(Kubeclient::Client).to receive(:new).with("https://kubernetes.local:6443", "v1", :ssl_options => {:verify_ssl => OpenSSL::SSL::VERIFY_PEER}, :auth_options => {:bearer_token => token}).and_return(kubeclient)
-
-        allow(kubeclient).to receive(:create_pod)
-        allow(kubeclient).to receive(:get_pod).and_return({"status" => {"phase" => "Succeeded"}})
-        allow(kubeclient).to receive(:get_pod_log).and_return(RestClient::Response.new("hello, world!"))
-        allow(kubeclient).to receive(:delete_pod)
+        stub_kubernetes_run(:status => 1)
 
         subject.run!("docker://hello-world:latest")
       end
@@ -278,11 +247,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
         expect(File).to receive(:read).with(token_file).and_return(token)
 
         expect(Kubeclient::Client).to receive(:new).with("https://kubernetes.local:6443", "v1", :ssl_options => {:verify_ssl => OpenSSL::SSL::VERIFY_PEER}, :auth_options => {:bearer_token => token}).and_return(kubeclient)
-
-        allow(kubeclient).to receive(:create_pod)
-        allow(kubeclient).to receive(:get_pod).and_return({"status" => {"phase" => "Succeeded"}})
-        allow(kubeclient).to receive(:get_pod_log).and_return(RestClient::Response.new("hello, world!"))
-        allow(kubeclient).to receive(:delete_pod)
+        stub_kubernetes_run(:status => 1)
 
         subject.run!("docker://hello-world:latest")
       end
@@ -373,5 +338,32 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
       subject.cleanup({"container_ref" => "my-pod", "secrets_ref" => "my-secret"})
     end
+  end
+
+  def stub_kubernetes_run(spec: nil, namespace: "default", status: 1, cleanup: true)
+    # start
+    if spec
+      expect(kubeclient).to receive(:create_pod).with(spec)
+    else
+      expect(kubeclient).to receive(:create_pod)
+    end
+
+    # run
+    if status && status > 0
+      (status - 1).times do
+        expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), namespace).and_return({"status" => {"phase" => "Running"}})
+      end
+      expect(kubeclient).to receive(:get_pod).with(a_string_including("hello-world-"), namespace).and_return({"status" => {"phase" => "Succeeded"}})
+      expect(kubeclient).to receive(:get_pod_log).with(a_string_including("hello-world-"), namespace).and_return(RestClient::Response.new("hello, world!"))
+    end
+
+    if cleanup
+      expect(kubeclient).to receive(:delete_pod).with(a_string_including("hello-world-"), namespace)
+    end
+  end
+
+  def stub_kubernetes_bad_run
+    expect(kubeclient).to receive(:create_pod).and_raise(Kubeclient::HttpError.new(403, "Forbidden", {}))
+    expect(kubeclient).to receive(:delete_pod).with(a_string_including("hello-world-"), "default").and_raise(Kubeclient::HttpError.new(404, "Not Found", {}))
   end
 end

--- a/spec/workflow/runner/podman_spec.rb
+++ b/spec/workflow/runner/podman_spec.rb
@@ -107,15 +107,17 @@ RSpec.describe Floe::Workflow::Runner::Podman do
 
       subject.cleanup({"container_ref" => container_id, "secrets_ref" => "my-secret"})
     end
+  end
 
+  context "run_async! parameters" do
     context "with docker runner options" do
       context "with --identity" do
         let(:runner_options) { {"identity" => ".ssh/id_rsa.pub"} }
 
         it "calls docker run with --identity .ssh/id_rsa.pub" do
-          stub_good_run!("podman", :params => [[:identity, ".ssh/id_rsa.pub"], "run", :rm, "hello-world:latest"])
+          stub_good_run!("podman", :params => [[:identity, ".ssh/id_rsa.pub"], "run", :detach, "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
 
@@ -123,9 +125,9 @@ RSpec.describe Floe::Workflow::Runner::Podman do
         let(:runner_options) { {"log-level" => "debug"} }
 
         it "calls docker run with --log-level debug" do
-          stub_good_run!("podman", :params => [[:"log-level", "debug"], "run", :rm, "hello-world:latest"])
+          stub_good_run!("podman", :params => [[:"log-level", "debug"], "run", :detach, "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
 
@@ -133,9 +135,9 @@ RSpec.describe Floe::Workflow::Runner::Podman do
         let(:runner_options) { {"network" => "host"} }
 
         it "calls docker run with --net host" do
-          stub_good_run!("podman", :params => ["run", :rm, [:net, "host"], "hello-world:latest"])
+          stub_good_run!("podman", :params => ["run", :detach, [:net, "host"], "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
 
@@ -143,9 +145,9 @@ RSpec.describe Floe::Workflow::Runner::Podman do
         let(:runner_options) { {"noout" => "true"} }
 
         it "calls docker run with --noout" do
-          stub_good_run!("podman", :params => [:noout, "run", :rm, "hello-world:latest"])
+          stub_good_run!("podman", :params => [:noout, "run", :detach, "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
 
@@ -153,9 +155,9 @@ RSpec.describe Floe::Workflow::Runner::Podman do
         let(:runner_options) { {"root" => "/run/containers/storage"} }
 
         it "calls docker run with --root /run/containers/storage" do
-          stub_good_run!("podman", :params => [[:root, "/run/containers/storage"], "run", :rm, "hello-world:latest"])
+          stub_good_run!("podman", :params => [[:root, "/run/containers/storage"], "run", :detach, "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
 
@@ -163,9 +165,9 @@ RSpec.describe Floe::Workflow::Runner::Podman do
         let(:runner_options) { {"runroot" => "/run/containers/runtime"} }
 
         it "calls docker run with --runroot /run/containers/runtime" do
-          stub_good_run!("podman", :params => [[:runroot, "/run/containers/runtime"], "run", :rm, "hello-world:latest"])
+          stub_good_run!("podman", :params => [[:runroot, "/run/containers/runtime"], "run", :detach, "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
 
@@ -173,9 +175,9 @@ RSpec.describe Floe::Workflow::Runner::Podman do
         let(:runner_options) { {"runtime-flag" => "'log debug'"} }
 
         it "calls docker run with --runtime-flag 'log debug'" do
-          stub_good_run!("podman", :params => [[:"runtime-flag", "'log debug'"], "run", :rm, "hello-world:latest"])
+          stub_good_run!("podman", :params => [[:"runtime-flag", "'log debug'"], "run", :detach, "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
 
@@ -183,9 +185,9 @@ RSpec.describe Floe::Workflow::Runner::Podman do
         let(:runner_options) { {"storage-driver" => "overlay"} }
 
         it "calls docker run with --storage-driver overlay" do
-          stub_good_run!("podman", :params => [[:"storage-driver", "overlay"], "run", :rm, "hello-world:latest"])
+          stub_good_run!("podman", :params => [[:"storage-driver", "overlay"], "run", :detach, "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
 
@@ -193,9 +195,9 @@ RSpec.describe Floe::Workflow::Runner::Podman do
         let(:runner_options) { {"storage-opt" => "ignore_chown_errors=true"} }
 
         it "calls docker run with --storage-driver overlay" do
-          stub_good_run!("podman", :params => [[:"storage-opt", "ignore_chown_errors=true"], "run", :rm, "hello-world:latest"])
+          stub_good_run!("podman", :params => [[:"storage-opt", "ignore_chown_errors=true"], "run", :detach, "hello-world:latest"], :output => container_id)
 
-          subject.run!("docker://hello-world:latest")
+          subject.run_async!("docker://hello-world:latest")
         end
       end
     end


### PR DESCRIPTION
The main code runs `Runner#run_async!` but the tests go through `run!` which is a little different.

This changes the tests to testing `run_async!`, the methods that our code uses.

followups will obviously be

- Change `Task` tests to not completely stub `Runner`
- Drop `Runner#run!`
- Drop `Workflow` methods that are blocking (unsure)