### PR TITLE
[test] Drop calls to blocking run/step

### DIFF
--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe Floe::Workflow::States::Choice do
     expect(state.end?).to eq(false)
   end
 
-  describe "#run!" do
+  describe "#run_nonblock!" do
     context "with a missing variable" do
       it "raises an exception" do
-        expect { state.run!(input) }.to raise_error(RuntimeError, "No such variable [$.foo]")
+        expect { state.run_nonblock! }.to raise_error(RuntimeError, "No such variable [$.foo]")
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe Floe::Workflow::States::Choice do
       let(:input) { {"foo" => 1} }
 
       it "returns the next state" do
-        state.run!(input)
+        state.run_nonblock!
         expect(ctx.next_state).to eq("FirstMatchState")
       end
     end
@@ -52,7 +52,7 @@ RSpec.describe Floe::Workflow::States::Choice do
       let(:input) { {"foo" => 4} }
 
       it "returns the default state" do
-        state.run!(input)
+        state.run_nonblock!
         expect(ctx.next_state).to eq("DefaultState")
       end
     end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe Floe::Workflow::States::Pass do
     end
   end
 
-  describe "#run!" do
+  describe "#run_nonblock!" do
     it "sets the result to the result path" do
-      state.run!(ctx.input)
+      state.run_nonblock!
       expect(ctx.output["result"]).to include({"foo" => "bar", "bar" => "baz"})
       expect(ctx.next_state).to eq("SuccessState")
     end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Floe::Workflow::States::Succeed do
     expect(state.end?).to be true
   end
 
-  describe "#run!" do
+  describe "#run_nonblock!" do
     it "has no next" do
-      state.run!(input)
+      state.run_nonblock!
       expect(ctx.next_state).to eq(nil)
     end
   end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Floe::Workflow do
     end
   end
 
-  describe "#step" do
+  describe "#step_nonblock" do
     it "runs a success step" do
       workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
 
@@ -106,7 +106,7 @@ RSpec.describe Floe::Workflow do
       expect(ctx.running?).to eq(false)
       expect(ctx.ended?).to eq(false)
 
-      workflow.step
+      workflow.step_nonblock
 
       expect(workflow.output).to eq(input)
       expect(workflow.status).to eq("success")
@@ -117,9 +117,7 @@ RSpec.describe Floe::Workflow do
       expect(ctx.running?).to eq(false)
       expect(ctx.ended?).to eq(true)
     end
-  end
 
-  describe "#step_nonblock" do
     context "with a workflow that hasn't started yet" do
       it "starts the first step" do
         workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})


### PR DESCRIPTION
Our code calls into `run_nonblock!` and `step_nonblock!`

Changed tests to reflect our use case.

Also dropping the `sleep` stub. This is not being called, and since we don't want `sleep` calls to creep in, this will make it very obvious and catch the issue quickly.

---

Obvious next move is to drop all `sleep` statements and blocking calls.
We will actually keep the sleep in `State#run_wait`. `Workflow#run` and possibly `Workflow#wait` will use this method.
