### PR TITLE
fix initialize and rescue rubocop warnings

### DIFF
--- a/lib/floe/runner.rb
+++ b/lib/floe/runner.rb
@@ -6,7 +6,7 @@ module Floe
 
     OUTPUT_MARKER = "__FLOE_OUTPUT__\n"
 
-    def initialize(_options = {})
+    def initialize(_options = {}) # rubocop:disable Style/RedundantInitialize
     end
 
     @runners = {}

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -110,7 +110,7 @@ module Floe
         context.state["Name"] = start_at
         context.state["Input"] = context.execution["Input"].dup
       end
-    rescue StandardError => err
+    rescue => err
       raise Floe::InvalidWorkflowError, err.message
     end
 


### PR DESCRIPTION
ignored one and fixed the other

running rubocop more frequently locally.
these are so trivial that I thought I'd just fix them