### PR TITLE
Drop Runner#run!

### DIFF
--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -38,34 +38,6 @@ module Floe
           super
         end
 
-        def run!(resource, env = {}, secrets = {})
-          raise ArgumentError, "Invalid resource" unless resource&.start_with?("docker://")
-
-          image  = resource.sub("docker://", "")
-          name   = pod_name(image)
-          secret = create_secret!(secrets) if secrets && !secrets.empty?
-
-          begin
-            runner_context = {"container_ref" => name}
-
-            create_pod!(name, image, env, secret)
-            loop do
-              case pod_info(name).dig("status", "phase")
-              when "Pending", "Running"
-                sleep(1)
-              else # also "Succeeded"
-                runner_context["exit_code"] = 0
-                output(runner_context)
-                break
-              end
-            end
-
-            runner_context
-          ensure
-            cleanup({"container_ref" => name, "secrets_ref" => secret})
-          end
-        end
-
         def run_async!(resource, env = {}, secrets = {})
           raise ArgumentError, "Invalid resource" unless resource&.start_with?("docker://")
 


### PR DESCRIPTION
### Overview

The various layers (`Workflow`, `State`, `Task`, and `Runner`) have quite a few methods forthat do blocking and non-blocking actions.

Feel like having only non-blocking methods would simplify the code.

If we want to provide blocking options to the outside world, that can be done in workflow using the current pattern in place.

depends:
- [x] #113 

Remove `Runner#run!`

`Task#run_nonblock!` only calls `Runner#run_nonblock!`. Since nothing calls into `Runner#run!` there is no need to keep this around.

questions:

- Remove `State#run` -- api will be `run_nonblock`

I'm thinking we'll keep `Workflow#step`, but it will call `run_nonblock` / wait combo.