### PR TITLE
Drop context state machine and task

### DIFF
--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -16,7 +16,6 @@ module Floe
         self["Execution"]["Input"] ||= input
         self["State"]              ||= {}
         self["StateHistory"]       ||= []
-        self["Task"]               ||= {}
       end
 
       def execution
@@ -89,10 +88,6 @@ module Floe
 
       def state_history
         @context["StateHistory"]
-      end
-
-      def task
-        @context["Task"]
       end
 
       def [](key)

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -16,7 +16,6 @@ module Floe
         self["Execution"]["Input"] ||= input
         self["State"]              ||= {}
         self["StateHistory"]       ||= []
-        self["StateMachine"]       ||= {}
         self["Task"]               ||= {}
       end
 
@@ -90,10 +89,6 @@ module Floe
 
       def state_history
         @context["StateHistory"]
-      end
-
-      def state_machine
-        @context["StateMachine"]
       end
 
       def task


### PR DESCRIPTION
any time I add funcitonality to context, my PRs show as red.
It says there are too many methods on context.

This is an attempt to remove a few unused methods from context

task holds an id for a human interaction task.