### PR TITLE
Task#Catcherr puts an "Error" into the output

### DIFF
--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -10,7 +10,7 @@ module Floe
 
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]
-        @result_path  = payload.fetch("ResultPath", "$")
+        @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
       end
     end
   end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -104,6 +104,7 @@ module Floe
           raise error if catcher.nil?
 
           context.next_state = catcher.next
+          context.output     = catcher.result_path.set(context.input, {"Error" => error})
         end
 
         def process_input(input)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -114,7 +114,7 @@ module Floe
         end
 
         def process_output!(results)
-          output = process_input(context.state["Input"])
+          output = context.input.dup
           return output if results.nil?
           return if output_path.nil?
 


### PR DESCRIPTION
https://states-language.net/#error-output

---
I'm pretty sure this should use the raw input and not the effective/processed input

picture form:

https://docs.aws.amazon.com/step-functions/latest/dg/concepts-input-output-filtering.html

text form:

https://states-language.net/#using-inputpath-parameters-resultselector-resultpath-and-outputpath

item 4 says that the "raw input" is used instead of the "effective input"