### PR TITLE
Workflow#wait_until

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -96,6 +96,10 @@ module Floe
       context.ended?
     end
 
+    def wait_until
+      context.wait_until
+    end
+
     def current_state
       @states_by_name[context.state_name]
     end

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -73,6 +73,10 @@ module Floe
         end
       end
 
+      def wait_until
+        state["WaitUntil"] && Time.parse(state["WaitUntil"])
+      end
+
       def state=(val)
         @context["State"] = val
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -93,6 +93,10 @@ module Floe
         context.state.key?("FinishedTime")
       end
 
+      def wait_until
+        context.wait_until
+      end
+
       private
 
       # Use a payload value or hardcoded path.
@@ -124,7 +128,7 @@ module Floe
       end
 
       def waiting?
-        context.state["WaitUntil"] && Time.now.utc <= Time.parse(context.state["WaitUntil"])
+        context.state["WaitUntil"] && Time.now.utc <= wait_until
       end
     end
   end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -261,4 +261,20 @@ RSpec.describe Floe::Workflow do
       end
     end
   end
+
+  describe "#wait_until" do
+    it "reads when the workflow will be ready to continue" do
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
+      workflow.run_nonblock
+
+      expect(workflow.wait_until).to be_within(1).of(Time.now.utc + 10)
+    end
+
+    it "doesn't have a wait" do
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
+      workflow.run_nonblock
+
+      expect(workflow.wait_until).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This exposes the `wait_until` for both Task (retry) and Wait. This can be used by the [workflow runner] for a better `deliver_on` value.

At a first glance, I feel it would be nice to hide this value.
After thinking about this, a `run_nonblock` stops due to 3 reasons:

1. The workflow has ended (success or failure)
2. The workflow is blocked on a Task container run
3. The state has requested a sleep (Task retry or standard Wait)

I don't think asking "how long until I can call you back" seems so bad.
Waiting on a container will not change/have a response (though we may want to put the hardcoded 1.second in the runner instead of the workflow provider). But the Wait and Task retrier will respond with a time when to call back.

[Workflow runner]: https://github.com/manageiq/manageiq-providers-workflows/blob/master/app/models/manageiq/providers/workflows/automation_manager/workflow_instance.rb#L93