### PR TITLE
Set manageiq-style to at least 1.5.2

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,8 +1,6 @@
----
 extends: relaxed
-
 rules:
   indentation:
     indent-sequences: false
   line-length:
-    max: 120
+    max: 1000

--- a/floe.gemspec
+++ b/floe.gemspec
@@ -37,10 +37,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "kubeclient", "~>4.7"
   spec.add_dependency "optimist", "~>3.0"
 
-  spec.add_development_dependency "manageiq-style"
+  spec.add_development_dependency "manageiq-style", ">= 1.5.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov", ">= 0.21.2"
   spec.add_development_dependency "timecop"
 end


### PR DESCRIPTION
I noticed locally that manageiq-style was being locked to 1.3.3, because rubocop was taking precedence and thus choosing a more liberal manageiq-style (i.e. 1.3.3 did not lock down the rubocop version).  Instead, here, we lock manageiq-style, which forces rubocop to the version we expect.