### PR TITLE
Drop step_nonblock_wait

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -126,10 +126,6 @@ module Floe
       current_state.run_nonblock!
     end
 
-    def step_nonblock_wait(timeout: nil)
-      current_state.wait(:timeout => timeout)
-    end
-
     def step_nonblock_ready?
       current_state.ready?
     end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -33,17 +33,6 @@ module Floe
         raise Floe::InvalidWorkflowError, "State name [#{name}] must be less than or equal to 80 characters" if name.length > 80
       end
 
-      def wait(timeout: nil)
-        start = Time.now.utc
-
-        loop do
-          return 0             if ready?
-          return Errno::EAGAIN if timeout && (timeout.zero? || Time.now.utc - start > timeout)
-
-          sleep(1)
-        end
-      end
-
       def run_nonblock!
         start(context.input) unless started?
         return Errno::EAGAIN unless ready?

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -256,33 +256,6 @@ RSpec.describe Floe::Workflow do
     end
   end
 
-  describe "#step_nonblock_wait" do
-    context "with a state that hasn't started yet" do
-      it "returns 0" do
-        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
-        expect(workflow.step_nonblock_wait).to eq(0)
-      end
-    end
-
-    context "with a state that has finished" do
-      it "return 0" do
-        ctx.state["EnteredTime"] = Time.now.utc.iso8601
-        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
-        expect(workflow.current_state).to receive(:running?).and_return(false)
-        expect(workflow.step_nonblock_wait).to eq(0)
-      end
-    end
-
-    context "with a state that is running" do
-      it "returns Try again" do
-        ctx.state["EnteredTime"] = Time.now.utc.iso8601
-        workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest", "End" => true}})
-        expect(workflow.current_state).to receive(:running?).and_return(true)
-        expect(workflow.step_nonblock_wait(:timeout => 0)).to eq(Errno::EAGAIN)
-      end
-    end
-  end
-
   describe "#step_nonblock_ready?" do
     context "with a state that hasn't started yet" do
       it "returns true" do


### PR DESCRIPTION
reduce the number of "run" methods

goal lead to another goal / thread
- simplify workflow so parallel and map are easier to implement
- reducing the manipulation of context in workflow
- reduce the number of run/step methods in workflow
- reduce the number of run/step methods in state

