### PR TITLE
Add ability to specify the API on the command line

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -10,6 +10,7 @@ opts = Optimist.options do
 
   opt :workflow, "Path to your workflow json (legacy)",         :type => :string
   opt :input, "JSON payload to input to the workflow (legacy)", :type => :string
+  opt :context, "JSON payload of the Context",                  :type => :string
   opt :credentials, "JSON payload with credentials",            :type => :string
   opt :credentials_file, "Path to a file with credentials",     :type => :string
   opt :docker_runner, "Type of runner for docker images",       :type => :string, :short => 'r'
@@ -49,7 +50,7 @@ credentials =
 
 workflows =
   args.each_slice(2).map do |workflow, input|
-    context = Floe::Workflow::Context.new(:input => input || opts[:input] || "{}")
+    context = Floe::Workflow::Context.new(opts[:context], :input => input || opts[:input] || "{}")
     Floe::Workflow.load(workflow, context, credentials)
   end
 

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -3,19 +3,19 @@
 module Floe
   class Workflow
     class Context
+      # @param context [Json|Hash] (default, create another with input and execution params)
+      # @param input [Hash] (default: {})
       def initialize(context = nil, input: {})
         context = JSON.parse(context) if context.kind_of?(String)
         input = JSON.parse(input) if input.kind_of?(String)
 
-        @context = context || {
-          "Execution"    => {
-            "Input" => input
-          },
-          "State"        => {},
-          "StateHistory" => [],
-          "StateMachine" => {},
-          "Task"         => {}
-        }
+        @context = context || {}
+        self["Execution"]          ||= {}
+        self["Execution"]["Input"] ||= input
+        self["State"]              ||= {}
+        self["StateHistory"]       ||= []
+        self["StateMachine"]       ||= {}
+        self["Task"]               ||= {}
       end
 
       def execution

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -3,8 +3,15 @@ RSpec.describe Floe::Workflow::Context do
   let(:input) { {"x" => "y"}.freeze }
 
   describe "#new" do
-    it "sets input" do
+    it "with an empty context, sets input" do
       expect(ctx.execution["Input"]).to eq(input)
+      expect(ctx.state).not_to eq(nil)
+    end
+
+    it "with a context, sets input and keeps context" do
+      ctx = described_class.new({"Execution" => {"api" => "http://localhost/"}}, :input => input)
+      expect(ctx.execution["api"]).to eq("http://localhost/")
+      expect(ctx.state).not_to eq(nil)
     end
   end
 


### PR DESCRIPTION
Our current workflows have the api endpoint url stored in `Context["Execution"]["_manageiq_api_url"]`.

Before
======

There is no way to set the api url in exe/floe

After
=====

```
./exe/floe --context '{"Execution": {"_manageiq_api_url": "http://localhost:3000"}}' workflow.asl "{}"
```

followup:
- [ ] https://github.com/ManageIQ/manageiq-providers-workflows/pull/73

Comments
========

The `input` changes per workflow, so it makes sense to specify alongside the workflow in the ARGV.

The api endpoint url, on the other hand, is the same across all executions, so a single value make sense.

