### PR TITLE
Add support for pluggable schemes

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -13,33 +13,21 @@ opts = Optimist.options do
   opt :context, "JSON payload of the Context",                  :type => :string
   opt :credentials, "JSON payload with credentials",            :type => :string
   opt :credentials_file, "Path to a file with credentials",     :type => :string
-  opt :docker_runner, "Type of runner for docker images",       :type => :string, :short => 'r'
-  opt :docker_runner_options, "Options to pass to the runner",  :type => :strings, :short => 'o'
 
-  opt :docker,     "Use docker to run images     (short for --docker_runner=docker)",     :type => :boolean
-  opt :podman,     "Use podman to run images     (short for --docker_runner=podman)",     :type => :boolean
-  opt :kubernetes, "Use kubernetes to run images (short for --docker_runner=kubernetes)", :type => :boolean
+  Floe::Runner::ContainerRunner.cli_options(self)
+
+  banner("")
+  banner("General options:")
 end
 
 # legacy support for --workflow
 args = ARGV.empty? ? [opts[:workflow], opts[:input]] : ARGV
 Optimist.die(:workflow, "must be specified") if args.empty?
 
-# shortcut support
-opts[:docker_runner] ||= "docker" if opts[:docker]
-opts[:docker_runner] ||= "podman" if opts[:podman]
-opts[:docker_runner] ||= "kubernetes" if opts[:kubernetes]
+Floe::Runner::ContainerRunner.resolve_cli_options!(opts)
 
 require "logger"
 Floe.logger = Logger.new($stdout)
-
-runner_options = opts[:docker_runner_options].to_h { |opt| opt.split("=", 2) }
-
-begin
-  Floe.set_runner("docker", opts[:docker_runner], runner_options)
-rescue ArgumentError => e
-  Optimist.die(:docker_runner, e.message)
-end
 
 credentials =
   if opts[:credentials_given]

--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -18,10 +18,6 @@ require_relative "floe/workflow/payload_template"
 require_relative "floe/workflow/reference_path"
 require_relative "floe/workflow/retrier"
 require_relative "floe/workflow/runner"
-require_relative "floe/workflow/runner/docker_mixin"
-require_relative "floe/workflow/runner/docker"
-require_relative "floe/workflow/runner/kubernetes"
-require_relative "floe/workflow/runner/podman"
 require_relative "floe/workflow/state"
 require_relative "floe/workflow/states/choice"
 require_relative "floe/workflow/states/fail"
@@ -33,6 +29,8 @@ require_relative "floe/workflow/states/pass"
 require_relative "floe/workflow/states/succeed"
 require_relative "floe/workflow/states/task"
 require_relative "floe/workflow/states/wait"
+
+require_relative "floe/runner/container_runner"
 
 require "jsonpath"
 require "time"
@@ -54,18 +52,5 @@ module Floe
   # @param logger [Logger] logger to use for logging actions
   def self.logger=(logger)
     @logger = logger
-  end
-
-  # Set the runner to use
-  #
-  # @example
-  #   Floe.set_runner "docker", kubernetes", {}
-  #   Floe.set_runner "docker", Floe::Workflow::Runner::Kubernetes.new({})
-  #
-  # @param scheme [String] scheme                           Protocol to register (e.g.: docker)
-  # @param name_or_instance [String|Floe::Workflow::Runner] Name of runner to use for docker (e.g.: docker)
-  # @param options [Hash]                                   Options for constructor of the runner (optional)
-  def self.set_runner(scheme, name_or_instance, options = {})
-    Floe::Workflow::Runner.set_runner(scheme, name_or_instance, options)
   end
 end

--- a/lib/floe/runner/container_runner.rb
+++ b/lib/floe/runner/container_runner.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "container_runner/docker_mixin"
+require_relative "container_runner/docker"
+require_relative "container_runner/kubernetes"
+require_relative "container_runner/podman"
+
+module Floe
+  class Runner
+    class ContainerRunner
+      class << self
+        def cli_options(optimist)
+          optimist.banner("")
+          optimist.banner("Container runner options:")
+
+          optimist.opt :container_runner, "Type of runner for docker container images (docker, podman, or kubernetes)", :type => :string, :short => 'r'
+          optimist.opt :container_runner_options, "Options to pass to the container runner", :type => :strings, :short => 'o'
+
+          optimist.opt :docker,     "Use docker to run container images     (short for --container-runner=docker)",     :type => :boolean
+          optimist.opt :podman,     "Use podman to run container images     (short for --container-runner=podman)",     :type => :boolean
+          optimist.opt :kubernetes, "Use kubernetes to run container images (short for --container-runner=kubernetes)", :type => :boolean
+        end
+
+        def resolve_cli_options!(opts)
+          # shortcut support
+          opts[:container_runner] ||= "docker" if opts[:docker]
+          opts[:container_runner] ||= "podman" if opts[:podman]
+          opts[:container_runner] ||= "kubernetes" if opts[:kubernetes]
+
+          runner_options = opts[:container_runner_options].to_h { |opt| opt.split("=", 2) }
+
+          begin
+            set_runner(opts[:container_runner], runner_options)
+          rescue ArgumentError => e
+            Optimist.die(:container_runner, e.message)
+          end
+        end
+
+        def runner
+          @runner || set_runner(nil)
+        end
+
+        def set_runner(name_or_instance, options = {})
+          @runner =
+            case name_or_instance
+            when "docker", nil
+              Floe::Runner::ContainerRunner::Docker.new(options)
+            when "podman"
+              Floe::Runner::ContainerRunner::Podman.new(options)
+            when "kubernetes"
+              Floe::Runner::ContainerRunner::Kubernetes.new(options)
+            when Floe::Workflow::Runner
+              name_or_instance
+            else
+              raise ArgumentError, "container runner must be one of: docker, podman, kubernetes"
+            end
+        end
+      end
+    end
+  end
+end
+
+Floe::Workflow::Runner.register_scheme("docker", -> { Floe::Runner::ContainerRunner.runner })

--- a/lib/floe/runner/container_runner/docker.rb
+++ b/lib/floe/runner/container_runner/docker.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Floe
-  class Workflow
-    class Runner
+  class Runner
+    class ContainerRunner
       class Docker < Floe::Workflow::Runner
         include DockerMixin
 

--- a/lib/floe/runner/container_runner/docker_mixin.rb
+++ b/lib/floe/runner/container_runner/docker_mixin.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 module Floe
-  class Workflow
-    class Runner
+  class Runner
+    class ContainerRunner
       module DockerMixin
         def image_name(image)
           image.match(%r{^(?<repository>.+/)?(?<image>.+):(?<tag>.+)$})&.named_captures&.dig("image")

--- a/lib/floe/runner/container_runner/kubernetes.rb
+++ b/lib/floe/runner/container_runner/kubernetes.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Floe
-  class Workflow
-    class Runner
+  class Runner
+    class ContainerRunner
       class Kubernetes < Floe::Workflow::Runner
         include DockerMixin
 

--- a/lib/floe/runner/container_runner/podman.rb
+++ b/lib/floe/runner/container_runner/podman.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Floe
-  class Workflow
-    class Runner
-      class Podman < Floe::Workflow::Runner::Docker
+  class Runner
+    class ContainerRunner
+      class Podman < Docker
         DOCKER_COMMAND = "podman"
 
         def initialize(options = {})

--- a/spec/runner/docker_spec.rb
+++ b/spec/runner/docker_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Floe::Workflow::Runner::Docker do
+RSpec.describe Floe::Runner::ContainerRunner::Docker do
   require "securerandom"
 
   let(:subject)        { described_class.new(runner_options) }

--- a/spec/runner/kubernetes_spec.rb
+++ b/spec/runner/kubernetes_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Floe::Workflow::Runner::Kubernetes do
+RSpec.describe Floe::Runner::ContainerRunner::Kubernetes do
   before do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with('KUBECONFIG', nil).and_return(nil)

--- a/spec/runner/podman_spec.rb
+++ b/spec/runner/podman_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Floe::Workflow::Runner::Podman do
+RSpec.describe Floe::Runner::ContainerRunner::Podman do
   require "securerandom"
 
   let(:subject)        { described_class.new(runner_options) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,7 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   require "awesome_spawn/spec_helper"
-  config.define_derived_metadata(:file_path => %r{/spec/workflow/}) do |metadata|
+  config.define_derived_metadata(:file_path => %r{/spec/runner/}) do |metadata|
     metadata[:uses_awesome_spawn] = true
   end
   config.include AwesomeSpawn::SpecHelper, :uses_awesome_spawn => true


### PR DESCRIPTION
The idea behind this PR is to move the docker runner (renamed here to container runner for clarity) into a separate directory in a way to show what a plugin would look like and what the registration of schemes would look like.

For now, this PR:
- Move docker schema runner into a Floe::Runner::ContainerRunner namespace to treat it like a plugin
- Add registration of schema to runner instance (with support for procs)
- Change exe/floe to not have anything schema-specific and to call out to the plugins for options and post-option setup.

TODO:
- I want to add specs around the registration and the container runner's class methods for registration.  Not sure if it's needed for this PR or not.

Here's what the `--help` looks like after this:

```
$ be exe/floe --help
Usage: floe [options] workflow input [workflow2 input2]

v0.9.0

Options:
  -w, --workflow=<s>                     Path to your workflow json (legacy)
  -i, --input=<s>                        JSON payload to input to the workflow (legacy)
  -c, --context=<s>                      JSON payload of the Context
  -e, --credentials=<s>                  JSON payload with credentials
  -d, --credentials-file=<s>             Path to a file with credentials

Container runner options:
  -r, --container-runner=<s>             Type of runner for docker container images (docker, podman, or kubernetes)
  -o, --container-runner-options=<s+>    Options to pass to the container runner
  -k, --docker                           Use docker to run container images     (short for --container-runner=docker)
  -p, --podman                           Use podman to run container images     (short for --container-runner=podman)
  -u, --kubernetes                       Use kubernetes to run container images (short for --container-runner=kubernetes)

General options:
  -v, --version                          Print version and exit
  -h, --help                             Show this message
```

Some future thoughts:
- I actually wanted `Floe::ContainerRunner` directly, but didn't want to deal with the un-indenting of 1 level of namespace.  I still may do this anyway, because then this would mirror what a real "plugin" would look like allowing for things like `require 'floe/container_runner'` and living in a `floe-container_runner` gem.
- While the exe/floe hardcodes the reference to the container runner, I think it's cleaner to loop over all of the registered schemes, and then call cli_options/resolve_cli_options on each. However, I thought it would make this PR less clear and didn't do that for now.

@agrare @kbrock Please review.

Closes #45