### PR TITLE
Fix task output handling by adding an output marker

### DIFF
--- a/lib/floe/workflow/runner.rb
+++ b/lib/floe/workflow/runner.rb
@@ -5,7 +5,8 @@ module Floe
     class Runner
       include Logging
 
-      TYPES = %w[docker podman kubernetes].freeze
+      TYPES         = %w[docker podman kubernetes].freeze
+      OUTPUT_MARKER = "__FLOE_OUTPUT__\n"
 
       def initialize(_options = {})
       end


### PR DESCRIPTION
Only consider output after the last occurrence of a pre-defined output marker.

Depends on:
- [x] https://github.com/ManageIQ/floe/pull/116
- [x] https://github.com/ManageIQ/floe/pull/115

Fixes https://github.com/ManageIQ/floe/issues/111