### PR TITLE
Don't put credentials into input

### DIFF
--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -21,7 +21,6 @@ module Floe
           secrets_file = nil
           if secrets && !secrets.empty?
             secrets_file = create_secret(secrets)
-            env["_CREDENTIALS"] = "/run/secrets"
           end
 
           output = run_container(image, env, secrets_file)
@@ -40,7 +39,6 @@ module Floe
 
           if secrets && !secrets.empty?
             runner_context["secrets_ref"] = create_secret(secrets)
-            env["_CREDENTIALS"] = "/run/secrets"
           end
 
           begin
@@ -85,6 +83,7 @@ module Floe
           params  = ["run"]
           params << (detached ? :detach : :rm)
           params += env.map { |k, v| [:e, "#{k}=#{v}"] }
+          params << [:e, "_CREDENTIALS=/run/secrets"] if secrets_file
           params << [:net, "host"] if @network == "host"
           params << [:v, "#{secrets_file}:/run/secrets:z"] if secrets_file
           params << image

--- a/lib/floe/workflow/runner/podman.rb
+++ b/lib/floe/workflow/runner/podman.rb
@@ -33,7 +33,6 @@ module Floe
 
           if secrets && !secrets.empty?
             secret = create_secret(secrets)
-            env["_CREDENTIALS"] = "/run/secrets/#{secret}"
           end
 
           output = run_container(image, env, secret)
@@ -50,7 +49,6 @@ module Floe
 
           if secrets && !secrets.empty?
             secret_guid = create_secret(secrets)
-            env["_CREDENTIALS"] = "/run/secrets/#{secret_guid}"
           end
 
           begin
@@ -93,6 +91,7 @@ module Floe
           params  = ["run"]
           params << (detached ? :detach : :rm)
           params += env.map { |k, v| [:e, "#{k}=#{v}"] }
+          params << [:e, "_CREDENTIALS=/run/secrets/#{secret}"] if secret
           params << [:net, "host"] if @network == "host"
           params << [:secret, secret] if secret
           params << image


### PR DESCRIPTION
since Runner param env is context.input
when we were modifying it
Input was then passed to other processes

This no longer modifies context.input

## Before

```
bundle exec exe/floe --docker-runner docker --workflow examples/hello-world.asl --input={"foo": 2}
I, [2023-10-06T13:22:34.351639 #52979]  INFO -- : Running state: [FirstState] with input [{"foo"=>2}]...
D, [2023-10-06T13:22:34.351937 #52979] DEBUG -- : Running docker: docker run --detach -e foo\=2 -e _CREDENTIALS\=/run/secrets -v /Users/kbrock/src/gems/floe/tmp/20231006-52979-uhazww:/run/secrets:z docker.io/kbrock/hello-world:latest
I, [2023-10-06T13:22:34.939089 #52979]  INFO -- : Running state: [FirstState] with input [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]...Complete - next state: [ChoiceState] output: [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]
I, [2023-10-06T13:22:34.961363 #52979]  INFO -- : Running state: [ChoiceState] with input [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]...
I, [2023-10-06T13:22:34.961647 #52979]  INFO -- : Running state: [ChoiceState] with input [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]...Complete - next state: [SecondMatchState] output: [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]
I, [2023-10-06T13:22:34.961698 #52979]  INFO -- : Running state: [SecondMatchState] with input [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]...
D, [2023-10-06T13:22:34.961765 #52979] DEBUG -- : Running docker: docker run --detach -e foo\=2 -e _CREDENTIALS\=/run/secrets docker.io/kbrock/hello-world:latest
I, [2023-10-06T13:22:35.322159 #52979]  INFO -- : Running state: [SecondMatchState] with input [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]...Complete - next state: [NextState] output: [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]
I, [2023-10-06T13:22:35.343200 #52979]  INFO -- : Running state: [NextState] with input [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]...
D, [2023-10-06T13:22:35.343352 #52979] DEBUG -- : Running docker: docker run --detach -e foo\=2 -e _CREDENTIALS\=/run/secrets docker.io/kbrock/hello-world:latest
I, [2023-10-06T13:22:35.741140 #52979]  INFO -- : Running state: [NextState] with input [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]...Complete - next state: [] output: [{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}]
{"foo"=>2, "_CREDENTIALS"=>"/run/secrets"}
```

## After

```
bundle exec exe/floe --docker-runner docker --workflow examples/hello-world.asl --input={"foo": 2}
I, [2023-10-06T13:22:55.688881 #53025]  INFO -- : Running state: [FirstState] with input [{"foo"=>2}]...
D, [2023-10-06T13:22:55.689171 #53025] DEBUG -- : Running docker: docker run --detach -e foo\=2 -e _CREDENTIALS\=/run/secrets -v /Users/kbrock/src/gems/floe/tmp/20231006-53025-1plco6:/run/secrets:z docker.io/kbrock/hello-world:latest
I, [2023-10-06T13:22:56.105892 #53025]  INFO -- : Running state: [FirstState] with input [{"foo"=>2}]...Complete - next state: [ChoiceState] output: [{"foo"=>2}]
I, [2023-10-06T13:22:56.130135 #53025]  INFO -- : Running state: [ChoiceState] with input [{"foo"=>2}]...
I, [2023-10-06T13:22:56.130368 #53025]  INFO -- : Running state: [ChoiceState] with input [{"foo"=>2}]...Complete - next state: [SecondMatchState] output: [{"foo"=>2}]
I, [2023-10-06T13:22:56.130417 #53025]  INFO -- : Running state: [SecondMatchState] with input [{"foo"=>2}]...
D, [2023-10-06T13:22:56.130475 #53025] DEBUG -- : Running docker: docker run --detach -e foo\=2 docker.io/kbrock/hello-world:latest
I, [2023-10-06T13:22:56.528706 #53025]  INFO -- : Running state: [SecondMatchState] with input [{"foo"=>2}]...Complete - next state: [NextState] output: [{"foo"=>2}]
I, [2023-10-06T13:22:56.551575 #53025]  INFO -- : Running state: [NextState] with input [{"foo"=>2}]...
D, [2023-10-06T13:22:56.551777 #53025] DEBUG -- : Running docker: docker run --detach -e foo\=2 docker.io/kbrock/hello-world:latest
I, [2023-10-06T13:22:56.948745 #53025]  INFO -- : Running state: [NextState] with input [{"foo"=>2}]...Complete - next state: [] output: [{"foo"=>2}]
{"foo"=>2}
```