### PR TITLE
Run multiple workflows in exe/floe

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -6,14 +6,20 @@ require "optimist"
 
 opts = Optimist.options do
   version("v#{Floe::VERSION}\n")
-  opt :workflow, "Path to your workflow json",                 :type => :string, :required => true
-  opt :input, "JSON payload to input to the workflow",         :default => '{}'
-  opt :credentials, "JSON payload with credentials",           :default => "{}"
-  opt :docker_runner, "Type of runner for docker images",      :default => "docker"
-  opt :docker_runner_options, "Options to pass to the runner", :type => :strings
+  usage("[options] workflow input [workflow2 input2]")
+
+  opt :workflow, "Path to your workflow json (legacy)",         :type => :string
+  opt :input, "JSON payload to input to the workflow (legacy)", :type => :string
+  opt :credentials, "JSON payload with credentials",            :default => "{}"
+  opt :docker_runner, "Type of runner for docker images",       :default => "docker"
+  opt :docker_runner_options, "Options to pass to the runner",  :type => :strings
 end
 
 Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.join(", ")}") unless Floe::Workflow::Runner::TYPES.include?(opts[:docker_runner])
+
+# legacy support for --workflow
+args = ARGV.empty? ? [opts[:workflow], opts[:input]] : ARGV
+Optimist.die(:workflow, "must be specified") if args.empty?
 
 require "logger"
 Floe.logger = Logger.new($stdout)
@@ -31,10 +37,29 @@ runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
 
 Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
 
-context = Floe::Workflow::Context.new(:input => opts[:input])
-workflow = Floe::Workflow.load(opts[:workflow], context, opts[:credentials])
+workflows =
+  args.each_slice(2).map do |workflow, input|
+    context = Floe::Workflow::Context.new(:input => input || opts[:input] || "{}")
+    Floe::Workflow.load(workflow, context, opts[:credentials])
+  end
 
-workflow.run!
+# run
 
-puts workflow.output.inspect
-exit workflow.status == "success" ? 0 : 1
+outstanding = workflows.dup
+until outstanding.empty?
+  ready = outstanding.select(&:step_nonblock_ready?)
+  ready.map(&:run_nonblock)
+  outstanding -= ready.select(&:end?)
+  sleep(1) if !outstanding.empty?
+end
+
+# display status
+
+workflows.each do |workflow|
+  puts "", "#{workflow.name}#{" (#{workflow.status})" unless workflow.context.success?}", "===" if workflows.size > 1
+  puts workflow.output.inspect
+end
+
+# exit status
+
+exit workflows.all? { |workflow| workflow.context.success? } ? 0 : 1

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -62,16 +62,6 @@ module Floe
       raise Floe::InvalidWorkflowError, err.message
     end
 
-    def run!
-      step until end?
-      self
-    end
-
-    def step
-      step_nonblock_wait until step_nonblock == 0
-      self
-    end
-
     def run_nonblock
       loop while step_nonblock == 0 && !end?
       self

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -74,6 +74,10 @@ module Floe
         end
       end
 
+      def success?
+        status == "success"
+      end
+
       def state=(val)
         @context["State"] = val
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -33,10 +33,6 @@ module Floe
         raise Floe::InvalidWorkflowError, "State name [#{name}] must be less than or equal to 80 characters" if name.length > 80
       end
 
-      def run!(_input = nil)
-        wait until run_nonblock! == 0
-      end
-
       def wait(timeout: 5)
         start = Time.now.utc
 

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Floe::Workflow::States::Fail do
     expect(state.end?).to be true
   end
 
-  describe "#run!" do
+  describe "#run_nonblock!" do
     it "populates static values" do
-      state.run!(input)
+      state.run_nonblock!
       expect(ctx.next_state).to eq(nil)
       expect(ctx.state["Error"]).to eq("FailStateError")
       expect(ctx.state["Cause"]).to eq("No Matches!")
@@ -41,7 +41,7 @@ RSpec.describe Floe::Workflow::States::Fail do
       end
 
       it "populates dynamic values" do
-        state.run!(input)
+        state.run_nonblock!
         expect(ctx.next_state).to eq(nil)
         expect(ctx.state["Error"]).to eq("DynamicError")
         expect(ctx.state["Cause"]).to eq("DynamicCause")

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe Floe::Workflow do
     end
   end
 
-  describe "#run!" do
+  describe "#run_nonblock" do
     it "sets execution variables for success" do
       workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
-      workflow.run!
+      workflow.run_nonblock
 
       # state
       expect(Time.parse(ctx.state["EnteredTime"])).to be_within(1).of(now)
@@ -83,7 +83,7 @@ RSpec.describe Floe::Workflow do
 
     it "sets execution variables for failure" do
       workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Fail", "Cause" => "Bad Stuff", "Error" => "Issue"}})
-      workflow.run!
+      workflow.run_nonblock
 
       # state
       expect(Time.parse(ctx.state["EnteredTime"])).to be_within(1).of(now)
@@ -107,9 +107,7 @@ RSpec.describe Floe::Workflow do
       expect(workflow.status).to eq("failure")
       expect(workflow.end?).to eq(true)
     end
-  end
 
-  describe "#run_nonblock" do
     it "starts the first state" do
       workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
       workflow.run_nonblock


### PR DESCRIPTION
commits:

- added Context#success?
- added Workflow#name
- workflows are passed as arguments rather than options.
- (Which means: Multiple workflows can be passed)
- drop blocking workflow and state methods

Usage
=====

```
TMPDIR=$(pwd)/tmp bundle exec exe/floe examples/hello-world.asl '{"foo":1}' examples/hello-world.asl '{"foo":5}'
```

Context#success
=====

I want to move all changeable state from `Workflow` to `Context`, so I put this on `Context`. But if you prefer this on workflow, we can do that.

Workflow#name
=====

I had wanted the arguments of `Workflow#new` to match `State#new` but since the provider-workflow calls that method, I put at the end.