### PR TITLE
Fix error raised on invalid resource scheme

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -110,7 +110,7 @@ module Floe
         context.state["Name"] = start_at
         context.state["Input"] = context.execution["Input"].dup
       end
-    rescue JSON::ParserError => err
+    rescue StandardError => err
       raise Floe::InvalidWorkflowError, err.message
     end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for invalid context" do
       expect { described_class.new(make_payload({"Start" => {"Type" => "Success"}}), "abc") }.to raise_error(Floe::InvalidWorkflowError, /unexpected token/)
     end
+
+    it "raises an exception for invalid resource scheme in a Task state" do
+      payload = make_payload({"Start" => {"Type" => "Task", "Resource" => "invalid://foo"}})
+
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, /Invalid resource scheme/)
+    end
   end
 
   describe "#run_nonblock" do


### PR DESCRIPTION
Before this commit, an ArgumentError is raised to the top, but now it raises a Floe::InvalidWorkflowError.

@agrare Please review.