### PR TITLE
Support podman with empty output

### DIFF
--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -137,8 +137,8 @@ module Floe
         end
 
         def parse_output(output)
-          return if output.nil?
           return output if output.kind_of?(Hash)
+          return if output.nil? || output.empty?
 
           JSON.parse(output.split("\n").last)
         rescue JSON::ParserError


### PR DESCRIPTION
```
bundle exec exe/floe --docker-runner=podman --workflow examples/hello-world.asl --input '{"foo":1}'

gems/json-2.7.0/lib/json/common.rb:219:in `initialize': no implicit conversion of nil into String (TypeError)
	from gems/json-2.7.0/lib/json/common.rb:219:in `new'
	from gems/json-2.7.0/lib/json/common.rb:219:in `parse'
	from lib/floe/workflow/states/task.rb:148:in `parse_output'
```