### PR TITLE
Fix 2 basic Cops

### DIFF
--- a/lib/floe/runner.rb
+++ b/lib/floe/runner.rb
@@ -17,7 +17,7 @@ module Floe
 
       private def resolve_scheme(scheme)
         runner = @runners[scheme]
-        runner = @runners[scheme] = @runners[scheme].call if runner.is_a?(Proc)
+        runner = @runners[scheme] = @runners[scheme].call if runner.kind_of?(Proc)
         runner
       end
 

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -6,10 +6,6 @@ module Floe
       class Succeed < Floe::Workflow::State
         attr_reader :input_path, :output_path
 
-        def initialize(workflow, name, payload)
-          super
-        end
-
         def finish
           context.next_state = nil
           context.output     = context.input


### PR DESCRIPTION
It did complain about empty initializers before, but those seemed necessary for an interface.
But this initializer seems pointless since the parent defines it.

```
lib/floe/runner.rb:20:69: C: [Correctable] Style/ClassCheck: Prefer Object#kind_of? over Object#is_a?.
        runner = @runners[scheme] = @runners[scheme].call if runner.is_a?(Proc)
                                                                    ^^^^^
lib/floe/workflow/states/succeed.rb:9:9: W: [Correctable] Lint/UselessMethodDefinition: Useless method definition detected.
        def initialize(workflow, name, payload) ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/floe/workflow/states/succeed.rb:9:9: C: [Correctable] Style/RedundantInitialize: Remove unnecessary initialize method.
        def initialize(workflow, name, payload) ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```