### PR TITLE
Test task

### DIFF
--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Floe::Workflow::States::Task do
     end
 
     describe "Retry" do
-      let(:payload) { {"Type" => "Task", "Resource" => "docker://hello-world:latest", "Retry" => retriers} }
+      let(:payload) { {"Type" => "Task", "Resource" => "docker://hello-world:latest", "Retry" => retriers, "TimeoutSeconds" => 2} }
       before { allow(Kernel).to receive(:sleep).and_return(0) }
 
       context "with specific errors" do
@@ -173,6 +173,7 @@ RSpec.describe Floe::Workflow::States::Task do
           expect(mock_runner)
             .to receive(:run_async!)
             .with(payload["Resource"], input, nil)
+            .and_return({"container_ref" => "abc"})
 
           state.run!(input)
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -160,7 +160,6 @@ RSpec.describe Floe::Workflow::States::Task do
 
     describe "Retry" do
       let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Retry" => retriers, "TimeoutSeconds" => 2}}) }
-      before { allow(Kernel).to receive(:sleep).and_return(0) }
 
       context "with specific errors" do
         let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 1}] }


### PR DESCRIPTION
Task spec changes

- use run_nonblock (since that is what is called in the real code)
- return a valid return from the run_nonblock
- use make_workflow. now, the test State#workflow has the correct values in it.
- drop sleep stubbing - we no longer use sleep