### PR TITLE
drop run!

### DIFF
--- a/lib/floe/runner.rb
+++ b/lib/floe/runner.rb
@@ -29,10 +29,6 @@ module Floe
       end
     end
 
-    def run!(resource, env = {}, secrets = {})
-      raise NotImplementedError, "Must be implemented in a subclass"
-    end
-
     # @return [Hash] runner_context
     def run_async!(_image, _env = {}, _secrets = {})
       raise NotImplementedError, "Must be implemented in a subclass"

--- a/lib/floe/runner.rb
+++ b/lib/floe/runner.rb
@@ -31,7 +31,7 @@ module Floe
 
     # Run a command asynchronously and create a runner_context
     # @return [Hash] runner_context
-    def run_async!(_image, _env = {}, _secrets = {})
+    def run_async!(_resource, _env = {}, _secrets = {})
       raise NotImplementedError, "Must be implemented in a subclass"
     end
 

--- a/lib/floe/runner.rb
+++ b/lib/floe/runner.rb
@@ -29,23 +29,48 @@ module Floe
       end
     end
 
+    # Run a command asynchronously and create a runner_context
     # @return [Hash] runner_context
     def run_async!(_image, _env = {}, _secrets = {})
       raise NotImplementedError, "Must be implemented in a subclass"
     end
 
+    # update the runner_context
+    # @param  [Hash] runner_context (the value returned from run_async!)
+    # @return [void]
+    def status!(_runner_context)
+      raise NotImplementedError, "Must be implemented in a subclass"
+    end
+
+    # check runner_contet to determine if the task is still running or completed
+    # @param  [Hash] runner_context (the value returned from run_async!)
+    # @return [Boolean] value if the task is still running
+    #   true if the task is still running
+    #   false if it has completed
     def running?(_runner_context)
       raise NotImplementedError, "Must be implemented in a subclass"
     end
 
+    # For a non-running? task, check if it was successful
+    # @param  [Hash] runner_context (the value returned from run_async!)
+    # @return [Boolean] value if the task is still running
+    #   true if the task completed successfully
+    #   false if the task had an error
     def success?(_runner_context)
       raise NotImplementedError, "Must be implemented in a subclass"
     end
 
+    # For a successful task, return the output
+    # @param  [Hash] runner_context (the value returned from run_async!)
+    # @return [String, Hash] output from task
     def output(_runner_context)
       raise NotImplementedError, "Must be implemented in a subclass"
     end
 
+    # Cleanup runner context resources
+    # Called after a task is completed and the runner_context is no longer needed.
+    # @param  [Hash] runner_context (the value returned from run_async!)
+    # @return [void]
     def cleanup(_runner_context)
       raise NotImplementedError, "Must be implemented in a subclass"
     end


### PR DESCRIPTION
## Overview

- We dropped all references to `run!` in 46c175f ( https://github.com/ManageIQ/floe/pull/149 ) but did not drop it from the abstract interface: `Floe::Runner#run!`
- `Task#running?` called `status!` but it was not part of the abstract interface: `Floe::Runner#status!`.
- 2 documentation changes -- Wondering if we should remove the leading `_` from method parameters and add yarddoc for all parameters.

## After

- Drop `Floe::Runner#run!`
- Add `Floe::Runner#status!`
- Added yarddoc for `Floe::Runner` methods
- renamed parameter `run_async!(image, ...)` to `run_async!(resource, ...)`

## Alternatives

If we don't want `Floe::Runner#status!` as part of the interface, then we can move that call from `Task#running?` to the `Floe::ContainerRunner::*#running?` implementations.