### PR TITLE
Simpler State#long_name

### DIFF
--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -103,7 +103,7 @@ module Floe
       end
 
       def long_name
-        "#{self.class.name.split("::").last}:#{name}"
+        "#{payload["Type"]}:#{name}"
       end
 
       private


### PR DESCRIPTION
Since the class name was derived from the type, just use the type variable

(this also makes it easier to output this information if we were logging without the class instantiated)

Logs have the same before/after