### PR TITLE
drop value_or_path

### DIFF
--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -95,23 +95,6 @@ module Floe
 
       private
 
-      # Use a payload value or hardcoded path.
-      #
-      # @param [Context] context     context
-      # @param [Hash|String] input   state input
-      # @param [Object] value        hardcoded value from the payload
-      # @param [Path|Nil] value_path path to the value
-      # @yield [String]              block to convert path fetched string into proper datatype
-      # @returns [Object]            value derived from hardcoded value or path
-      def value_or_path(context, input, value = nil, path:)
-        if path
-          value = path.value(context, input)
-          block_given? ? yield(value) : value
-        else
-          value
-        end
-      end
-
       def wait(seconds: nil, time: nil)
         context.state["WaitUntil"] =
           if seconds

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -22,8 +22,8 @@ module Floe
           # see https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-fail-state.html
           #     https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html#asl-intrsc-func-generic
           context.output     = {
-            "Error" => value_or_path(context, input, error, :path => @error_path),
-            "Cause" => value_or_path(context, input, cause, :path => @cause_path)
+            "Error" => @error_path ? @error_path.value(context, input) : error,
+            "Cause" => @cause_path ? @cause_path.value(context, input) : cause
           }.compact
           context.state["Error"] = context.output["Error"]
           context.state["Cause"] = context.output["Cause"]

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -29,8 +29,8 @@ module Floe
           context.output     = output_path.value(context, input)
           context.next_state = end? ? nil : @next
           wait(
-            :seconds => value_or_path(context, input, @seconds, :path => @seconds_path, &:to_i),
-            :time    => value_or_path(context, input, @timestamp, :path => @timestamp_path)
+            :seconds => @seconds_path ? @seconds_path.value(context, input).to_i : @seconds,
+            :time    => @timestamp_path ? @timestamp_path.value(context, input) : @timestamp
           )
         end
 

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -28,10 +28,7 @@ module Floe
 
           context.output     = output_path.value(context, input)
           context.next_state = end? ? nil : @next
-          wait(
-            :seconds => @seconds_path ? @seconds_path.value(context, input).to_i : @seconds,
-            :time    => @timestamp_path ? @timestamp_path.value(context, input) : @timestamp
-          )
+          please_hold(input)
         end
 
         def running?
@@ -40,6 +37,15 @@ module Floe
 
         def end?
           @end
+        end
+
+        private
+
+        def please_hold(input)
+          wait(
+            :seconds => @seconds_path ? @seconds_path.value(context, input).to_i : @seconds,
+            :time    => @timestamp_path ? @timestamp_path.value(context, input) : @timestamp
+          )
         end
       end
     end


### PR DESCRIPTION
No need for `value_or_path`
The alternative is just as easy to read
and even a hint shorter.


When I was writing this code, it was easier to reason through with this abstraction.
Now, it is no longer necessary

---

@agrare you seemed to want to get away from this.
Unfortunate that this adds some "complexity" to `Wait#start`