### PR TITLE
Fix Retry issues

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -161,7 +161,13 @@ module Floe
     private
 
     def step_next
-      context.state = {"Name" => context.next_state, "Input" => context.output} if context.next_state
+      if context.next_state
+        # if rerunning due to an error (and we are using Retry)
+        if context.state_name == context.next_state && context.failed? && context.state.key?("Retrier")
+          restore_values = context.state.slice("RetryCount", "Input", "Retrier")
+        end
+        context.state = {"Name" => context.next_state, "Input" => context.output}.merge!(restore_values || {})
+      end
     end
   end
 end

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -14,8 +14,9 @@ module Floe
         @backoff_rate     = payload["BackoffRate"] || 2.0
       end
 
+      # @param [Integer] attempt 1 for the first attempt
       def sleep_duration(attempt)
-        interval_seconds * (backoff_rate * attempt)
+        interval_seconds * (backoff_rate**(attempt - 1))
       end
     end
   end

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -5,8 +5,8 @@ module Floe
     module States
       module NonTerminalMixin
         def finish
-          # If this state is failed or the End state set next_state to nil
-          context.next_state = end? || context.failed? ? nil : @next
+          # If this state is failed or this is an end state, next_state to nil
+          context.next_state ||= end? || context.failed? ? nil : @next
 
           super
         end

--- a/spec/workflow/retrier_spec.rb
+++ b/spec/workflow/retrier_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Floe::Workflow::Retrier do
+  let(:payload) { {"ErrorEquals" => ["States.ALL"]} }
+  subject { described_class.new(payload) }
+
+  {1 => 1, 2 => 2, 3 => 4}.each do |attempt, duration|
+    it "try #{attempt} takes #{duration}" do
+      expect(subject.sleep_duration(attempt)).to eq(duration)
+    end
+  end
+
+  # https://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html
+  # For example, say your IntervalSeconds is 3, MaxAttempts is 3, and BackoffRate is 2.
+  # The first retry attempt takes place three seconds after the error occurs.
+  # The second retry takes place six seconds after the first retry attempt.
+  # While the third retry takes place 12 seconds after the second retry attempt.
+  context "with values specified" do
+    let(:payload) do
+      {
+        "IntervalSeconds" => 3,
+        "BackoffRate"     => 2,
+        "MaxAttempts"     => 3,
+        "ErrorEquals"     => ["States.ALL"]
+      }
+    end
+
+    {1 => 3, 2 => 6, 3 => 12}.each do |attempt, duration|
+      it "try #{attempt} takes #{duration}" do
+        expect(subject.sleep_duration(attempt)).to eq(duration)
+      end
+    end
+  end
+end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
           it "resets the retrier if a different exception is raised" do
             expect_run_async(input, :error => "States.Timeout")
-            expect(workflow.current_state).to receive(:wait_until!).twice.with(:seconds => 2)
+            expect(workflow.current_state).to receive(:wait_until!).twice.with(:seconds => 1)
 
             workflow.current_state.run_nonblock!
 
@@ -190,7 +190,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
         it "fails the workflow if the number of retries is greater than MaxAttempts" do
           expect_run_async(input, :error => "States.Timeout")
-          expect(workflow.current_state).to receive(:wait_until!).with(:seconds => 2)
+          expect(workflow.current_state).to receive(:wait_until!).with(:seconds => 1)
 
           2.times { workflow.current_state.run_nonblock! }
 

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -23,7 +23,19 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with an InputPath" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "InputPath" => "$.foo", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+        let(:workflow) do
+          make_workflow(
+            ctx, {
+              "State"        => {
+                "Type"      => "Task",
+                "Resource"  => resource,
+                "InputPath" => "$.foo",
+                "Next"      => "SuccessState"
+              },
+              "SuccessState" => {"Type" => "Succeed"}
+            }
+          )
+        end
 
         it "filters the context passed to the resource" do
           expect_run_async({"bar" => "baz"}, :output => nil)
@@ -33,7 +45,19 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with Parameters" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Parameters" => {"var1.$" => "$.foo.bar"}, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+        let(:workflow) do
+          make_workflow(
+            ctx, {
+              "State"        => {
+                "Type"       => "Task",
+                "Resource"   => resource,
+                "Parameters" => {"var1.$" => "$.foo.bar"},
+                "Next"       => "SuccessState"
+              },
+              "SuccessState" => {"Type" => "Succeed"}
+            }
+          )
+        end
 
         it "passes the interpolated parameters to the resource" do
           expect_run_async({"var1" => "baz"}, :output => nil)
@@ -73,7 +97,19 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "ResultSelector" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultSelector" => {"ip_addrs.$" => "$.response"}, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+        let(:workflow) do
+          make_workflow(
+            ctx, {
+              "State"        => {
+                "Type"           => "Task",
+                "Resource"       => resource,
+                "ResultSelector" => {"ip_addrs.$" => "$.response"},
+                "Next"           => "SuccessState"
+              },
+              "SuccessState" => {"Type" => "Succeed"}
+            }
+          )
+        end
 
         it "filters the results" do
           expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "ABCD\nHELLO\n{\"response\":[\"192.168.1.2\"],\"exit_code\":0}")
@@ -85,7 +121,14 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "ResultPath" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.ip_addrs", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+        let(:workflow) do
+          make_workflow(
+            ctx, {
+              "State"        => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.ip_addrs", "Next" => "SuccessState"},
+              "SuccessState" => {"Type" => "Succeed"}
+            }
+          )
+        end
 
         it "inserts the response into the input" do
           expect_run_async(input, :output => "[\"192.168.1.2\"]")
@@ -100,7 +143,19 @@ RSpec.describe Floe::Workflow::States::Task do
         end
 
         context "setting a Credential" do
-          let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.Credentials", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+          let(:workflow) do
+            make_workflow(
+              ctx, {
+                "State"        => {
+                  "Type"       => "Task",
+                  "Resource"   => resource,
+                  "ResultPath" => "$.Credentials",
+                  "Next"       => "SuccessState"
+                },
+                "SuccessState" => {"Type" => "Succeed"}
+              }
+            )
+          end
 
           it "inserts the response into the workflow credentials" do
             expect_run_async(input, :output => "{\"token\": \"shhh!\"}")
@@ -117,7 +172,20 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "OutputPath" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "ResultPath" => "$.data.ip_addrs", "OutputPath" => output_path, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+        let(:workflow) do
+          make_workflow(
+            ctx, {
+              "State"        => {
+                "Type"       => "Task",
+                "Resource"   => resource,
+                "ResultPath" => "$.data.ip_addrs",
+                "OutputPath" => output_path,
+                "Next"       => "SuccessState"
+              },
+              "SuccessState" => {"Type" => "Succeed"}
+            }
+          )
+        end
 
         context "with the default '$'" do
           let(:output_path) { "$" }
@@ -150,7 +218,21 @@ RSpec.describe Floe::Workflow::States::Task do
     end
 
     describe "Retry" do
-      let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Retry" => retriers, "TimeoutSeconds" => 2, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+      let(:workflow) do
+        make_workflow(
+          ctx, {
+            "State"        => {
+              "Type"     => "Task",
+              "Resource" => resource,
+              "Retry"    => retriers,
+              "Next"     => "SuccessState"
+            }.compact,
+            "FirstState"   => {"Type" => "Succeed"},
+            "SuccessState" => {"Type" => "Succeed"},
+            "FailState"    => {"Type" => "Succeed"}
+          }
+        )
+      end
 
       context "with specific errors" do
         let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 1}] }
@@ -225,7 +307,21 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with a Catch" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Retry" => [{"ErrorEquals" => ["States.Timeout"]}], "Catch" => [{"ErrorEquals" => ["States.ALL"], "Next" => "FailState"}], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+        let(:workflow) do
+          make_workflow(
+            ctx, {
+              "State"        => {
+                "Type"     => "Task",
+                "Resource" => resource,
+                "Retry"    => [{"ErrorEquals" => ["States.Timeout"]}],
+                "Catch"    => [{"ErrorEquals" => ["States.ALL"], "Next" => "FailState"}],
+                "Next"     => "SuccessState"
+              },
+              "FailState"    => {"Type" => "Succeed"},
+              "SuccessState" => {"Type" => "Succeed"}
+            }
+          )
+        end
 
         it "retry preceeds catch" do
           expect_run_async(input, :error => "States.Timeout")
@@ -249,7 +345,20 @@ RSpec.describe Floe::Workflow::States::Task do
 
     describe "Catch" do
       context "with specific errors" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Catch" => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+        let(:workflow) do
+          make_workflow(
+            ctx, {
+              "State"        => {
+                "Type"     => "Task",
+                "Resource" => resource,
+                "Catch"    => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}],
+                "Next"     => "SuccessState"
+              },
+              "FirstState"   => {"Type" => "Succeed"},
+              "SuccessState" => {"Type" => "Succeed"}
+            }
+          )
+        end
 
         it "catches the exception" do
           expect_run_async(input, :output => "States.Timeout", :success => false)
@@ -270,8 +379,29 @@ RSpec.describe Floe::Workflow::States::Task do
         end
       end
 
-      context "with a State.ALL catcher" do
-        let(:workflow) { make_workflow(ctx, {"State" => {"Type" => "Task", "Resource" => resource, "Catch" => [{"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"}, {"ErrorEquals" => ["States.ALL"], "Next" => "FailState"}], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+      context "with a States.ALL catcher" do
+        let(:catchers) do
+          [
+            {"ErrorEquals" => ["States.Timeout"], "Next" => "FirstState"},
+            {"ErrorEquals" => ["States.ALL"],     "Next" => "FailState"}
+          ]
+        end
+        let(:workflow) do
+          make_workflow(
+            ctx,
+            {
+              "State"        => {
+                "Type"     => "Task",
+                "Resource" => resource,
+                "Catch"    => catchers,
+                "Next"     => "SuccessState"
+              },
+              "FirstState"   => {"Type" => "Succeed"},
+              "SuccessState" => {"Type" => "Succeed"},
+              "FailState"    => {"Type" => "Succeed"}
+            }
+          )
+        end
 
         it "catches a more specific exception" do
           expect_run_async(input, :output => "States.Timeout", :success => false)
@@ -300,7 +430,7 @@ RSpec.describe Floe::Workflow::States::Task do
     end
 
     it "with an end state" do
-      workflow = make_workflow(ctx, {"NextState" => {"Type" => "Task", "Resource" => "docker://agrare/hello-world:latest", "End" => true}})
+      workflow = make_workflow(ctx, {"NextState" => {"Type" => "Task", "Resource" => resource, "End" => true}})
       state = workflow.current_state
       expect(state.end?).to be true
     end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Floe::Workflow::States::Task do
         it "passes the whole context to the resource" do
           expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "hello, world!")
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
         end
       end
 
@@ -40,7 +40,7 @@ RSpec.describe Floe::Workflow::States::Task do
         it "filters the context passed to the resource" do
           expect_run_async({"bar" => "baz"}, :output => nil)
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe Floe::Workflow::States::Task do
         it "passes the interpolated parameters to the resource" do
           expect_run_async({"var1" => "baz"}, :output => nil)
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
         end
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe Floe::Workflow::States::Task do
       it "uses the last line as output if it is JSON" do
         expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "ABCD\nHELLO\n{\"response\":[\"192.168.1.2\"]}")
 
-        workflow.current_state.run_nonblock!
+        workflow.run_nonblock
 
         expect(ctx.output).to eq("response" => ["192.168.1.2"])
       end
@@ -82,7 +82,7 @@ RSpec.describe Floe::Workflow::States::Task do
         it "uses the last error line as output if it is JSON" do
           expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "ABCD\nHELLO\n{\"Error\":\"Custom Error\"}", :success => false)
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
           expect(ctx.output).to eq({"Error" => "Custom Error"})
         end
@@ -91,7 +91,7 @@ RSpec.describe Floe::Workflow::States::Task do
       it "returns nil if the output isn't JSON" do
         expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "HELLO")
 
-        workflow.current_state.run_nonblock!
+        workflow.run_nonblock
 
         expect(ctx.output).to eq("foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"})
       end
@@ -114,7 +114,7 @@ RSpec.describe Floe::Workflow::States::Task do
         it "filters the results" do
           expect_run_async({"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}}, :output => "ABCD\nHELLO\n{\"response\":[\"192.168.1.2\"],\"exit_code\":0}")
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
           expect(ctx.output).to eq("ip_addrs" => ["192.168.1.2"])
         end
@@ -133,7 +133,7 @@ RSpec.describe Floe::Workflow::States::Task do
         it "inserts the response into the input" do
           expect_run_async(input, :output => "[\"192.168.1.2\"]")
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
           expect(ctx.output).to eq(
             "foo"      => {"bar" => "baz"},
@@ -160,7 +160,7 @@ RSpec.describe Floe::Workflow::States::Task do
           it "inserts the response into the workflow credentials" do
             expect_run_async(input, :output => "{\"token\": \"shhh!\"}")
 
-            workflow.current_state.run_nonblock!
+            workflow.run_nonblock
 
             expect(workflow.credentials).to include("token" => "shhh!")
             expect(ctx.output).to eq(
@@ -193,7 +193,7 @@ RSpec.describe Floe::Workflow::States::Task do
           it "returns the entire input as the output" do
             expect_run_async(input, :output => "[\"192.168.1.2\"]")
 
-            workflow.current_state.run_nonblock!
+            workflow.run_nonblock
 
             expect(ctx.output).to eq(
               "foo"  => {"bar" => "baz"},
@@ -209,7 +209,7 @@ RSpec.describe Floe::Workflow::States::Task do
           it "filters the output" do
             expect_run_async(input, :output => "[\"192.168.1.2\"]")
 
-            workflow.current_state.run_nonblock!
+            workflow.run_nonblock
 
             expect(ctx.output).to eq("ip_addrs" => ["192.168.1.2"])
           end
@@ -235,46 +235,60 @@ RSpec.describe Floe::Workflow::States::Task do
       end
 
       context "with specific errors" do
-        let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 1}] }
+        let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 2}] }
 
         it "retries if that error is raised" do
-          expect_run_async(input, :error => "States.Timeout")
+          # 1 regular run + 2 retries = 3 times
+          3.times { expect_run_async(input, :error => "States.Timeout") }
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
-          expect(ctx.next_state).to          eq(ctx.state_name)
+          expect(ctx.next_state).to          be_nil
           expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
-          expect(ctx.state["RetryCount"]).to eq(1)
+          expect(ctx.state["RetryCount"]).to eq(3)
+          expect(ctx.state_history.count).to eq(3)
+          expect(ctx.input).to               eq(input)
+          expect(ctx.output).to              eq({"Error" => "States.Timeout"})
+          expect(ctx.status).to              eq("failure")
+          expect(ctx.ended?).to              eq(true)
         end
 
         context "with multiple retriers" do
-          let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 1}, {"ErrorEquals" => ["Exception"], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}] }
+          let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 3}, {"ErrorEquals" => ["Exception"], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}] }
 
           it "resets the retrier if a different exception is raised" do
-            expect_run_async(input, :error => "States.Timeout")
             expect(workflow.current_state).to receive(:wait_until!).twice.with(:seconds => 1)
+            expect(workflow.current_state).to receive(:wait_until!).with(:seconds => 2.0)
 
-            workflow.current_state.run_nonblock!
+            expect_run_async(input, :error => "States.Timeout")
+            workflow.step_nonblock
 
-            expect(ctx.next_state).to          eq(ctx.state_name)
+            expect(ctx.next_state).to          eq("State")
             expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
             expect(ctx.state["RetryCount"]).to eq(1)
 
-            expect(mock_runner).to receive("output").once.and_return("Exception")
+            expect_run_async(input, :error => "States.Timeout")
+            workflow.step_nonblock
 
-            workflow.current_state.run_nonblock!
+            expect(ctx.next_state).to          eq("State")
+            expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
+            expect(ctx.state["RetryCount"]).to eq(2)
 
-            expect(ctx.next_state).to          eq(ctx.state_name)
+            expect_run_async(input, :error => "Exception")
+            workflow.step_nonblock
+
+            expect(ctx.next_state).to          eq("State")
             expect(ctx.state["Retrier"]).to    eq(["Exception"])
             expect(ctx.state["RetryCount"]).to eq(1)
           end
         end
 
         it "fails the workflow if the number of retries is greater than MaxAttempts" do
-          expect_run_async(input, :error => "States.Timeout")
-          expect(workflow.current_state).to receive(:wait_until!).with(:seconds => 1)
+          3.times { expect_run_async(input, :error => "States.Timeout") }
+          expect(workflow.current_state).to receive(:wait_until!).times.with(:seconds => 1)
+          expect(workflow.current_state).to receive(:wait_until!).times.with(:seconds => 2)
 
-          2.times { workflow.current_state.run_nonblock! }
+          3.times { workflow.step_nonblock }
 
           expect(ctx.next_state).to be_nil
           expect(ctx.status).to     eq("failure")
@@ -284,7 +298,7 @@ RSpec.describe Floe::Workflow::States::Task do
         it "fails the workflow if the exception isn't caught" do
           expect_run_async(input, :output => "Exception", :success => false)
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
           expect(ctx.next_state).to be_nil
           expect(ctx.status).to     eq("failure")
@@ -295,14 +309,23 @@ RSpec.describe Floe::Workflow::States::Task do
       context "with a States.ALL retrier" do
         let(:retriers) { [{"ErrorEquals" => ["States.Timeout"]}, {"ErrorEquals" => ["States.ALL"]}] }
 
+        it "retries if that error is raised" do
+          4.times { expect_run_async(input, :error => "States.Timeout") }
+          workflow.run_nonblock
+
+          expect(ctx.next_state).to          be_nil
+          expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
+          expect(ctx.state["RetryCount"]).to eq(4)
+        end
+
         it "retries if any error is raised" do
-          expect_run_async(input, :success => true)
-          expect(mock_runner).to receive("output").once.and_return("ABORT!")
-          expect(mock_runner).to receive("output").once.and_return(nil)
+          4.times { expect_run_async(input, :error => "ABORT!") }
+          workflow.run_nonblock
 
-          2.times { workflow.current_state.run_nonblock! }
-
-          expect(ctx.output).to eq("bar" => {"baz"=>"foo"}, "foo" => {"bar"=>"baz"})
+          expect(ctx.next_state).to          be_nil
+          expect(ctx.state["Retrier"]).to    eq(["States.ALL"])
+          expect(ctx.state["RetryCount"]).to eq(4)
+          expect(ctx.output).to              eq({"Error"=>"ABORT!"})
         end
       end
 
@@ -326,9 +349,9 @@ RSpec.describe Floe::Workflow::States::Task do
         it "retry preceeds catch" do
           expect_run_async(input, :error => "States.Timeout")
 
-          workflow.current_state.run_nonblock!
+          workflow.step_nonblock
 
-          expect(ctx.next_state).to          eq(ctx.state_name)
+          expect(ctx.state_name).to          eq("State")
           expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
           expect(ctx.state["RetryCount"]).to eq(1)
         end
@@ -336,9 +359,10 @@ RSpec.describe Floe::Workflow::States::Task do
         it "invokes the Catch if no retriers match" do
           expect_run_async(input, :error => "Exception")
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
-          expect(ctx.next_state).to eq("FailState")
+          expect(ctx.state_name).to eq("FailState")
+          expect(ctx.output).to     eq({"Error" => "Exception"})
         end
       end
     end
@@ -363,15 +387,15 @@ RSpec.describe Floe::Workflow::States::Task do
         it "catches the exception" do
           expect_run_async(input, :output => "States.Timeout", :success => false)
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
-          expect(ctx.next_state).to eq("FirstState")
+          expect(ctx.state_name).to eq("FirstState")
         end
 
         it "raises if the exception isn't caught" do
           expect_run_async(input, :output => "Exception", :success => false)
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
           expect(ctx.next_state).to be_nil
           expect(ctx.status).to     eq("failure")
@@ -406,17 +430,17 @@ RSpec.describe Floe::Workflow::States::Task do
         it "catches a more specific exception" do
           expect_run_async(input, :output => "States.Timeout", :success => false)
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
-          expect(ctx.next_state).to eq("FirstState")
+          expect(ctx.state_name).to eq("FirstState")
         end
 
         it "catches the exception and transits to the next state" do
           expect_run_async(input, :output => "Exception", :success => false)
 
-          workflow.current_state.run_nonblock!
+          workflow.run_nonblock
 
-          expect(ctx.next_state).to eq("FailState")
+          expect(ctx.state_name).to eq("FailState")
         end
       end
     end


### PR DESCRIPTION
## Dependencies

- [x] https://github.com/ManageIQ/floe/pull/199
- [x] https://github.com/ManageIQ/floe/pull/200 (I can remove if needed)

## Overview

Running the steps was causing setting `workflow#end? = true`, so in some cases it was not retrying. In other cases it was losing the `RetryCount`. I think `state_history` was not properly stored. The most obvious issue here is you can notice the number of times we stub `run_async!` has changed. Think this should shine a light on the issues.

A few cases I increased the retry_count because that caused the errors to be exposed.

## Changes

- Workspace#step_next carries across `RetryCount` when there is an error and it ends up on the same state. I felt like there are a few potential edge cases - hence so many checks around propagating those fields.
- `next_state ||=` fixed issues where we deleted a `next_state` and skipped the retry.
- moving `self` after the retry logic helped us avoid setting `end? = true` which would have `state.run_nonblock!` working but `workspace.run_nonblock` failing.