### PR TITLE
Add Fail#CausePath and Fail#ErrorPath

### DIFF
--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -92,6 +92,25 @@ module Floe
       def finished?
         context.state.key?("FinishedTime")
       end
+
+      private
+
+      # Use a payload value or hardcoded path.
+      #
+      # @param [Context] context     context
+      # @param [Hash|String] input   state input
+      # @param [Object] value        hardcoded value from the payload
+      # @param [Path|Nil] value_path path to the value
+      # @yield [String]              block to convert path fetched string into proper datatype
+      # @returns [Object]            value derived from hardcoded value or path
+      def value_or_path(context, input, value = nil, path:)
+        if path
+          value = path.value(context, input)
+          block_given? ? yield(value) : value
+        else
+          value
+        end
+      end
     end
   end
 end

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -15,10 +15,13 @@ module Floe
 
         def start(input)
           super
+          context.next_state = nil
+          context.output     = {
+            "Error" => error,
+            "Cause" => cause
+          }
           context.state["Error"] = error
           context.state["Cause"] = cause
-          context.next_state     = nil
-          context.output         = input
         end
 
         def running?

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -18,10 +18,34 @@ RSpec.describe Floe::Workflow::States::Fail do
     expect(state.end?).to be true
   end
 
-  it "#run!" do
-    state.run!(input)
-    expect(ctx.next_state).to eq(nil)
-    expect(ctx.state["Error"]).to eq("FailStateError")
-    expect(ctx.state["Cause"]).to eq("No Matches!")
+  describe "#run!" do
+    it "populates static values" do
+      state.run!(input)
+      expect(ctx.next_state).to eq(nil)
+      expect(ctx.state["Error"]).to eq("FailStateError")
+      expect(ctx.state["Cause"]).to eq("No Matches!")
+    end
+
+    context "with dynamic error text" do
+      let(:input) { {"output" => "xyz", "error_message" => "DynamicError", "cause_message" => "DynamicCause"} }
+      let(:workflow) do
+        make_workflow(
+          ctx, {
+            "FailState" => {
+              "Type"      => "Fail",
+              "ErrorPath" => "$.error_message",
+              "CausePath" => "$.cause_message"
+            }
+          }
+        )
+      end
+
+      it "populates dynamic values" do
+        state.run!(input)
+        expect(ctx.next_state).to eq(nil)
+        expect(ctx.state["Error"]).to eq("DynamicError")
+        expect(ctx.state["Cause"]).to eq("DynamicCause")
+      end
+    end
   end
 end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Floe::Workflow do
       expect(ctx.state["Guid"]).to be
       expect(ctx.state_name).to eq("FirstState")
       expect(ctx.input).to eq(input)
-      expect(ctx.output).to eq(input)
+      expect(ctx.output).to eq({"Cause" => "Bad Stuff", "Error" => "Issue"})
       expect(ctx.state["Duration"].to_f).to be <= 1
       expect(ctx.state["Cause"]).to eq("Bad Stuff")
       expect(ctx.state["Error"]).to eq("Issue")
@@ -74,7 +74,7 @@ RSpec.describe Floe::Workflow do
       expect(ctx.ended?).to eq(true)
 
       # final results
-      expect(workflow.output).to eq(input) # TODO: think Cause and Error should be here
+      expect(workflow.output).to eq({"Cause" => "Bad Stuff", "Error" => "Issue"})
       expect(workflow.status).to eq("failure")
       expect(workflow.end?).to eq(true)
     end


### PR DESCRIPTION
- Add `Fail` parameters `CausePath` and `ErrorPath`
- output contains `{Error:, Cause:}`

AWS gave a great example for `ErrorPath` and `CausePath`
This is used to convey a failed task
error/cause got into the final output