### PR TITLE
[WIP] Abort if StartAt or Next [state] is not valid

### DIFF
--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -93,6 +93,26 @@ RSpec.describe Floe::Workflow do
       expect(ctx.running?).to eq(true)
       expect(ctx.ended?).to   eq(false)
     end
+
+    it "detects invalid StartAt" do
+      workflow = Floe::Workflow.new({"StartAt" => "Bogus", "States" => {"FirstState" => {"Type" => "Succeed"}}}, ctx, {})
+
+      workflow.run_nonblock
+
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to   eq(true)
+      expect(ctx.status).to eq("failure")
+    end
+
+    it "detects invalid Next" do
+      workflow = Floe::Workflow.new({"StartAt" => "FirstState", "States" => {"FirstState" => {"Type" => "Pass", "Next" => "Bogus"}}}, ctx, {})
+
+      workflow.run_nonblock
+
+      expect(ctx.running?).to eq(false)
+      expect(ctx.ended?).to   eq(true)
+      expect(ctx.status).to eq("failure")
+    end
   end
 
   describe "#step" do


### PR DESCRIPTION
I tried to run a workflow with an invalid StartAt
This caused a strange error

before
------

```
lib/floe/workflow.rb:76:in `step_nonblock': undefined method `run_nonblock!' for nil:NilClass (NoMethodError)

      current_state.run_nonblock!
                   ^^^^^^^^^^^^^^
	from lib/floe/workflow.rb:63:in `step'
	from lib/floe/workflow.rb:58:in `run!'
	from exe/floe:37:in `<top (required)>'
```

after
-----

```
{"Error"=>"States.Runtime", "Cause"=>"State \"FirstState\" does not exist"}
```