### PR TITLE
Pass credentials around with context

### DIFF
--- a/exe/floe
+++ b/exe/floe
@@ -57,8 +57,8 @@ credentials =
 
 workflows =
   args.each_slice(2).map do |workflow, input|
-    context = Floe::Workflow::Context.new(opts[:context], :input => input)
-    Floe::Workflow.load(workflow, context, credentials)
+    context = Floe::Workflow::Context.new(opts[:context], :input => input, :credentials => credentials)
+    Floe::Workflow.load(workflow, context)
   end
 
 # run

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -85,12 +85,16 @@ module Floe
       end
     end
 
-    attr_reader :context, :credentials, :payload, :states, :states_by_name, :start_at, :name, :comment
+    attr_reader :context, :payload, :states, :states_by_name, :start_at, :name, :comment
 
-    def initialize(payload, context = nil, credentials = {}, name = nil)
+    def initialize(payload, context = nil, credentials = nil, name = nil)
       payload     = JSON.parse(payload)     if payload.kind_of?(String)
       credentials = JSON.parse(credentials) if credentials.kind_of?(String)
       context     = Context.new(context)    unless context.kind_of?(Context)
+
+      # backwards compatibility
+      # caller should really put credentials into context and not pass that variable
+      context.credentials = credentials if credentials
 
       raise Floe::InvalidWorkflowError, "Missing field \"States\""  if payload["States"].nil?
       raise Floe::InvalidWorkflowError, "Missing field \"StartAt\"" if payload["StartAt"].nil?
@@ -99,7 +103,6 @@ module Floe
       @name        = name
       @payload     = payload
       @context     = context
-      @credentials = credentials || {}
       @comment     = payload["Comment"]
       @start_at    = payload["StartAt"]
 
@@ -175,6 +178,10 @@ module Floe
       @states_by_name[context.state_name]
     end
 
+    # backwards compatibility. Caller should access directly from context
+    def credentials
+      @context.credentials
+    end
     private
 
     def step!

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -3,9 +3,11 @@
 module Floe
   class Workflow
     class Context
+      attr_accessor :credentials
+
       # @param context [Json|Hash] (default, create another with input and execution params)
       # @param input [Hash] (default: {})
-      def initialize(context = nil, input: nil)
+      def initialize(context = nil, input: nil, credentials: {})
         context = JSON.parse(context) if context.kind_of?(String)
 
         input ||= {}
@@ -18,6 +20,8 @@ module Floe
         self["StateHistory"]       ||= []
         self["StateMachine"]       ||= {}
         self["Task"]               ||= {}
+
+        @credentials = credentials || {}
       end
 
       def execution

--- a/lib/floe/workflow/states/input_output_mixin.rb
+++ b/lib/floe/workflow/states/input_output_mixin.rb
@@ -16,8 +16,8 @@ module Floe
 
           results = result_selector.value(context, results) if @result_selector
           if result_path.payload.start_with?("$.Credentials")
-            credentials = result_path.set(workflow.credentials, results)["Credentials"]
-            workflow.credentials.merge!(credentials)
+            credentials = result_path.set(context.credentials, results)["Credentials"]
+            context.credentials.merge!(credentials)
             output = input
           else
             output = result_path.set(input, results)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -36,7 +36,7 @@ module Floe
           super
 
           input          = process_input(input)
-          runner_context = runner.run_async!(resource, input, credentials&.value({}, workflow.credentials), context)
+          runner_context = runner.run_async!(resource, input, credentials&.value({}, workflow.context.credentials), context)
 
           context.state["RunnerContext"] = runner_context
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,8 +59,8 @@ RSpec.configure do |config|
 
   # factory methods
 
-  def make_workflow(ctx, payload, creds: {})
-    Floe::Workflow.new(make_payload(payload), ctx, creds)
+  def make_workflow(ctx, payload)
+    Floe::Workflow.new(make_payload(payload), ctx)
   end
 
   def make_payload(states)

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Floe::Workflow::Context do
       expect(ctx.execution["api"]).to eq("http://localhost/")
       expect(ctx.state).not_to eq(nil)
     end
+
+    it "defaults credentials to {}" do
+      expect(ctx.credentials).to eq({})
+    end
   end
 
   describe "#started?" do

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Floe::Workflow::States::Pass do
 
       it "sets the result in Credentials" do
         state.run_nonblock!
-        expect(workflow.credentials).to include({"user" => "luggage", "password" => "1234"})
+        expect(ctx.credentials).to include({"user" => "luggage", "password" => "1234"})
         expect(ctx.next_state).to eq("SuccessState")
       end
     end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Floe::Workflow::States::Task do
 
             workflow.run_nonblock
 
-            expect(workflow.credentials).to include("token" => "shhh!")
+            expect(ctx.credentials).to include("token" => "shhh!")
             expect(ctx.output).to eq(
               "foo" => {"bar" => "baz"},
               "bar" => {"baz" => "foo"}

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -16,11 +16,6 @@ RSpec.describe Floe::Workflow do
       expect(ctx.ended?).to eq(false)
     end
 
-    it "sets credentials to empty hash if nil passed in" do
-      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}}, :creds => nil)
-      expect(workflow.credentials).to eq({})
-    end
-
     it "raises an exception for missing States" do
       payload = {"StartAt" => "Nothing"}
 
@@ -366,12 +361,12 @@ RSpec.describe Floe::Workflow do
 
   describe "#comment" do
     it "handles no comment" do
-      workflow = Floe::Workflow.new({"StartAt" => "First", "States" => {"First" => {"Type" => "Succeed"}}}, {})
+      workflow = Floe::Workflow.new({"StartAt" => "First", "States" => {"First" => {"Type" => "Succeed"}}})
       expect(workflow.comment).to be nil
     end
 
     it "handles a comment" do
-      workflow = Floe::Workflow.new({"StartAt" => "First", "Comment" => "great stuff", "States" => {"First" => {"Type" => "Succeed"}}}, {})
+      workflow = Floe::Workflow.new({"StartAt" => "First", "Comment" => "great stuff", "States" => {"First" => {"Type" => "Succeed"}}})
       expect(workflow.comment).to eq("great stuff")
     end
   end


### PR DESCRIPTION
Overview
========

My higher goal is to have `State` not store the `workspace`, `context`, nor `credentials`. See #210 

We store `Context` and `Credentials` separately in the database. So it makes sense to keep them separate.

But having a single container that holds all runtime state simplifies matters.

Before
======

Passed `Context` and `Credentials` separately.
The `State` accessed them using `State#workspace#context` and `State#workspace#credentials`.

If we go towards removing `State#workspace`, `run_nonblock(context, credentials)` will provide that data.

After
=====

`Context` contains the context and `Context#to_h` returns the same value. But `Context#credentials` will contain the sensitive credentials.

The `State` accesses them using `State#workspace#context` and `State#workspace#context#credentials.

If we go towards removing `State#workspace`, `run_nonblock(context)` will be able to provide that data.

Compromise
==========

Would have liked to remove `Workspace#context` and `Workspace#initialize(..., context`), but left it in there until we update `manageiq-providers-workspace`.
