### PR TITLE
Drop non-standard Error/Cause fields.

### DIFF
--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -30,6 +30,10 @@ module Floe
         started? && !ended?
       end
 
+      def failed?
+        output&.key?("Error") || false
+      end
+
       def ended?
         execution.key?("EndTime")
       end
@@ -67,7 +71,7 @@ module Floe
           "pending"
         elsif running?
           "running"
-        elsif state["Error"]
+        elsif failed?
           "failure"
         else
           "success"

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -25,8 +25,6 @@ module Floe
             "Error" => @error_path ? @error_path.value(context, input) : error,
             "Cause" => @cause_path ? @cause_path.value(context, input) : cause
           }.compact
-          context.state["Error"] = context.output["Error"]
-          context.state["Cause"] = context.output["Cause"]
         end
 
         def running?

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -125,7 +125,6 @@ module Floe
         def fail_workflow!(error)
           context.next_state     = nil
           context.output         = {"Error" => error["Error"], "Cause" => error["Cause"]}.compact
-          context.state["Error"] = context.output["Error"]
         end
 
         def parse_error(output)

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -65,6 +65,32 @@ RSpec.describe Floe::Workflow::Context do
     end
   end
 
+  describe "#failed?" do
+    it "new context" do
+      expect(ctx.failed?).to eq(false)
+    end
+
+    it "started" do
+      ctx.state["Output"] = {}
+
+      expect(ctx.failed?).to eq(false)
+    end
+
+    it "ended" do
+      ctx.state["Output"] = input.dup
+
+      expect(ctx.failed?).to eq(false)
+    end
+
+    it "ended with error" do
+      ctx.execution["StartTime"] ||= Time.now.utc
+      ctx.execution["EndTime"] ||= Time.now.utc
+      ctx.output = {"Cause" => "issue", "Error" => "error"}
+
+      expect(ctx.failed?).to eq(true)
+    end
+  end
+
   describe "#input" do
     it "started" do
       ctx.state["Input"] = input
@@ -121,8 +147,7 @@ RSpec.describe Floe::Workflow::Context do
     it "ended with error" do
       ctx.execution["StartTime"] ||= Time.now.utc
       ctx.execution["EndTime"] ||= Time.now.utc
-      ctx.state["Cause"] = "issue"
-      ctx.state["Error"] = "error"
+      ctx.output = {"Cause" => "issue", "Error" => "error"}
 
       expect(ctx.status).to eq("failure")
     end

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe Floe::Workflow::States::Fail do
     it "populates static values" do
       state.run_nonblock!
       expect(ctx.next_state).to eq(nil)
-      expect(ctx.state["Error"]).to eq("FailStateError")
-      expect(ctx.state["Cause"]).to eq("No Matches!")
+      expect(ctx.output).to eq("Error" => "FailStateError", "Cause" => "No Matches!")
     end
 
     context "with dynamic error text" do
@@ -43,8 +42,7 @@ RSpec.describe Floe::Workflow::States::Fail do
       it "populates dynamic values" do
         state.run_nonblock!
         expect(ctx.next_state).to eq(nil)
-        expect(ctx.state["Error"]).to eq("DynamicError")
-        expect(ctx.state["Cause"]).to eq("DynamicCause")
+        expect(ctx.output).to eq("Error" => "DynamicError", "Cause" => "DynamicCause")
       end
     end
   end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -194,9 +194,9 @@ RSpec.describe Floe::Workflow::States::Task do
 
           2.times { workflow.current_state.run_nonblock! }
 
-          expect(ctx.next_state).to     be_nil
-          expect(ctx.status).to         eq("failure")
-          expect(ctx.state["Error"]).to eq("States.Timeout")
+          expect(ctx.next_state).to be_nil
+          expect(ctx.status).to     eq("failure")
+          expect(ctx.output).to     eq("Error" => "States.Timeout")
         end
 
         it "fails the workflow if the exception isn't caught" do
@@ -204,9 +204,9 @@ RSpec.describe Floe::Workflow::States::Task do
 
           workflow.current_state.run_nonblock!
 
-          expect(ctx.next_state).to     be_nil
-          expect(ctx.status).to         eq("failure")
-          expect(ctx.state["Error"]).to eq("Exception")
+          expect(ctx.next_state).to be_nil
+          expect(ctx.status).to     eq("failure")
+          expect(ctx.output).to     eq("Error" => "Exception")
         end
       end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -98,8 +98,6 @@ RSpec.describe Floe::Workflow do
       expect(ctx.input).to eq(input)
       expect(ctx.output).to eq({"Cause" => "Bad Stuff", "Error" => "Issue"})
       expect(ctx.state["Duration"].to_f).to be <= 1
-      expect(ctx.state["Cause"]).to eq("Bad Stuff")
-      expect(ctx.state["Error"]).to eq("Issue")
       expect(ctx.status).to eq("failure")
 
       # execution


### PR DESCRIPTION
We had introduced this to access the errors.
At that time exceptions were being thrown and it was tricky to determine failed runs.

Now output is properly populated with Error/Cause.

So we can use the standard `context.output` and no longer need these.