### PR TITLE
Fix waiting on very short wait durations

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -54,7 +54,8 @@ module Floe
           # it will be done sleeping
           if wait_until
             sleep_thread = Thread.new do
-              sleep wait_until - Time.now.utc
+              sleep_duration = wait_until - Time.now.utc
+              sleep sleep_duration if sleep_duration > 0
               queue.push(nil)
             end
           end


### PR DESCRIPTION
If a wait duration is extremely short or we check the duration right before we should wakeup it is possible to get a negative sleep duration.

Fixes:
```
#<Thread:0x00007fb98629d0c8 /home/grare/adam/src/manageiq/floe/lib/floe/workflow.rb:56 run> terminated with exception (report_on_exception is true):
/home/grare/adam/src/manageiq/floe/lib/floe/workflow.rb:57:in `sleep': time interval must not be negative (ArgumentError)
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
