### PR TITLE
extra cli options

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -12,8 +12,12 @@ opts = Optimist.options do
   opt :input, "JSON payload to input to the workflow (legacy)", :type => :string
   opt :credentials, "JSON payload with credentials",            :type => :string
   opt :credentials_file, "Path to a file with credentials",     :type => :string
-  opt :docker_runner, "Type of runner for docker images",       :default => "docker"
-  opt :docker_runner_options, "Options to pass to the runner",  :type => :strings
+  opt :docker_runner, "Type of runner for docker images",       :type => :string, :short => 'r'
+  opt :docker_runner_options, "Options to pass to the runner",  :type => :strings, :short => 'o'
+
+  opt :docker,     "Use docker to run images     (short for --docker_runner=docker)",     :type => :boolean
+  opt :podman,     "Use podman to run images     (short for --docker_runner=podman)",     :type => :boolean
+  opt :kubernetes, "Use kubernetes to run images (short for --docker_runner=kubernetes)", :type => :boolean
 end
 
 Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.join(", ")}") unless Floe::Workflow::Runner::TYPES.include?(opts[:docker_runner])
@@ -21,6 +25,11 @@ Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.joi
 # legacy support for --workflow
 args = ARGV.empty? ? [opts[:workflow], opts[:input]] : ARGV
 Optimist.die(:workflow, "must be specified") if args.empty?
+
+# shortcut support
+opts[:docker_runner] ||= "docker" if opts[:docker]
+opts[:docker_runner] ||= "podman" if opts[:podman]
+opts[:docker_runner] ||= "kubernetes" if opts[:kubernetes]
 
 require "logger"
 Floe.logger = Logger.new($stdout)


### PR DESCRIPTION
- Added logical shortcuts for parameters. (NOTE: docker runner changed from `-d` to `-r`)
- Added `--docker`, `--podman`, and `--kubernetes` shortcut

Before
=====

```
Usage: floe [options] workflow input [workflow2 input2]

v0.7.0

Options:
  -w, --workflow=<s>                  Path to your workflow json (legacy)
  -i, --input=<s>                     JSON payload to input to the workflow (legacy)
  -c, --credentials=<s>               JSON payload with credentials
  -r, --credentials-file=<s>          Path to a file with credentials
  -d, --docker-runner=<s>             Type of runner for docker images (default: docker)
  -o, --docker-runner-options=<s+>    Options to pass to the runner
  -v, --version                       Print version and exit
  -h, --help                          Show this message
```

After
======

```
Usage: floe [options] workflow input [workflow2 input2]

v0.7.0

Options:
  -w, --workflow=<s>                  Path to your workflow json (legacy)
  -i, --input=<s>                     JSON payload to input to the workflow (legacy)
  -c, --credentials=<s>               JSON payload with credentials
  -e, --credentials-file=<s>          Path to a file with credentials
  -r, --docker-runner=<s>             Type of runner for docker images
  -o, --docker-runner-options=<s+>    Options to pass to the runner
  -d, --docker                        Use docker to run images     (short for --docker_runner=docker)
  -p, --podman                        Use podman to run images     (short for --docker_runner=podman)
  -k, --kubernetes                    Use kubernetes to run images (short for --docker_runner=kubernetes)
  -v, --version                       Print version and exit
  -h, --help                          Show this message
```
