### PR TITLE
A failed state can leave a workflow in "running"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix issue where a failed state can leave a workflow in "running" ([#182](https://github.com/ManageIQ/floe/pull/182))
 
 ## [0.11.0] - 2024-05-02
 ### Fixed

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -4,11 +4,6 @@ module Floe
   class Workflow
     module States
       module NonTerminalMixin
-        def finish
-          context.next_state = end? ? nil : @next
-          super
-        end
-
         def validate_state_next!
           raise Floe::InvalidWorkflowError, "Missing \"Next\" field in state [#{name}]" if @next.nil? && !@end
           raise Floe::InvalidWorkflowError, "\"Next\" [#{@next}] not in \"States\" for state [#{name}]" if @next && !workflow.payload["States"].key?(@next)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -46,11 +46,12 @@ module Floe
 
           if success?
             output = parse_output(output)
-            context.output = process_output(context.input.dup, output)
+            context.output     = process_output(context.input.dup, output)
+            context.next_state = end? ? nil : @next
             super
           else
+            context.output     = error = parse_error(output)
             context.next_state = nil
-            context.output = error = parse_error(output)
             super
             retry_state!(error) || catch_error!(error) || fail_workflow!(error)
           end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -38,8 +38,9 @@ module Floe
         end
 
         def finish
-          input          = input_path.value(context, context.input)
-          context.output = output_path.value(context, input)
+          input              = input_path.value(context, context.input)
+          context.output     = output_path.value(context, input)
+          context.next_state = end? ? nil : @next
           super
         end
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
     describe "Input" do
       context "with no InputPath" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         it "passes the whole context to the resource" do
           expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "hello, world!")
@@ -23,7 +23,7 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with an InputPath" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "InputPath" => "$.foo", "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "InputPath" => "$.foo", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         it "filters the context passed to the resource" do
           expect_run_async({"bar" => "baz"}, :output => nil)
@@ -33,7 +33,7 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with Parameters" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Parameters" => {"var1.$" => "$.foo.bar"}, "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Parameters" => {"var1.$" => "$.foo.bar"}, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         it "passes the interpolated parameters to the resource" do
           expect_run_async({"var1" => "baz"}, :output => nil)
@@ -44,7 +44,7 @@ RSpec.describe Floe::Workflow::States::Task do
     end
 
     describe "Output" do
-      let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "End" => true}}) }
+      let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
       it "uses the last line as output if it is JSON" do
         expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "ABCD\nHELLO\n{\"response\":[\"192.168.1.2\"]}")
@@ -73,7 +73,7 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "ResultSelector" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultSelector" => {"ip_addrs.$" => "$.response"}, "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultSelector" => {"ip_addrs.$" => "$.response"}, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         it "filters the results" do
           expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "ABCD\nHELLO\n{\"response\":[\"192.168.1.2\"],\"exit_code\":0}")
@@ -85,7 +85,7 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "ResultPath" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.ip_addrs", "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.ip_addrs", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         it "inserts the response into the input" do
           expect_run_async(input, :output => "[\"192.168.1.2\"]")
@@ -100,7 +100,7 @@ RSpec.describe Floe::Workflow::States::Task do
         end
 
         context "setting a Credential" do
-          let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.Credentials", "End" => true}}) }
+          let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.Credentials", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
           it "inserts the response into the workflow credentials" do
             expect_run_async(input, :output => "{\"token\": \"shhh!\"}")
@@ -117,7 +117,7 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "OutputPath" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.data.ip_addrs", "OutputPath" => output_path, "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.data.ip_addrs", "OutputPath" => output_path, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         context "with the default '$'" do
           let(:output_path) { "$" }
@@ -150,7 +150,7 @@ RSpec.describe Floe::Workflow::States::Task do
     end
 
     describe "Retry" do
-      let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Retry" => retriers, "TimeoutSeconds" => 2, "End" => true}}) }
+      let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Retry" => retriers, "TimeoutSeconds" => 2, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
       context "with specific errors" do
         let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 1}] }
@@ -166,7 +166,7 @@ RSpec.describe Floe::Workflow::States::Task do
         end
 
         context "with multiple retriers" do
-          let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 1}, {"ErrorEquals" => ["Exception"], "End" => true}] }
+          let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 1}, {"ErrorEquals" => ["Exception"], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}] }
 
           it "resets the retrier if a different exception is raised" do
             expect_run_async(input, :error => "States.Timeout")
@@ -225,7 +225,7 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with a Catch" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Retry" => [{"ErrorEquals" => ["States.Timeout"]}], "Catch" => [{"ErrorEquals" => ["States.ALL"], "Next" => "FailState"}], "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Retry" => [{"ErrorEquals" => ["States.Timeout"]}], "Catch" => [{"ErrorEquals" => ["States.ALL"], "Next" => "FailState"}], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         it "retry preceeds catch" do
           expect_run_async(input, :error => "States.Timeout")
@@ -249,7 +249,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
     describe "Catch" do
       context "with specific errors" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Catch" => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}], "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Catch" => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         it "catches the exception" do
           expect_run_async(input, :output => "States.Timeout", :success => false)
@@ -271,7 +271,7 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with a State.ALL catcher" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Catch" => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}, {"ErrorEquals" => ["States.ALL"], "Next" => "FailState"}], "End" => true}}) }
+        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Catch" => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}, {"ErrorEquals" => ["States.ALL"], "Next" => "FailState"}], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
         it "catches a more specific exception" do
           expect_run_async(input, :output => "States.Timeout", :success => false)


### PR DESCRIPTION
Right now just tweaking the specs to show the issue.

The problem is `Task#finish` has the following in the event of a state failure
https://github.com/ManageIQ/floe/blob/master/lib/floe/workflow/states/task.rb#L51-L56
```ruby
          else
            context.next_state = nil
            context.output = error = parse_error(output)
            super
            retry_state!(error) || catch_error!(error) || fail_workflow!(error)
          end
```

But `super` goes to the `NonTerminalMixin` https://github.com/ManageIQ/floe/blob/master/lib/floe/workflow/states/non_terminal_mixin.rb#L7-L10 which does:
```ruby
        def finish
          context.next_state = end? ? nil : @next
          super
        end
```

If the state doesn't have `"End": true` in the payload, this will re-set the next_state to `"Next": ...` and not mark the workflow as failed&ended here: https://github.com/ManageIQ/floe/blob/master/lib/floe/workflow/state.rb#L71
```ruby
        context.execution["EndTime"]    = finished_time_iso if context.next_state.nil?
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
