### PR TITLE
bin/floe converts input to json

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -31,7 +31,7 @@ runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
 
 Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
 
-context = Floe::Workflow::Context.new(:input => opts[:input])
+context = Floe::Workflow::Context.new(:input => JSON.parse(opts[:input]))
 workflow = Floe::Workflow.load(opts[:workflow], context, opts[:credentials])
 
 workflow.run!


### PR DESCRIPTION
The Context expects input to be a json object.
bin/floe is passing in a raw string to the Context.

BEFORE:

If there is an error in the Task, the result_path is not able to apply to the input.
This causes an error:

```
lib/floe/workflow/reference_path.rb:35:in `set': undefined method `merge!' for "{\\"foo\\": 2}":String (NoMethodError)

          result.merge!(value)
                ^^^^^^^
  from lib/floe/workflow/states/task.rb:114:in `catch_error!'
  from lib/floe/workflow/states/task.rb:55:in `finish'
  from lib/floe/workflow/state.rb:51:in `run_nonblock!'
  from lib/floe/workflow.rb:76:in `step_nonblock'
  from lib/floe/workflow.rb:63:in `step'
  from lib/floe/workflow.rb:58:in `run!'
  from exe/floe:37:in `<top (required)>'
```

After:

An error is able to be merged with the input

```
{"Error"=>"FailStateError", "Cause"=>"No Matches!"}
```