### PR TITLE
Return an error payload if run_async! fails

### DIFF
--- a/spec/workflow/runner/kubernetes_spec.rb
+++ b/spec/workflow/runner/kubernetes_spec.rb
@@ -160,8 +160,7 @@ RSpec.describe Floe::Workflow::Runner::Kubernetes do
       expect(kubeclient).to receive(:create_secret).with(hash_including(:kind => "Secret", :type => "Opaque"))
       stub_kubernetes_bad_run
       expect(kubeclient).to receive(:delete_secret)
-
-      expect { subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"}) }.to raise_error(Kubeclient::HttpError, /Forbidden/)
+      expect(subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})).to eq({"Error" => "States.TaskFailed", "Cause" => "HTTP status code 403, Forbidden"})
     end
 
     context "with an alternate namespace" do

--- a/spec/workflow/runner/podman_spec.rb
+++ b/spec/workflow/runner/podman_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Floe::Workflow::Runner::Podman do
       stub_bad_run!("podman", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, a_string_including("_CREDENTIALS=")], [:secret, anything], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"])
       stub_good_run!("podman", :params => ["secret", "rm", anything])
 
-      expect { subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"}) }.to raise_error(AwesomeSpawn::CommandResultError, /podman exit code: 1/)
+      expect(subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"}))
+        .to eq({"Error" => "States.TaskFailed", "Cause" => "podman exit code: 1 error was: Failure"})
     end
   end
 


### PR DESCRIPTION
Currently if the command to start the container fails we simply raise the exception up to the caller rather than "handle" the error payload.  This effectively aborts the workflow runtime without going through the normal failure paths that are already builtin to handle if a task fails after it is started.

This commit changes how these failures are handled in order to line up with how the rest of the Task error handling operates.

https://github.com/ManageIQ/floe/issues/141