### PR TITLE
Implement runner#wait in a generic way

### DIFF
--- a/lib/floe/runner.rb
+++ b/lib/floe/runner.rb
@@ -27,6 +27,13 @@ module Floe
         scheme = resource.split("://").first
         resolve_scheme(scheme) || raise(ArgumentError, "Invalid resource scheme [#{scheme}]")
       end
+
+      def runners
+        @runners.each_value.map do |runner|
+          runner = runner.call if runner.kind_of?(Proc)
+          runner
+        end
+      end
     end
 
     # Run a command asynchronously and create a runner_context

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -20,16 +20,21 @@ module Floe
         workflows = [workflows] if workflows.kind_of?(self)
         logger.info("checking #{workflows.count} workflows...")
 
-        run_until   = Time.now.utc + timeout if timeout.to_i > 0
-        ready       = []
-        queue       = Queue.new
-        wait_thread = Thread.new do
-          loop do
-            Runner.for_resource("docker").wait do |event, runner_context|
-              queue.push([event, runner_context])
+        run_until    = Time.now.utc + timeout if timeout.to_i > 0
+        ready        = []
+        queue        = Queue.new
+        wait_threads =
+          Runner.runners.map do |runner|
+            next unless runner.respond_to?(:wait)
+
+            Thread.new do
+              loop do
+                runner.wait do |event, runner_context|
+                  queue.push([event, runner_context])
+                end
+              end
             end
           end
-        end
 
         loop do
           ready = workflows.select(&:step_nonblock_ready?)
@@ -81,7 +86,7 @@ module Floe
         logger.info("checking #{workflows.count} workflows...Complete - #{ready.count} ready")
         ready
       ensure
-        wait_thread&.kill
+        wait_threads.compact.map(&:kill)
       end
     end
 


### PR DESCRIPTION
pulled out of #178

Depend upon:
- [x] #190

## Overview

The `builtin` runner does not need a `wait` method since it does not listen to completed tasks. But other runners may need a a `wait`.

So the solution is to make wait optional, and setup a thread for all the runners that implement that interface.

## Before

Run a thread to support `wait` from `"docker"` runner, but no others.

## After

Run a thread for every runner that requires `wait`.

Developer speak
===============

```ruby
# handle docker scheme
Thread.new do
  loop do
    Runner.for_resource("docker").wait do |event, runner_context|
      queue.push([event, runner_context])
    end
  end
end
```

aka:

```ruby
# handle docker scheme
runner = Runner.for_resource("docker")
Thread.new do
  loop do
    runner.wait do |event, runner_context|
      queue.push([event, runner_context])
    end
  end
end
```

handling multiple runners:

```ruby
# handle all schemes
Runner.runners.each do |runner|
  Thread.new do
    loop do
      runner.wait do |event, runner_context|
        queue.push([event, runner_context])
      end
    end
  end
end
```

## Aside

I had wanted to add something with `exe/floe`'s interface, since that is also hard coded, but this addresses my primary concerns.
