### PR TITLE
Don't set next_state until finish for Wait state

### DIFF
--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -4,6 +4,11 @@ module Floe
   class Workflow
     module States
       module NonTerminalMixin
+        def finish
+          context.next_state = end? ? nil : @next
+          super
+        end
+
         def validate_state_next!
           raise Floe::InvalidWorkflowError, "Missing \"Next\" field in state [#{name}]" if @next.nil? && !@end
           raise Floe::InvalidWorkflowError, "\"Next\" [#{@next}] not in \"States\" for state [#{name}]" if @next && !workflow.payload["States"].key?(@next)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -46,18 +46,19 @@ module Floe
         end
 
         def finish
+          super
+
           output = runner.output(context.state["RunnerContext"])
 
           if success?
             output = parse_output(output)
             context.state["Output"] = process_output(context.input.dup, output)
-            context.next_state      = next_state
           else
+            context.next_state = nil
             error = parse_error(output)
             retry_state!(error) || catch_error!(error) || fail_workflow!(error)
           end
 
-          super
         ensure
           runner.cleanup(context.state["RunnerContext"])
         end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -28,15 +28,19 @@ module Floe
 
         def start(input)
           super
-          input = input_path.value(context, input)
 
-          context.output     = output_path.value(context, input)
-          context.next_state = end? ? nil : @next
+          input          = input_path.value(context, input)
+          context.output = output_path.value(context, input)
 
           wait_until!(
             :seconds => seconds_path ? seconds_path.value(context, input).to_i : seconds,
             :time    => timestamp_path ? timestamp_path.value(context, input) : timestamp
           )
+        end
+
+        def finish
+          context.next_state = end? ? nil : @next
+          super
         end
 
         def running?

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -38,11 +38,6 @@ module Floe
           )
         end
 
-        def finish
-          context.next_state = end? ? nil : @next
-          super
-        end
-
         def running?
           waiting?
         end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -11,8 +11,17 @@ RSpec.describe Floe::Workflow::States::Pass do
   end
 
   describe "#start" do
+    it "sets WaitUntil" do
+      state.start(ctx.input)
+
+      expect(state.waiting?).to be_truthy
+    end
+  end
+
+  describe "#finish" do
     it "transitions to the next state" do
       state.start(ctx.input)
+      state.finish
 
       expect(ctx.next_state).to eq("SuccessState")
     end


### PR DESCRIPTION
By setting the next_state in Wait#start we were bypassing the Wait#finish step because the next_state was already set.  This caused missing entries in the context for the state completion.


Before:
```
$ bundle exec exe/floe --podman --workflow examples/wait.asl --input '{"foo": 1}'
I, [2024-02-14T11:19:44.894906 #87255]  INFO -- : checking 1 workflows...
I, [2024-02-14T11:19:44.895029 #87255]  INFO -- : Running state: [FirstState] with input [{"foo"=>1}]...
D, [2024-02-14T11:19:44.895117 #87255] DEBUG -- : Running podman run --detach -e foo\=1 --name floe-sleep-4f985a02 localhost/sleep:latest
I, [2024-02-14T11:19:59.828972 #87255]  INFO -- : Running state: [FirstState] with input [{"foo"=>1}]...Complete - next state: [WaitState] output: [{"foo"=>1}]
I, [2024-02-14T11:20:00.035521 #87255]  INFO -- : Running state: [WaitState] with input [{"foo"=>1}]...
I, [2024-02-14T11:20:05.000492 #87255]  INFO -- : Running state: [SuccessState] with input [{"foo"=>1}]...
I, [2024-02-14T11:20:05.000658 #87255]  INFO -- : Running state: [SuccessState] with input [{"foo"=>1}]...Complete - next state: [] output: [{"foo"=>1}]
I, [2024-02-14T11:20:05.000713 #87255]  INFO -- : checking 1 workflows...Complete - 1 ready
{"foo"=>1}
```

Notice there is no `Running state: [WaitState] with input [{"foo"=>1}]...Complete` log line
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
