### PR TITLE
Extract ErrorMatcherMixin from Catch and Retry

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -8,6 +8,7 @@ require_relative "floe/logging"
 require_relative "floe/runner"
 
 require_relative "floe/workflow"
+require_relative "floe/workflow/error_matcher_mixin"
 require_relative "floe/workflow/catcher"
 require_relative "floe/workflow/choice_rule"
 require_relative "floe/workflow/choice_rule/not"

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -3,6 +3,8 @@
 module Floe
   class Workflow
     class Catcher
+      include Floe::Workflow::ErrorMatcherMixin
+
       attr_reader :error_equals, :next, :result_path
 
       def initialize(payload)
@@ -11,6 +13,7 @@ module Floe
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]
         @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
+        raise Floe::InvalidWorkflowError, "State requires ErrorEquals" if !@error_equals.kind_of?(Array) || @error_equals.empty?
       end
     end
   end

--- a/lib/floe/workflow/error_matcher_mixin.rb
+++ b/lib/floe/workflow/error_matcher_mixin.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Floe
+  class Workflow
+    # Methods for common error handling
+    module ErrorMatcherMixin
+      # @param [String] error the error thrown
+      def match_error?(error)
+        return true if error_equals.include?("States.ALL")
+
+        error_equals.include?(error)
+      end
+    end
+  end
+end

--- a/lib/floe/workflow/error_matcher_mixin.rb
+++ b/lib/floe/workflow/error_matcher_mixin.rb
@@ -7,6 +7,7 @@ module Floe
       # @param [String] error the error thrown
       def match_error?(error)
         return true if error_equals.include?("States.ALL")
+        return true if error_equals.include?("States.Timeout") && error == "States.HeartbeatTimeout"
 
         error_equals.include?(error)
       end

--- a/lib/floe/workflow/error_matcher_mixin.rb
+++ b/lib/floe/workflow/error_matcher_mixin.rb
@@ -6,6 +6,7 @@ module Floe
     module ErrorMatcherMixin
       # @param [String] error the error thrown
       def match_error?(error)
+        return false if error == "States.Runtime"
         return true if error_equals.include?("States.ALL")
         return true if error_equals.include?("States.Timeout") && error == "States.HeartbeatTimeout"
 

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -3,6 +3,8 @@
 module Floe
   class Workflow
     class Retrier
+      include Floe::Workflow::ErrorMatcherMixin
+
       attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate
 
       def initialize(payload)
@@ -12,6 +14,7 @@ module Floe
         @interval_seconds = payload["IntervalSeconds"] || 1.0
         @max_attempts     = payload["MaxAttempts"] || 3
         @backoff_rate     = payload["BackoffRate"] || 2.0
+        raise Floe::InvalidWorkflowError, "State requires ErrorEquals" if !@error_equals.kind_of?(Array) || @error_equals.empty?
       end
 
       # @param [Integer] attempt 1 for the first attempt

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -82,11 +82,11 @@ module Floe
         end
 
         def find_retrier(error)
-          self.retry.detect { |r| (r.error_equals & [error, "States.ALL"]).any? }
+          self.retry.detect { |r| r.match_error?(error) }
         end
 
         def find_catcher(error)
-          self.catch.detect { |c| (c.error_equals & [error, "States.ALL"]).any? }
+          self.catch.detect { |c| c.match_error?(error) }
         end
 
         def retry_state!(context, error)

--- a/spec/workflow/error_matcher_mixin_spec.rb
+++ b/spec/workflow/error_matcher_mixin_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe Floe::Workflow::ErrorMatcherMixin do
       it "matches other exceptions" do
         expect(subject.match_error?("States.Permissions")).to eq(true)
       end
+
+      it "does not match States.Runtime" do
+        expect(subject.match_error?("States.Runtime")).to eq(false)
+      end
     end
 
     context "when matching States.Timeout" do

--- a/spec/workflow/error_matcher_mixin_spec.rb
+++ b/spec/workflow/error_matcher_mixin_spec.rb
@@ -52,5 +52,16 @@ RSpec.describe Floe::Workflow::ErrorMatcherMixin do
         expect(subject.match_error?("States.Permissions")).to eq(true)
       end
     end
+
+    context "when matching States.Timeout" do
+      let(:retriers) { [{"ErrorEquals" => ["States.Timeout"]}] }
+      it "matches HearbeatTimeout" do
+        expect(subject.match_error?("States.HeartbeatTimeout")).to eq(true)
+      end
+
+      it "fails to match other errors" do
+        expect(subject.match_error?("States.Permissions")).to eq(false)
+      end
+    end
   end
 end

--- a/spec/workflow/error_matcher_mixin_spec.rb
+++ b/spec/workflow/error_matcher_mixin_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe Floe::Workflow::ErrorMatcherMixin do
+  let(:input) { {} }
+  let(:ctx) { Floe::Workflow::Context.new(:input => input) }
+  let(:resource) { "docker://hello-world:latest" }
+  # we could have used catchers
+  let(:retriers) { {"ErrorEquals" => ["States.ALL"]} }
+  let(:catchers) { retriers.map { |rt| rt.merge("Next" => "SuccessState") } }
+  let(:workflow) do
+    make_workflow(
+      ctx, {
+        "State"        => {
+          "Type"     => "Task",
+          "Resource" => resource,
+          "Retry"    => retriers,
+          "Catcher"  => catchers,
+          "Next"     => "SuccessState"
+        }.compact,
+        "FirstState"   => {"Type" => "Succeed"},
+        "SuccessState" => {"Type" => "Succeed"},
+        "FailState"    => {"Type" => "Succeed"}
+      }
+    )
+  end
+
+  let(:subject) { workflow.start_workflow.current_state.retry.first }
+
+  describe "#match_error?" do
+    context "with no ErrorEquals" do
+      let(:retriers) { [{}] }
+      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, /requires.*ErrorEquals/) }
+    end
+
+    context "with empty ErrorEquals" do
+      let(:retriers) { [{"ErrorEquals" => []}] }
+      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, /requires.*ErrorEquals/) }
+    end
+
+    context "when matching an error" do
+      let(:retriers) { [{"ErrorEquals" => ["States.Permissions"]}] }
+      it "matches the error" do
+        expect(subject.match_error?("States.Permissions")).to eq(true)
+      end
+
+      it "fails to match other errors" do
+        expect(subject.match_error?("States.Timeout")).to eq(false)
+      end
+    end
+
+    context "when matching States.ALL" do
+      let(:retriers) { [{"ErrorEquals" => ["States.ALL"]}] }
+      it "matches other exceptions" do
+        expect(subject.match_error?("States.Permissions")).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION

- Extract ErrorMatcherMixin#match_error?
- `States.HeartbeatTimeout` is handled by `States.Timeout`
- `States.Runtime` is not caught by any catchers/retriers
