### PR TITLE
Add secure options for passing credentials via command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ You can provide that at runtime via the `--credentials` parameter:
 bundle exec ruby exe/floe --workflow my-workflow.asl --credentials='{"roleArn": "arn:aws:iam::111122223333:role/LambdaRole"}'
 ```
 
+Or if you are running the floe command programmatically you can securely provide the credentials via a stdin pipe via `--credentials=-`:
+```
+echo '{"roleArn": "arn:aws:iam::111122223333:role/LambdaRole"}' | bundle exec ruby exe/floe --workflow my-workflow.asl --credentials -
+```
+
+Or you can pass a file path with the `--credentials-file` parameter:
+```
+bundle exec ruby exe/floe --workflow my-workflow.asl --credentials-file /tmp/20231218-80537-kj494t
+```
+
 If you need to set a credential at runtime you can do that by using the `"ResultPath": "$.Credentials"` directive, for example to user a username/password to login and get a Bearer token:
 
 ```

--- a/exe/floe
+++ b/exe/floe
@@ -10,7 +10,8 @@ opts = Optimist.options do
 
   opt :workflow, "Path to your workflow json (legacy)",         :type => :string
   opt :input, "JSON payload to input to the workflow (legacy)", :type => :string
-  opt :credentials, "JSON payload with credentials",            :default => "{}"
+  opt :credentials, "JSON payload with credentials",            :type => :string
+  opt :credentials_file, "Path to a file with credentials",     :type => :string
   opt :docker_runner, "Type of runner for docker images",       :default => "docker"
   opt :docker_runner_options, "Options to pass to the runner",  :type => :strings
 end
@@ -37,10 +38,17 @@ runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
 
 Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
 
+credentials =
+  if opts[:credentials_given]
+    opts[:credentials] == "-" ? $stdin.read : opts[:credentials]
+  elsif opts[:credentials_file_given]
+    File.read(opts[:credentials_file])
+  end
+
 workflows =
   args.each_slice(2).map do |workflow, input|
     context = Floe::Workflow::Context.new(:input => input || opts[:input] || "{}")
-    Floe::Workflow.load(workflow, context, opts[:credentials])
+    Floe::Workflow.load(workflow, context, credentials)
   end
 
 # run


### PR DESCRIPTION
Passing `--credentials='{}'` on the command-line is okay for simple testing but any real-world use of the command-line utility will require a more secure method for passing credentials.

It is common for command-line utilities to accept secure input via stdin with the `-` directive so a parent process can fork and exec the `floe` utility and write the credentials via a pipe connected to the child process' stdin.  This allows for the secret data to be passed without being visible to any outside observers.

Other common options are via a tempfile, env var, and a `_fd=N` parameter.  So far I've chosen to implement file and stdin but can add others if we so choose.