### PR TITLE
allow non quoted json keys for input

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -15,6 +15,10 @@ end
 
 Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.join(", ")}") unless Floe::Workflow::Runner::TYPES.include?(opts[:docker_runner])
 
+# allow quoted keys
+
+opts[:input].gsub!(/([a-z]\w*):/, '"\1":')
+
 require "logger"
 Floe.logger = Logger.new($stdout)
 


### PR DESCRIPTION
Before
======

```
bundle exec exe/floe --input='{"foo": 2}' examples/run-json.asl
```

After
=====

```
bundle exec exe/floe --input='{foo: 2}' examples/run-json.asl
```