### PR TITLE
Default to waiting infinitely

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -16,7 +16,7 @@ module Floe
         new(payload, context, credentials, name)
       end
 
-      def wait(workflows, timeout: 5)
+      def wait(workflows, timeout: nil)
         logger.info("checking #{workflows.count} workflows...")
 
         start = Time.now.utc
@@ -74,7 +74,7 @@ module Floe
       current_state.run_nonblock!
     end
 
-    def step_nonblock_wait(timeout: 5)
+    def step_nonblock_wait(timeout: nil)
       current_state.wait(:timeout => timeout)
     end
 

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -33,12 +33,12 @@ module Floe
         raise Floe::InvalidWorkflowError, "State name [#{name}] must be less than or equal to 80 characters" if name.length > 80
       end
 
-      def wait(timeout: 5)
+      def wait(timeout: nil)
         start = Time.now.utc
 
         loop do
           return 0             if ready?
-          return Errno::EAGAIN if timeout.zero? || Time.now.utc - start > timeout
+          return Errno::EAGAIN if timeout && (timeout.zero? || Time.now.utc - start > timeout)
 
           sleep(1)
         end


### PR DESCRIPTION
I thought that blocking indefinitely was a better default if a user didn't specify anything, returning early means you might want to check something (e.g should a daemon exit) but not specifying anything I'd expect to block until it is ready