### PR TITLE
ResultPath=$ replaces complete output

### DIFF
--- a/lib/floe/workflow/reference_path.rb
+++ b/lib/floe/workflow/reference_path.rb
@@ -25,12 +25,9 @@ module Floe
       def set(context, value)
         result = context.dup
 
-        # If the payload is '$' then merge the value into the context
-        # otherwise store the value under the path
-        #
-        # TODO: how to handle non-hash values, raise error if path=$ and value not a hash?
+        # If the payload is '$' then replace the output with the value
         if path.empty?
-          result.merge!(value)
+          result = value.dup
         else
           child    = result
           keys     = path.dup

--- a/spec/workflow/reference_path_spec.rb
+++ b/spec/workflow/reference_path_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Floe::Workflow::ReferencePath do
 
   describe "#set" do
     let(:payload) { "$" }
-    let(:input) { {} }
+    let(:input) { {"old" => "key"} }
 
     context "with a simple path" do
       it "sets the output at the top-level" do
@@ -58,11 +58,19 @@ RSpec.describe Floe::Workflow::ReferencePath do
       end
     end
 
+    context "with a top level path" do
+      let(:payload) { "$.hash" }
+
+      it "sets the output at the correct nested level" do
+        expect(subject.set(input, "foo" => "bar")).to eq("old" => "key", "hash" => {"foo" => "bar"})
+      end
+    end
+
     context "with a nested path" do
       let(:payload) { "$.nested.hash" }
 
       it "sets the output at the correct nested level" do
-        expect(subject.set(input, "foo" => "bar")).to eq("nested" => {"hash" => {"foo" => "bar"}})
+        expect(subject.set(input, "foo" => "bar")).to eq("old" => "key", "nested" => {"hash" => {"foo" => "bar"}})
       end
     end
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
         workflow.current_state.run_nonblock!
 
-        expect(ctx.output).to eq("foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}, "response" => ["192.168.1.2"])
+        expect(ctx.output).to eq("response" => ["192.168.1.2"])
       end
 
       context "with an error" do
@@ -80,7 +80,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
           workflow.current_state.run_nonblock!
 
-          expect(ctx.output).to eq("foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}, "ip_addrs" => ["192.168.1.2"])
+          expect(ctx.output).to eq("ip_addrs" => ["192.168.1.2"])
         end
       end
 


### PR DESCRIPTION
ok, https://states-language.net/#error-output

> The default value, if the "ResultPath" field is not provided, is "$", meaning that the output consists entirely of the Error Output.

Which differs from the previous code
 https://github.com/ManageIQ/floe/blob/master/lib/floe/workflow/reference_path.rb#L28-L29

> If the payload is '$' then merge the value into the context

This fixes issues where the output is a simple class inserting at the top level

I stumbled across this because the `Task` `Catch` should output the error as the output node