### PR TITLE
Output contains output and errors

### DIFF
--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -58,7 +58,7 @@ module Floe
         context.state["Guid"]            = SecureRandom.uuid
         context.state["EnteredTime"]     = start_time
 
-        logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...")
+        logger.info("Running state: [#{long_name}] with input [#{context.input}]...")
       end
 
       def finish
@@ -70,7 +70,8 @@ module Floe
         context.state["Duration"]       = finished_time - entered_time
         context.execution["EndTime"]    = finished_time_iso if context.next_state.nil?
 
-        logger.info("Running state: [#{context.state_name}] with input [#{context.input}]...Complete - next state: [#{context.next_state}] output: [#{context.output}]")
+        level = context.output&.[]("Error") ? :error : :info
+        logger.public_send(level, "Running state: [#{long_name}] with input [#{context.input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.output}]")
 
         context.state_history << context.state
 
@@ -99,6 +100,10 @@ module Floe
 
       def wait_until
         context.state["WaitUntil"] && Time.parse(context.state["WaitUntil"])
+      end
+
+      def long_name
+        "#{self.class.name.split("::").last}:#{name}"
       end
 
       private

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -18,14 +18,14 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def start(input)
-          super
-          input      = input_path.value(context, input)
+        def finish
+          input      = input_path.value(context, context.input)
           next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default
           output     = output_path.value(context, input)
 
           context.next_state = next_state
           context.output     = output
+          super
         end
 
         def running?

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -15,16 +15,16 @@ module Floe
           @error_path = Path.new(payload["ErrorPath"]) if payload["ErrorPath"]
         end
 
-        def start(input)
-          super
+        def finish
           context.next_state = nil
           # TODO: support intrinsic functions here
           # see https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-fail-state.html
           #     https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html#asl-intrsc-func-generic
           context.output     = {
-            "Error" => @error_path ? @error_path.value(context, input) : error,
-            "Cause" => @cause_path ? @cause_path.value(context, input) : cause
+            "Error" => @error_path ? @error_path.value(context, context.input) : error,
+            "Cause" => @cause_path ? @cause_path.value(context, context.input) : cause
           }.compact
+          super
         end
 
         def running?

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -24,13 +24,11 @@ module Floe
           validate_state!
         end
 
-        def start(input)
-          super
-
-          input = process_input(input)
-
+        def finish
+          input              = process_input(context.input)
           context.output     = process_output(input, result)
           context.next_state = end? ? nil : @next
+          super
         end
 
         def running?

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -10,10 +10,10 @@ module Floe
           super
         end
 
-        def start(input)
-          super
+        def finish
           context.next_state = nil
-          context.output     = input
+          context.output     = context.input
+          super
         end
 
         def running?

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -109,6 +109,7 @@ module Floe
 
           wait_until!(:seconds => retrier.sleep_duration(context["State"]["RetryCount"]))
           context.next_state = context.state_name
+          logger.info("Running state: [#{long_name}] with input [#{context.input}]...Retry - delay: #{wait_until}")
           true
         end
 
@@ -118,12 +119,15 @@ module Floe
 
           context.next_state = catcher.next
           context.output     = catcher.result_path.set(context.input, error)
+          logger.info("Running state: [#{long_name}] with input [#{context.input}]...CatchError - next state: [#{context.next_state}] output: [#{context.output}]")
+
           true
         end
 
         def fail_workflow!(error)
           context.next_state     = nil
           context.output         = {"Error" => error["Error"], "Cause" => error["Cause"]}.compact
+          logger.error("Running state: [#{long_name}] with input [#{context.input}]...Complete workflow - output: [#{context.output}]")
         end
 
         def parse_error(output)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -46,16 +46,16 @@ module Floe
         end
 
         def finish
-          super
-
           output = runner.output(context.state["RunnerContext"])
 
           if success?
             output = parse_output(output)
-            context.state["Output"] = process_output(context.input.dup, output)
+            context.output = process_output(context.input.dup, output)
+            super
           else
             context.next_state = nil
-            error = parse_error(output)
+            context.output = error = parse_error(output)
+            super
             retry_state!(error) || catch_error!(error) || fail_workflow!(error)
           end
         ensure

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -29,13 +29,18 @@ module Floe
         def start(input)
           super
 
-          input          = input_path.value(context, input)
-          context.output = output_path.value(context, input)
+          input = input_path.value(context, context.input)
 
           wait_until!(
             :seconds => seconds_path ? seconds_path.value(context, input).to_i : seconds,
             :time    => timestamp_path ? timestamp_path.value(context, input) : timestamp
           )
+        end
+
+        def finish
+          input          = input_path.value(context, context.input)
+          context.output = output_path.value(context, input)
+          super
         end
 
         def running?


### PR DESCRIPTION
Change output

- Failure state logs to ERROR
- output is displayed
- displays state as StateClass:StateName (was StateName)
- This changed the use of `super` in `finished`. Also added `finished` in the `Fail` state.
- Now set 'next' and 'output' before `finished()#super`, so the logging can include those variables.

Unsure:
- Do we want to remove the input from the `Complete` line? it is very verbose.
- Didn't test retry

Before
======

```
floe examples/hello-world.asl '{"foo": 1}' examples/hello-world.asl '{"foo": 2}' examples/hello-world.asl '{"foo": 99}'

 INFO -- : checking 3 workflows...
 INFO -- : Running state: [FirstState] with input [{"foo"=>1}]...
DEBUG -- : Running docker run --detach -e foo\=1 ...
 INFO -- : Running state: [FirstState] with input [{"foo"=>1}]...Complete - next state: [ChoiceState] output: []
 INFO -- : Running state: [FirstState] with input [{"foo"=>2}]...
DEBUG -- : Running docker run --detach -e foo\=2 ...
 INFO -- : Running state: [FirstState] with input [{"foo"=>2}]...Complete - next state: [ChoiceState] output: []
 INFO -- : Running state: [FirstState] with input [{"foo"=>99}]...
DEBUG -- : Running docker run --detach -e foo\=99 ...
 INFO -- : Running state: [FirstState] with input [{"foo"=>99}]...Complete - next state: [ChoiceState] output: []
 INFO -- : Running state: [ChoiceState] with input [{"foo"=>1}]...
 INFO -- : Running state: [ChoiceState] with input [{"foo"=>1}]...Complete - next state: [FirstMatchState] output: [{"foo"=>1}]
 INFO -- : Running state: [FirstMatchState] with input [{"foo"=>1}]...
DEBUG -- : Running docker run --detach -e foo\=1 ...
 INFO -- : Running state: [FirstMatchState] with input [{"foo"=>1}]...Complete - next state: [PassState] output: []
 INFO -- : Running state: [ChoiceState] with input [{"foo"=>2}]...
 INFO -- : Running state: [ChoiceState] with input [{"foo"=>2}]...Complete - next state: [SecondMatchState] output: [{"foo"=>2}]
 INFO -- : Running state: [SecondMatchState] with input [{"foo"=>2}]...
DEBUG -- : Running docker run --detach -e foo\=2 ...
 INFO -- : Running state: [SecondMatchState] with input [{"foo"=>2}]...Complete - next state: [NextState] output: []
 INFO -- : Running state: [ChoiceState] with input [{"foo"=>99}]...
 INFO -- : Running state: [ChoiceState] with input [{"foo"=>99}]...Complete - next state: [FailState] output: [{"foo"=>99}]
 INFO -- : Running state: [FailState] with input [{"foo"=>99}]...
 INFO -- : Running state: [FailState] with input [{"foo"=>99}]...Complete - next state: [] output: [{"Error"=>"FailStateError", "Cause"=>"No Matches!"}]
 INFO -- : Running state: [PassState] with input [{"foo"=>1}]...
 INFO -- : Running state: [PassState] with input [{"foo"=>1}]...Complete - next state: [WaitState] output: [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]
 INFO -- : Running state: [WaitState] with input [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]...
 INFO -- : Running state: [NextState] with input [{"foo"=>2}]...
DEBUG -- : Running docker run --detach -e foo\=2 ...
 INFO -- : Running state: [NextState] with input [{"foo"=>2}]...Complete - next state: [] output: []
 INFO -- : Running state: [WaitState] with input [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]...Complete - next state: [NextState] output: [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]
 INFO -- : Running state: [NextState] with input [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]...
DEBUG -- : Running docker run --detach -e foo\=1 ...
 INFO -- : Running state: [NextState] with input [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]...Complete - next state: [] output: []
 INFO -- : checking 3 workflows...Complete - 3 ready
```

After
=====

```
  INFO -- : checking 3 workflows...
  INFO -- : Running state: [Task:FirstState] with input [{"foo"=>1}]...
 DEBUG -- : Running docker run --detach -e foo\=1 -e _CREDENTIALS\=/run/secrets -v /Users/kbrock/src/gems/floe/tmp/20240329-82828-c6n4hk:/run/secrets:z --name floe-hello-world-c9a39580 docker.io/kbrock/hello-world:latest
  INFO -- : Running state: [Task:FirstState] with input [{"foo"=>1}]...Complete - next state [ChoiceState] output: [{"foo"=>1}]
  INFO -- : Running state: [Choice:ChoiceState] with input [{"foo"=>1}]...
  INFO -- : Running state: [Choice:ChoiceState] with input [{"foo"=>1}]...Complete - next state [FirstMatchState] output: [{"foo"=>1}]
  INFO -- : Running state: [Task:FirstMatchState] with input [{"foo"=>1}]...
 DEBUG -- : Running docker run --detach -e foo\=1 --name floe-hello-world-e30409b3 docker.io/kbrock/hello-world:latest
  INFO -- : Running state: [Task:FirstMatchState] with input [{"foo"=>1}]...Complete - next state [PassState] output: [{"foo"=>1}]
  INFO -- : Running state: [Pass:PassState] with input [{"foo"=>1}]...
  INFO -- : Running state: [Pass:PassState] with input [{"foo"=>1}]...Complete - next state [WaitState] output: [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]
  INFO -- : Running state: [Wait:WaitState] with input [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]...
  INFO -- : Running state: [Task:FirstState] with input [{"foo"=>2}]...
 DEBUG -- : Running docker run --detach -e foo\=2 -e _CREDENTIALS\=/run/secrets -v /Users/kbrock/src/gems/floe/tmp/20240329-82828-dkm9b4:/run/secrets:z --name floe-hello-world-cf3d39a2 docker.io/kbrock/hello-world:latest
  INFO -- : Running state: [Task:FirstState] with input [{"foo"=>2}]...Complete - next state [ChoiceState] output: [{"foo"=>2}]
  INFO -- : Running state: [Choice:ChoiceState] with input [{"foo"=>2}]...
  INFO -- : Running state: [Choice:ChoiceState] with input [{"foo"=>2}]...Complete - next state [SecondMatchState] output: [{"foo"=>2}]
  INFO -- : Running state: [Task:SecondMatchState] with input [{"foo"=>2}]...
 DEBUG -- : Running docker run --detach -e foo\=2 --name floe-hello-world-816c29f0 docker.io/kbrock/hello-world:latest
  INFO -- : Running state: [Task:SecondMatchState] with input [{"foo"=>2}]...Complete - next state [NextState] output: [{"foo"=>2}]
  INFO -- : Running state: [Task:NextState] with input [{"foo"=>2}]...
 DEBUG -- : Running docker run --detach -e foo\=2 --name floe-hello-world-93f8c5f8 docker.io/kbrock/hello-world:latest
  INFO -- : Running state: [Task:NextState] with input [{"foo"=>2}]...Complete workflow - output: [{"foo"=>2}]
  INFO -- : Running state: [Task:FirstState] with input [{"foo"=>99}]...
 DEBUG -- : Running docker run --detach -e foo\=99 -e _CREDENTIALS\=/run/secrets -v /Users/kbrock/src/gems/floe/tmp/20240329-82828-q6xhhv:/run/secrets:z --name floe-hello-world-54fdb316 docker.io/kbrock/hello-world:latest
  INFO -- : Running state: [Task:FirstState] with input [{"foo"=>99}]...Complete - next state [ChoiceState] output: [{"foo"=>99}]
  INFO -- : Running state: [Choice:ChoiceState] with input [{"foo"=>99}]...
  INFO -- : Running state: [Choice:ChoiceState] with input [{"foo"=>99}]...Complete - next state [FailState] output: [{"foo"=>99}]
  INFO -- : Running state: [Fail:FailState] with input [{"foo"=>99}]...
 ERROR -- : Running state: [Fail:FailState] with input [{"foo"=>99}]...Complete workflow - output: [{"Error"=>"FailStateError", "Cause"=>"No Matches!"}]
  INFO -- : Running state: [Wait:WaitState] with input [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]...Complete - next state [NextState] output: [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]
  INFO -- : Running state: [Task:NextState] with input [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]...
 DEBUG -- : Running docker run --detach -e foo\=1 -e result\=\{\"foo\"\=\>\"bar\",\ \"bar\"\=\>\"baz\"\} --name floe-hello-world-3a1d9475 docker.io/kbrock/hello-world:latest
  INFO -- : Running state: [Task:NextState] with input [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]...Complete workflow - output: [{"foo"=>1, "result"=>{"foo"=>"bar", "bar"=>"baz"}}]
  INFO -- : checking 3 workflows...Complete - 3 ready
```