### PR TITLE
step_nonblock_wait is no longer used

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -74,10 +74,6 @@ module Floe
       current_state.run_nonblock!
     end
 
-    def step_nonblock_wait(timeout: nil)
-      current_state.wait(:timeout => timeout)
-    end
-
     def step_nonblock_ready?
       current_state.ready?
     end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -240,33 +240,6 @@ RSpec.describe Floe::Workflow do
     end
   end
 
-  describe "#step_nonblock_wait" do
-    context "with a state that hasn't started yet" do
-      it "returns 0" do
-        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
-        expect(workflow.step_nonblock_wait).to eq(0)
-      end
-    end
-
-    context "with a state that has finished" do
-      it "return 0" do
-        ctx.state["EnteredTime"] = Time.now.utc.iso8601
-        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
-        expect(workflow.current_state).to receive(:running?).and_return(false)
-        expect(workflow.step_nonblock_wait).to eq(0)
-      end
-    end
-
-    context "with a state that is running" do
-      it "returns Try again" do
-        ctx.state["EnteredTime"] = Time.now.utc.iso8601
-        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest", "End" => true}})
-        expect(workflow.current_state).to receive(:running?).and_return(true)
-        expect(workflow.step_nonblock_wait(:timeout => 0)).to eq(Errno::EAGAIN)
-      end
-    end
-  end
-
   describe "#step_nonblock_ready?" do
     context "with a state that hasn't started yet" do
       it "returns true" do


### PR DESCRIPTION
If we need this method, then don't delete it. I just wanted to highlight that the code was not being called from here or provider-workflow

We are running wait/step_nonblocking_ready? on a list of workflows and no longer on a single workflow

After merging https://github.com/ManageIQ/floe/pull/157, I double checked that all the methods were being called...

Followup / or what this PR should be about:

I do feel that the main loop in `exe/floe` should be moved into `Workflow.` The version of `wait` isn't quite right and I like the version of `exe/floe` better.
