### PR TITLE
output now based upon raw input not effective input

### DIFF
--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -19,9 +19,8 @@ module Floe
         end
 
         def finish
-          input      = input_path.value(context, context.input)
-          next_state = choices.detect { |choice| choice.true?(context, input) }&.next || default
-          output     = output_path.value(context, input)
+          output     = output_path.value(context, context.input)
+          next_state = choices.detect { |choice| choice.true?(context, output) }&.next || default
 
           context.next_state = next_state
           context.output     = output

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -25,8 +25,7 @@ module Floe
         end
 
         def finish
-          input          = process_input(context.input)
-          context.output = process_output(input, result)
+          context.output = process_output(context.input.dup, result)
           super
         end
 

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -53,5 +53,41 @@ RSpec.describe Floe::Workflow::States::Pass do
         expect(ctx.next_state).to eq("SuccessState")
       end
     end
+
+    # https://states-language.net/#inputoutput-processing-examples
+    context "with 2 blocks" do
+      let(:payload) do
+        {
+          "First"   => {
+            "Type"       => "Pass",
+            "Result"     => {
+              "title"   => "Numbers to add",
+              "numbers" => {"val1" => 3, "val2" => 4}
+            },
+            "ResultPath" => "$",
+            "Next"       => "Second"
+          },
+          "Second"  => {
+            "Type"       => "Pass",
+            "Result"     => 7,
+            "InputPath"  => "$.numbers",
+            "ResultPath" => "$.sum",
+            "Next"       => "Success"
+          },
+          "Success" => {
+            "Type" => "Succeed"
+          }
+        }
+      end
+
+      it "Uses raw input" do
+        workflow.run_nonblock
+        expect(ctx.output).to eq(
+          "val1"    => 3,
+          "val2"    => 4,
+          "sum"     => 7
+        )
+      end
+    end
   end
 end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe Floe::Workflow::States::Pass do
       it "Uses raw input" do
         workflow.run_nonblock
         expect(ctx.output).to eq(
-          "val1"    => 3,
-          "val2"    => 4,
+          "title"   => "Numbers to add",
+          "numbers" => {"val1" => 3, "val2" => 4},
           "sum"     => 7
         )
       end


### PR DESCRIPTION
## Context

```
// raw input
{
  "title": "Numbers to add",
  "numbers": { "val1": 3, "val2": 4 }
}

// result
7

// state
"InputPath": "$.numbers",
"ResultPath": "$.sum"
```

## Before

```
// raw output:
{
  "val1": 3,
  "val2": 4,
  "sum": 7
}
```

## After

```
// raw output:
{
  "title": "Numbers to add",
  "numbers": { "val1": 3, "val2": 4 },
  "sum": 7
}
```



refs:
- https://states-language.net/#inputoutput-processing-examples
- https://docs.aws.amazon.com/step-functions/latest/dg/input-output-example.html
