### PR TITLE
Handle ImagePullErr/ImagePullBackOff as errors

### DIFF
--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -85,7 +85,7 @@ module Floe
           runner_context["output"] =
             if container_failed?(runner_context)
               failed_state = failed_container_states(runner_context).first
-              "#{failed_state["reason"]}: #{failed_state["message"]}"
+              {"Error" => failed_state["reason"], "Cause" => failed_state["message"]}
             else
               kubeclient.get_pod_log(runner_context["container_ref"], namespace).body
             end

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -9,7 +9,7 @@ module Floe
         TOKEN_FILE      = "/run/secrets/kubernetes.io/serviceaccount/token"
         CA_CERT_FILE    = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         RUNNING_PHASES  = %w[Pending Running].freeze
-        FAILURE_REASONS = %w[ImagePullBackOff ErrImagePull].freeze
+        FAILURE_REASONS = %w[CrashLoopBackOff ImagePullBackOff ErrImagePull].freeze
 
         def initialize(options = {})
           require "awesome_spawn"

--- a/lib/floe/workflow/runner/kubernetes.rb
+++ b/lib/floe/workflow/runner/kubernetes.rb
@@ -12,6 +12,7 @@ module Floe
         FAILURE_REASONS = %w[CrashLoopBackOff ImagePullBackOff ErrImagePull].freeze
 
         def initialize(options = {})
+          require "active_support/core_ext/hash/keys"
           require "awesome_spawn"
           require "securerandom"
           require "base64"
@@ -64,7 +65,7 @@ module Floe
         end
 
         def status!(runner_context)
-          runner_context["container_state"] = pod_info(runner_context["container_ref"])["status"]
+          runner_context["container_state"] = pod_info(runner_context["container_ref"]).to_h.deep_stringify_keys["status"]
         end
 
         def running?(runner_context)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -126,6 +126,7 @@ module Floe
 
         def parse_error(output)
           return if output.nil?
+          return output if output.kind_of?(Hash)
 
           JSON.parse(output.split("\n").last)
         rescue JSON::ParserError
@@ -134,6 +135,7 @@ module Floe
 
         def parse_output(output)
           return if output.nil?
+          return output if output.kind_of?(Hash)
 
           JSON.parse(output.split("\n").last)
         rescue JSON::ParserError

--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -405,12 +405,12 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
 
     it "returns an error when  there is an ErrImagePull" do
       runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Pending", "containerStatuses" => [{"name" => "my-container", "state" => {"waiting" => {"reason" => "ErrImagePull", "message" => "rpc error: code = Unknown desc = failed to pull and unpack image"}}}]}}
-      expect(subject.output(runner_context)).to eq("ErrImagePull: rpc error: code = Unknown desc = failed to pull and unpack image")
+      expect(subject.output(runner_context)).to eq({"Error" => "ErrImagePull", "Cause" => "rpc error: code = Unknown desc = failed to pull and unpack image"})
     end
 
     it "returns an error when  there is an ImagePullBackOff" do
       runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Pending", "containerStatuses" => [{"name" => "my-container", "state" => {"waiting" => {"reason" => "ImagePullBackOff", "message" => "Back-off pulling image"}}}]}}
-      expect(subject.output(runner_context)).to eq("ImagePullBackOff: Back-off pulling image")
+      expect(subject.output(runner_context)).to eq({"Error" => "ImagePullBackOff", "Cause" => "Back-off pulling image"})
     end
   end
 

--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -351,6 +351,16 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Succeeded"}}
       expect(subject.running?(runner_context)).to be_falsey
     end
+
+    it "returns false when there is an ErrImagePull" do
+      runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Pending", "containerStatuses" => [{"name" => "my-container", "state" => {"waiting" => {"reason" => "ErrImagePull", "message" => "rpc error: code = Unknown desc = failed to pull and unpack image"}}}]}}
+      expect(subject.running?(runner_context)).to be_falsey
+    end
+
+    it "returns false when there is an ImagePullBackOff" do
+      runner_context = {"container_ref" => "my-pod", "container_state" => {"phase" => "Pending", "containerStatuses" => [{"name" => "my-container", "state" => {"waiting" => {"reason" => "ImagePullBackOff", "message" => "Back-off pulling image"}}}]}}
+      expect(subject.running?(runner_context)).to be_falsey
+    end
   end
 
   describe "#success?" do


### PR DESCRIPTION
When a kubernetes pod fails to pull an image the pod stays in "Pending" indefinitely.  This causes floe to "hang" waiting for the pod to start but it never will.