### PR TITLE
Ensure that wf.credentials is not-nil

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -48,7 +48,7 @@ module Floe
       @name        = name
       @payload     = payload
       @context     = context
-      @credentials = credentials
+      @credentials = credentials || {}
       @start_at    = payload["StartAt"]
 
       @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, state_name, state) }

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Floe::Workflow do
       expect(ctx.input).to eq(input)
     end
 
+    it "sets credentials to empty hash if nil passed in" do
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}}, :creds => nil)
+      expect(workflow.credentials).to eq({})
+    end
+
     it "raises an exception for missing States" do
       payload = {"Comment" => "Test", "StartAt" => "Nothing"}
 


### PR DESCRIPTION
Now that we are allowing assignment to Credentials we have to ensure it is at least an empty hash.

We already were defaulting to `{}` if not specified but it was possible for the caller to pass an explicit `nil` in.