### PR TITLE
Fix run_container logger saying docker when using podman

### DIFF
--- a/lib/floe/workflow/runner/docker.rb
+++ b/lib/floe/workflow/runner/docker.rb
@@ -72,7 +72,7 @@ module Floe
         def run_container(image, env, secrets_file)
           params = run_container_params(image, env, secrets_file)
 
-          logger.debug("Running #{AwesomeSpawn.build_command_line("docker", params)}")
+          logger.debug("Running #{AwesomeSpawn.build_command_line(self.class::DOCKER_COMMAND, params)}")
 
           result = docker!(*params)
           result.output


### PR DESCRIPTION
Before:
```
$ bundle exec exe/floe --docker-runner=podman  --workflow examples/workflow.asl --input '{"foo": 2}'
INFO -- : Running state: [FirstState] with input [{"foo"=>2}]...
DEBUG -- : Running docker run etc...
...
```

After:
```
$ bundle exec exe/floe --docker-runner=podman --workflow examples/workflow.asl --input '{"foo": 2}'
INFO -- : Running state: [FirstState] with input [{"foo"=>2}]...
DEBUG -- : Running podman run etc...
```