### PR TITLE
Make Runner#wait optional

### DIFF
--- a/lib/floe/runner.rb
+++ b/lib/floe/runner.rb
@@ -75,8 +75,13 @@ module Floe
       raise NotImplementedError, "Must be implemented in a subclass"
     end
 
-    def wait(timeout: nil, events: %i[create update delete])
-      raise NotImplementedError, "Must be implemented in a subclass"
-    end
+    # Optional Watcher for events that is run in another thread.
+    #
+    # @yield [event, runner_context]
+    # @yieldparam [Symbol] event values: :create :update :delete :unknown
+    # @yieldparam [Hash] runner_context context provided by runner
+    # def wait(timeout: nil, events: %i[create update delete])
+    #   raise NotImplementedError, "Must be implemented in a subclass"
+    # end
   end
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Floe::Runner do
 
   describe "#wait" do
     it "is not implemented" do
-      expect { runner.wait }.to raise_error(NotImplementedError)
+      expect(runner.respond_to?(:wait)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
I've mentioned before.

Some runners require a wait thread, others do not.
Wanted to modify the runner interface to make that evident.