### PR TITLE
drop unused Task#status

### DIFF
--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -41,10 +41,6 @@ module Floe
           context.state["RunnerContext"] = runner_context
         end
 
-        def status
-          @end ? "success" : "running"
-        end
-
         def finish
           output = runner.output(context.state["RunnerContext"])
 


### PR DESCRIPTION
This method is now Workflow#context => Context#status

It used to be called on `State#status` but was moved to
`Context#state` in 1cf45d608894d954c81d
The method `Task#status` is no longer called.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
