### PR TITLE
Fix a new task_spec test after task_spec_helper merge

### DIFF
--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -55,13 +55,8 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with an error" do
-        let(:success) { false }
-
         it "uses the last error line as output if it is JSON" do
-          expect(mock_runner)
-            .to receive(:run_async!)
-            .with(resource, {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, nil)
-          expect(mock_runner).to receive("output").and_return("ABCD\nHELLO\n{\"Error\":\"Custom Error\"}")
+          expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "ABCD\nHELLO\n{\"Error\":\"Custom Error\"}", :success => false)
 
           workflow.current_state.run_nonblock!
 


### PR DESCRIPTION
PR https://github.com/ManageIQ/floe/pull/123 was green at the time but failed after merge due to a new test having been added