### PR TITLE
Create docker runners factory and add scheme

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -35,7 +35,7 @@ Floe.logger = Logger.new($stdout)
 runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
 
 begin
-  Floe.set_runner(opts[:docker_runner], runner_options)
+  Floe.set_runner("docker", opts[:docker_runner], runner_options)
 rescue ArgumentError => e
   Optimist.die(:docker_runner, e.message)
 end

--- a/exe/floe
+++ b/exe/floe
@@ -20,8 +20,6 @@ opts = Optimist.options do
   opt :kubernetes, "Use kubernetes to run images (short for --docker_runner=kubernetes)", :type => :boolean
 end
 
-Optimist.die(:docker_runner, "must be one of #{Floe::Workflow::Runner::TYPES.join(", ")}") unless Floe::Workflow::Runner::TYPES.include?(opts[:docker_runner])
-
 # legacy support for --workflow
 args = ARGV.empty? ? [opts[:workflow], opts[:input]] : ARGV
 Optimist.die(:workflow, "must be specified") if args.empty?
@@ -34,18 +32,13 @@ opts[:docker_runner] ||= "kubernetes" if opts[:kubernetes]
 require "logger"
 Floe.logger = Logger.new($stdout)
 
-runner_klass = case opts[:docker_runner]
-               when "docker"
-                 Floe::Workflow::Runner::Docker
-               when "podman"
-                 Floe::Workflow::Runner::Podman
-               when "kubernetes"
-                 Floe::Workflow::Runner::Kubernetes
-               end
-
 runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
 
-Floe::Workflow::Runner.docker_runner = runner_klass.new(runner_options)
+begin
+  Floe.set_runner(opts[:docker_runner], runner_options)
+rescue ArgumentError => e
+  Optimist.die(:docker_runner, e.message)
+end
 
 credentials =
   if opts[:credentials_given]

--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -59,12 +59,13 @@ module Floe
   # Set the runner to use
   #
   # @example
-  #   Floe.set_runner "kubernetes"
-  #   Floe.set_runner Floe::Workflow::Runner::Kubernetes.new
+  #   Floe.set_runner "docker", kubernetes", {}
+  #   Floe.set_runner "docker", Floe::Workflow::Runner::Kubernetes.new({})
   #
+  # @param scheme [String] scheme                           Protocol to register (e.g.: docker)
   # @param name_or_instance [String|Floe::Workflow::Runner] Name of runner to use for docker (e.g.: docker)
   # @param options [Hash]                                   Options for constructor of the runner (optional)
-  def self.set_runner(name, options = {})
-    Floe::Workflow::Runner.set_runner(name, options)
+  def self.set_runner(scheme, name_or_instance, options = {})
+    Floe::Workflow::Runner.set_runner(scheme, name_or_instance, options)
   end
 end

--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -45,7 +45,26 @@ module Floe
     @logger ||= NullLogger.new
   end
 
+  # Set the logger to use
+  #
+  # @example
+  #   require "logger"
+  #   Floe.logger = Logger.new($stdout)
+  #
+  # @param logger [Logger] logger to use for logging actions
   def self.logger=(logger)
     @logger = logger
+  end
+
+  # Set the runner to use
+  #
+  # @example
+  #   Floe.set_runner "kubernetes"
+  #   Floe.set_runner Floe::Workflow::Runner::Kubernetes.new
+  #
+  # @param name_or_instance [String|Floe::Workflow::Runner] Name of runner to use for docker (e.g.: docker)
+  # @param options [Hash]                                   Options for constructor of the runner (optional)
+  def self.set_runner(name, options = {})
+    Floe::Workflow::Runner.set_runner(name, options)
   end
 end

--- a/lib/floe/workflow/runner.rb
+++ b/lib/floe/workflow/runner.rb
@@ -10,15 +10,16 @@ module Floe
       def initialize(_options = {})
       end
 
+      @runners = {}
       class << self
         # deprecated -- use Floe.set_runner instead
         def docker_runner=(value)
-          set_runner(value)
+          set_runner("docker", value)
         end
 
         # see Floe.set_runner
-        def set_runner(name_or_instance, options = {})
-          @docker_runner =
+        def set_runner(scheme, name_or_instance, options = {})
+          @runners[scheme] =
             case name_or_instance
             when "docker", nil
               Floe::Workflow::Runner::Docker.new(options)
@@ -33,20 +34,13 @@ module Floe
             end
         end
 
-        def docker_runner
-          @docker_runner || set_runner("docker")
-        end
-
         def for_resource(resource)
           raise ArgumentError, "resource cannot be nil" if resource.nil?
 
+          # if no runners are set, default docker:// to docker
+          set_runner("docker", "docker") if @runners.empty?
           scheme = resource.split("://").first
-          case scheme
-          when "docker"
-            docker_runner
-          else
-            raise "Invalid resource scheme [#{scheme}]"
-          end
+          @runners[scheme] || raise(ArgumentError, "Invalid resource scheme [#{scheme}]")
         end
       end
 


### PR DESCRIPTION
Defining the runners in a single place

- extracted from #147
- dependent upon this PR: https://github.com/ManageIQ/manageiq-providers-workflows/pull/63

Before
======

- types specified in came from `Floe::Workflow::Runner::TYPES` and `exe/floe`
- class names specified in `exe/floe` and `manageiq-providers-workflow`
- default specified in `Floe::Workflow::Runner::TYPES` and `exe/floe`
- users of floe need to know internal class names

After
=====

- types and class names only specified in `Floe::Workflow::Runner`
- use `Floe.set_runner` to specify the name of the runner
- deprecated old `docker_runner=` interface
- support multiple schemes