### PR TITLE
remove newline at the end of runner output

### DIFF
--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -129,7 +129,7 @@ module Floe
 
           JSON.parse(output)
         rescue JSON::ParserError
-          {"Error" => output}
+          {"Error" => output.chomp}
         end
 
         def parse_output(output)


### PR DESCRIPTION
This comes into play when the Task outputs plain text message and has an error code.

```ruby
#!/usr/bin/ruby

puts "failure message"
exit 1
```

before
------

```json
{"Error": "failure message\n"}
```

after
-----

```json
{"Error": "failure message"}
```