### PR TITLE
Fix missing require active_support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 # Specify your gem's dependencies in floe.gemspec
 gemspec
 
+gem "activesupport"
 gem "manageiq-style"
 gem "rake", "~> 13.0"
 gem "rspec"

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/time'
 
 RSpec.describe Floe::Workflow do


### PR DESCRIPTION
Active Support is pulled in from more_core_extensions.  There is a require active_support/time in spec/workflow_spec that is now failing with 7.1

Fix for https://github.com/ManageIQ/floe/actions/runs/6420493122/job/17432692433
```
An error occurred while loading ./spec/workflow_spec.rb.
Failure/Error: require 'active_support/time'

NoMethodError:
  undefined method `deprecator' for ActiveSupport:Module
  Did you mean?  deprecate_constant
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/core_ext/array/conversions.rb:108:in `<class:Array>'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/core_ext/array/conversions.rb:8:in `<top (required)>'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/duration.rb:3:in `require'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/duration.rb:3:in `<top (required)>'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/core_ext/time/calculations.rb:3:in `require'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/core_ext/time/calculations.rb:3:in `<top (required)>'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/core_ext/time.rb:4:in `require'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/core_ext/time.rb:4:in `<top (required)>'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/time.rb:12:in `require'
# ./vendor/bundle/ruby/2.7.0/gems/activesupport-7.1.0/lib/active_support/time.rb:12:in `<top (required)>'
# ./spec/workflow_spec.rb:1:in `require'
# ./spec/workflow_spec.rb:1:in `<top (required)>'
```

with active_support 7.1.0