### PR TITLE
State only modifies Context#state - prep for Map/Parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ until running_workflows.empty?
   ready_workflows = Floe::Workflow.wait(running_workflows)
   # Step through the ready workflows until they would block
   ready_workflows.each do |workflow|
-    loop while workflow.step_nonblock == 0
+    workflow.run_nonblock
   end
   # Remove any finished workflows from the list of running_workflows
   running_workflows.reject!(&:end?)

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -159,6 +159,7 @@ module Floe
 
       context.state["Name"] = start_at
       context.state["Input"] = context.execution["Input"].dup
+      context.execution["StartTime"] = Time.now.utc.iso8601
 
       self
     end

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -84,6 +84,16 @@ module Floe
         status == "success"
       end
 
+      def state_started?
+        state.key?("EnteredTime")
+      end
+
+      # State#running? also checks docker to see if it is running.
+      # You possibly want to use that instead
+      def state_finished?
+        state.key?("FinishedTime")
+      end
+
       def state=(val)
         @context["State"] = val
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -83,7 +83,7 @@ module Floe
       end
 
       def started?
-        context.state.key?("EnteredTime")
+        context.state_started?
       end
 
       def ready?
@@ -91,7 +91,7 @@ module Floe
       end
 
       def finished?
-        context.state.key?("FinishedTime")
+        context.state_finished?
       end
 
       def waiting?

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -52,11 +52,8 @@ module Floe
       end
 
       def start(_input)
-        start_time = Time.now.utc.iso8601
-
-        context.execution["StartTime"] ||= start_time
         context.state["Guid"]            = SecureRandom.uuid
-        context.state["EnteredTime"]     = start_time
+        context.state["EnteredTime"]     = Time.now.utc.iso8601
 
         logger.info("Running state: [#{long_name}] with input [#{context.input}]...")
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -60,12 +60,10 @@ module Floe
 
       def finish
         finished_time     = Time.now.utc
-        finished_time_iso = finished_time.iso8601
         entered_time      = Time.parse(context.state["EnteredTime"])
 
-        context.state["FinishedTime"] ||= finished_time_iso
+        context.state["FinishedTime"] ||= finished_time.iso8601
         context.state["Duration"]       = finished_time - entered_time
-        context.execution["EndTime"]    = finished_time_iso if context.next_state.nil?
 
         level = context.output&.[]("Error") ? :error : :info
         logger.public_send(level, "Running state: [#{long_name}] with input [#{context.input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.output}]")

--- a/spec/workflow/state_spec.rb
+++ b/spec/workflow/state_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Floe::Workflow::State do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
-  let(:state)    { workflow.current_state }
+  let(:state)    { workflow.start_workflow.current_state }
   # picked a state that doesn't instantly finish
   let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Floe::Workflow::States::Choice do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
-  let(:state)    { workflow.current_state }
+  let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) do
     make_workflow(
       ctx, {

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Floe::Workflow::States::Fail do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
-  let(:state)    { workflow.current_state }
+  let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) do
     make_workflow(
       ctx, {

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Floe::Workflow::States::Pass do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
-  let(:state)    { workflow.current_state }
+  let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) { make_workflow(ctx, payload) }
   let(:payload)  do
     {

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Floe::Workflow::States::Succeed do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
-  let(:state)    { workflow.current_state }
+  let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) { make_workflow(ctx, {"SuccessState" => {"Type" => "Succeed"}}) }
 
   it "#end?" do

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Floe::Workflow::States::Pass do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
-  let(:state)    { workflow.current_state }
+  let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
   describe "#end?" do


### PR DESCRIPTION
In prep for `Map`, have State only modify its own data in `Context`. (Followup will pass `context` into `State` methods, so the caller (i.e.: `Map`, `Parallel`, or `Workspace`) will determine the context and act accordingly.

1. Don't modify the context in `Workflow.new` - instead modify it in the first step.
2. `State#start` only modifies `Context#state` and not `Context#execute` - instead `Workflow` is responsible for `execute`.
3. `State#finish` only modified `Context#state` and not `Context#execute` - instead `Workflow` is responsible for that.
