### PR TITLE
Ensure the local code is loaded in exe/floe

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
 require "optimist"
 require "floe"
 require "floe/container_runner"


### PR DESCRIPTION
This fixes an issue where if exe/floe is run without bundle exec it will pull in the version of floe installed on the system instead of the local adjacent code.

Incidentally, now you no longer are forced to run it with bundle exec, however, you may still want to as it ensures dependency gem versions.
