### PR TITLE
State does not store workflow or context

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -7,6 +7,7 @@ require_relative "floe/logging"
 
 require_relative "floe/runner"
 
+require_relative "floe/validator"
 require_relative "floe/workflow"
 require_relative "floe/workflow/catcher"
 require_relative "floe/workflow/choice_rule"

--- a/lib/floe/validator.rb
+++ b/lib/floe/validator.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Floe
+  class Validator
+    # @attr_reader [Array<String>] state_names list of valid state names
+    attr_accessor :state_names
+    # @attr_reader [String] state_name currently processed state. nil for workflow.
+    attr_reader :state_name
+    # @attr_reader [String] rule currently processed rule. e.g.: "Choice"
+    attr_reader :rule
+    # @attr_reader [Boolean] children. true when processing a choice sub children (level 2+)
+    attr_reader :children
+
+    def initialize(state_names = [], state_name = nil, rule: nil, children: nil)
+      @state_names = state_names
+      @state_name  = state_name
+      @rule        = rule
+      @children    = children
+    end
+
+    # @param [String|Class] klass typically passing a klass, but if the types are complicated, pass a string description (used by ChoiceRule)
+    def validate_field!(field_name, field_value, klass: String, force: false)
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires field \"#{field_name}\"" if field_value.nil?
+
+      return field_value if (klass.kind_of?(String) || (field_value.kind_of?(klass) && !field_value.empty?)) && !force
+
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires #{klass} field \"#{field_name}\" got [#{field_value}]"
+    end
+
+    def validate_state_ref!(field_name, field_value, optional: false)
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires field \"#{field_name}\"" if field_value.nil? && !optional
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires field \"#{field_name}\" to be in \"States\" list but got [#{field_value}]" if field_value && !state?(field_value)
+
+      field_value
+    end
+
+    def validate_list!(field_name, field_value, klass: Array, optional: false)
+      return field_value if optional && field_value.nil?
+      return field_value if field_value.kind_of?(klass) && !field_value.empty?
+
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires non-empty #{klass.name} field \"#{field_name}\""
+    end
+
+    def reject!(field_name, field_value)
+      raise Floe::InvalidWorkflowError, "#{src_reference} does not allow field \"#{field_name}\" with value [#{field_value}]" if field_value
+    end
+
+    def for_state(name, rule: nil)
+      self.class.new(state_names, name, :rule => rule)
+    end
+
+    def for_children
+      self.class.new(state_names, state_name, :rule => rule, :children => true)
+    end
+
+    private
+
+    def state?(name)
+      @state_names.include?(name)
+    end
+
+    def src_reference
+      "#{state_name ? "State [#{state_name}]" : "Workflow"}#{" " if rule}#{rule}#{" child" if children}"
+    end
+  end
+end

--- a/lib/floe/validator.rb
+++ b/lib/floe/validator.rb
@@ -45,6 +45,10 @@ module Floe
       raise Floe::InvalidWorkflowError, "#{src_reference} does not allow field \"#{field_name}\" with value [#{field_value}]" if field_value
     end
 
+    def with_states(state_names)
+      self.class.new(state_names, state_name, :rule => rule)
+    end
+
     def for_state(name, rule: nil)
       self.class.new(state_names, name, :rule => rule)
     end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -124,7 +124,7 @@ module Floe
     def step_nonblock
       return Errno::EPERM if end?
 
-      result = current_state.run_nonblock!
+      result = current_state.run_nonblock!(context)
       return result if result != 0
 
       # if it completed the step
@@ -136,7 +136,7 @@ module Floe
 
     # if this hasn't started (and we have no current_state yet), assume it is ready
     def step_nonblock_wait(timeout: nil)
-      context.started? ? current_state.wait(:timeout => timeout) : 0
+      context.started? ? current_state.wait(context, :timeout => timeout) : 0
     end
 
     # if this hasn't started (and we have no current_state yet), assume it is ready
@@ -149,7 +149,7 @@ module Floe
     end
 
     def wait_until
-      current_state.wait_until
+      current_state.wait_until(context)
     end
 
     def status

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -141,11 +141,11 @@ module Floe
 
     # if this hasn't started (and we have no current_state yet), assume it is ready
     def step_nonblock_ready?
-      !context.started? || current_state.ready?
+      !context.started? || current_state.ready?(context)
     end
 
     def waiting?
-      current_state.waiting?
+      current_state.waiting?(context)
     end
 
     def wait_until

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -108,6 +108,8 @@ module Floe
 
       @states         = states.map { |state_name, state| State.build!(self, state_name, state) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
+    rescue Floe::InvalidWorkflowError
+      raise
     rescue => err
       raise Floe::InvalidWorkflowError, err.message
     end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -106,7 +106,7 @@ module Floe
       @comment     = payload["Comment"]
       @start_at    = validator.validate_state_ref!("StartAt", payload["StartAt"])
 
-      @states         = states.map { |state_name, state| State.build!(self, state_name, state) }
+      @states         = states.map { |state_name, state| State.build!(validator.for_state(state_name), state_name, state) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
     rescue Floe::InvalidWorkflowError
       raise

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -85,7 +85,7 @@ module Floe
       end
     end
 
-    attr_reader :context, :payload, :states, :states_by_name, :start_at, :name, :comment, :validator
+    attr_reader :context, :payload, :states, :states_by_name, :start_at, :name, :comment
 
     def initialize(payload, context = nil, credentials = nil, name = nil)
       payload     = JSON.parse(payload)     if payload.kind_of?(String)
@@ -96,9 +96,9 @@ module Floe
       # caller should really put credentials into context and not pass that variable
       context.credentials = credentials if credentials
 
-      @validator  = Validator.new
-      states      = validator.validate_list!("States", payload["States"], :klass => Hash)
-      @validator.state_names = states.keys
+      validator    = Validator.new
+      states       = validator.validate_list!("States", payload["States"], :klass => Hash)
+      validator    = validator.with_states(states.keys)
 
       @name        = name
       @payload     = payload

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -5,11 +5,11 @@ module Floe
     class Catcher
       attr_reader :error_equals, :next, :result_path
 
-      def initialize(payload)
+      def initialize(validator, payload)
         @payload = payload
 
-        @error_equals = payload["ErrorEquals"]
-        @next         = payload["Next"]
+        @error_equals = validator.validate_list!("ErrorEquals", payload["ErrorEquals"])
+        @next         = validator.validate_state_ref!("Next", payload["Next"])
         @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
       end
     end

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -4,31 +4,33 @@ module Floe
   class Workflow
     class ChoiceRule
       class << self
-        def build(payload)
+        def build(validator, payload)
           if (sub_payloads = payload["Not"])
-            Floe::Workflow::ChoiceRule::Not.new(payload, build_children([sub_payloads]))
+            Floe::Workflow::ChoiceRule::Not.new(validator, payload, build_children(validator.for_children, [sub_payloads]))
           elsif (sub_payloads = payload["And"])
-            Floe::Workflow::ChoiceRule::And.new(payload, build_children(sub_payloads))
+            Floe::Workflow::ChoiceRule::And.new(validator, payload, build_children(validator.for_children, sub_payloads))
           elsif (sub_payloads = payload["Or"])
-            Floe::Workflow::ChoiceRule::Or.new(payload, build_children(sub_payloads))
+            Floe::Workflow::ChoiceRule::Or.new(validator, payload, build_children(validator.for_children, sub_payloads))
           else
-            Floe::Workflow::ChoiceRule::Data.new(payload)
+            Floe::Workflow::ChoiceRule::Data.new(validator, payload)
           end
         end
 
-        def build_children(sub_payloads)
-          sub_payloads.map { |payload| build(payload) }
+        def build_children(validator, sub_payloads)
+          sub_payloads.map { |payload| build(validator, payload) }
         end
       end
 
       attr_reader :next, :payload, :variable, :children
 
-      def initialize(payload, children = nil)
+      def initialize(validator, payload, children = nil)
         @payload   = payload
         @children  = children
 
         @next     = payload["Next"]
         @variable = payload["Variable"]
+
+        validate_next!(validator)
       end
 
       def true?(*)
@@ -36,6 +38,16 @@ module Floe
       end
 
       private
+
+      def validate_next!(validator)
+        if validator.children
+          # next is not allowed for lower levels
+          validator.reject!("Next", @next)
+        else
+          # next is required for the top level
+          validator.validate_state_ref!("Next", @next)
+        end
+      end
 
       def variable_value(context, input)
         Path.value(variable, context, input)

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -5,10 +5,10 @@ module Floe
     class Retrier
       attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate
 
-      def initialize(payload)
+      def initialize(validator, payload)
         @payload = payload
 
-        @error_equals     = payload["ErrorEquals"]
+        @error_equals     = validator.validate_list!("ErrorEquals", payload["ErrorEquals"])
         @interval_seconds = payload["IntervalSeconds"] || 1.0
         @max_attempts     = payload["MaxAttempts"] || 3
         @backoff_rate     = payload["BackoffRate"] || 2.0

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -36,7 +36,7 @@ module Floe
         raise Floe::InvalidWorkflowError, "State name [#{name[..79]}...] must be less than or equal to 80 characters" if name.length > 80
       end
 
-      def wait(timeout: nil)
+      def wait(context, timeout: nil)
         start = Time.now.utc
 
         loop do
@@ -48,7 +48,7 @@ module Floe
       end
 
       # @return for incomplete Errno::EAGAIN, for completed 0
-      def run_nonblock!
+      def run_nonblock!(context)
         start(context) unless context.state_started?
         return Errno::EAGAIN unless ready?(context)
 
@@ -91,7 +91,7 @@ module Floe
         context.state["WaitUntil"] && Time.now.utc <= Time.parse(context.state["WaitUntil"])
       end
 
-      def wait_until
+      def wait_until(context)
         context.state["WaitUntil"] && Time.parse(context.state["WaitUntil"])
       end
 
@@ -101,7 +101,7 @@ module Floe
 
       private
 
-      def wait_until!(seconds: nil, time: nil)
+      def wait_until!(context, seconds: nil, time: nil)
         context.state["WaitUntil"] =
           if seconds
             (Time.parse(context.state["EnteredTime"]) + seconds).iso8601

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -40,7 +40,7 @@ module Floe
         start = Time.now.utc
 
         loop do
-          return 0             if ready?
+          return 0             if ready?(context)
           return Errno::EAGAIN if timeout && (timeout.zero? || Time.now.utc - start > timeout)
 
           sleep(1)
@@ -50,7 +50,7 @@ module Floe
       # @return for incomplete Errno::EAGAIN, for completed 0
       def run_nonblock!
         start(context.input) unless context.state_started?
-        return Errno::EAGAIN unless ready?
+        return Errno::EAGAIN unless ready?(context)
 
         finish
       end
@@ -79,11 +79,15 @@ module Floe
         workflow.context
       end
 
-      def ready?
-        !context.state_started? || !running?
+      def ready?(context)
+        !context.state_started? || !running?(context)
       end
 
-      def waiting?
+      def running?(context)
+        raise NotImplementedError, "Must be implemented in a subclass"
+      end
+
+      def waiting?(context)
         context.state["WaitUntil"] && Time.now.utc <= Time.parse(context.state["WaitUntil"])
       end
 

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -21,10 +21,9 @@ module Floe
         end
       end
 
-      attr_reader :workflow, :comment, :name, :type, :payload
+      attr_reader :comment, :name, :type, :payload
 
       def initialize(workflow, name, payload)
-        @workflow = workflow
         @name     = name
         @payload  = payload
         @type     = payload["Type"]
@@ -73,10 +72,6 @@ module Floe
         logger.public_send(level, "Running state: [#{long_name}] with input [#{context.input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.output}]")
 
         0
-      end
-
-      def context
-        workflow.context
       end
 
       def ready?(context)

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -49,20 +49,20 @@ module Floe
 
       # @return for incomplete Errno::EAGAIN, for completed 0
       def run_nonblock!
-        start(context.input) unless context.state_started?
+        start(context) unless context.state_started?
         return Errno::EAGAIN unless ready?(context)
 
-        finish
+        finish(context)
       end
 
-      def start(_input)
+      def start(context)
         context.state["Guid"]        = SecureRandom.uuid
         context.state["EnteredTime"] = Time.now.utc.iso8601
 
         logger.info("Running state: [#{long_name}] with input [#{context.input}]...")
       end
 
-      def finish
+      def finish(context)
         finished_time     = Time.now.utc
         entered_time      = Time.parse(context.state["EnteredTime"])
 

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -6,8 +6,7 @@ module Floe
       include Logging
 
       class << self
-        def build!(workflow, name, payload)
-          validator = workflow.validator.for_state(name)
+        def build!(validator, name, payload)
           state_type = payload["Type"]
           validator.validate_field!("Type", payload["Type"])
 
@@ -17,20 +16,19 @@ module Floe
             validator.reject!("Type", state_type)
           end
 
-          klass.new(workflow, name, payload)
+          klass.new(validator, name, payload)
         end
       end
 
       attr_reader :comment, :name, :type, :payload
 
-      def initialize(workflow, name, payload)
+      def initialize(validator, name, payload)
         @name     = name
         @payload  = payload
         @type     = payload["Type"]
         @comment  = payload["Comment"]
 
         # We should be using build so this should never get hit
-        validator = workflow.validator.for_state(name)
         validator.validate_field!("Type", @type)
         raise Floe::InvalidWorkflowError, "State name [#{name[..79]}...] must be less than or equal to 80 characters" if name.length > 80
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -49,7 +49,7 @@ module Floe
 
       # @return for incomplete Errno::EAGAIN, for completed 0
       def run_nonblock!
-        start(context.input) unless started?
+        start(context.input) unless context.state_started?
         return Errno::EAGAIN unless ready?
 
         finish
@@ -79,16 +79,8 @@ module Floe
         workflow.context
       end
 
-      def started?
-        context.state_started?
-      end
-
       def ready?
-        !started? || !running?
-      end
-
-      def finished?
-        context.state_finished?
+        !context.state_started? || !running?
       end
 
       def waiting?

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -29,7 +29,7 @@ module Floe
           super
         end
 
-        def running?
+        def running?(_)
           false
         end
 

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -20,7 +20,7 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def finish
+        def finish(context)
           output     = output_path.value(context, context.input)
           next_state = choices.detect { |choice| choice.true?(context, output) }&.next || default
 

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -6,14 +6,12 @@ module Floe
       class Choice < Floe::Workflow::State
         attr_reader :choices, :default, :input_path, :output_path
 
-        def initialize(workflow, name, payload)
+        def initialize(validator, name, payload)
           super
-
-          validator = workflow.validator.for_state(name)
 
           validator.validate_list!("Choices", payload["Choices"])
 
-          @choices = payload["Choices"].map { |choice| ChoiceRule.build(workflow.validator.for_state(name, :rule => "ChoiceRule"), choice) }
+          @choices = payload["Choices"].map { |choice| ChoiceRule.build(validator.for_state(name, :rule => "ChoiceRule"), choice) }
           @default = validator.validate_state_ref!("Default", payload["Default"])
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -9,10 +9,12 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          validate_state!
+          validator = workflow.validator.for_state(name)
+
+          validator.validate_list!("Choices", payload["Choices"])
 
           @choices = payload["Choices"].map { |choice| ChoiceRule.build(choice) }
-          @default = payload["Default"]
+          @default = validator.validate_state_ref!("Default", payload["Default"])
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
@@ -33,22 +35,6 @@ module Floe
 
         def end?
           false
-        end
-
-        private
-
-        def validate_state!
-          validate_state_choices!
-          validate_state_default!
-        end
-
-        def validate_state_choices!
-          raise Floe::InvalidWorkflowError, "Choice state must have \"Choices\"" unless payload.key?("Choices")
-          raise Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array" unless payload["Choices"].kind_of?(Array) && !payload["Choices"].empty?
-        end
-
-        def validate_state_default!
-          raise Floe::InvalidWorkflowError, "\"Default\" not in \"States\"" unless workflow.payload["States"].include?(payload["Default"])
         end
       end
     end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -13,7 +13,7 @@ module Floe
 
           validator.validate_list!("Choices", payload["Choices"])
 
-          @choices = payload["Choices"].map { |choice| ChoiceRule.build(choice) }
+          @choices = payload["Choices"].map { |choice| ChoiceRule.build(workflow.validator.for_state(name, :rule => "ChoiceRule"), choice) }
           @default = validator.validate_state_ref!("Default", payload["Default"])
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -15,7 +15,7 @@ module Floe
           @error_path = Path.new(payload["ErrorPath"]) if payload["ErrorPath"]
         end
 
-        def finish
+        def finish(context)
           context.next_state = nil
           # TODO: support intrinsic functions here
           # see https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-fail-state.html

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -27,7 +27,7 @@ module Floe
           super
         end
 
-        def running?
+        def running?(_)
           false
         end
 

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -6,7 +6,7 @@ module Floe
       class Fail < Floe::Workflow::State
         attr_reader :cause, :error
 
-        def initialize(workflow, name, payload)
+        def initialize(validator, name, payload)
           super
 
           @cause      = payload["Cause"]

--- a/lib/floe/workflow/states/input_output_mixin.rb
+++ b/lib/floe/workflow/states/input_output_mixin.rb
@@ -4,23 +4,23 @@ module Floe
   class Workflow
     module States
       module InputOutputMixin
-        def process_input(input)
-          input = input_path.value(context, input)
+        def process_input(context)
+          input = input_path.value(context, context.input)
           input = parameters.value(context, input) if parameters
           input
         end
 
-        def process_output(input, results)
-          return input if results.nil?
+        def process_output(context, results)
+          return context.input.dup if results.nil?
           return if output_path.nil?
 
           results = result_selector.value(context, results) if @result_selector
           if result_path.payload.start_with?("$.Credentials")
             credentials = result_path.set(context.credentials, results)["Credentials"]
             context.credentials.merge!(credentials)
-            output = input
+            output = context.input.dup
           else
-            output = result_path.set(input, results)
+            output = result_path.set(context.input.dup, results)
           end
 
           output_path.value(context, output)

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -4,7 +4,7 @@ module Floe
   class Workflow
     module States
       module NonTerminalMixin
-        def finish
+        def finish(context)
           # If this state is failed or this is an end state, next_state to nil
           context.next_state ||= end? || context.failed? ? nil : @next
 

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -12,8 +12,7 @@ module Floe
         end
 
         def validate_state_next!
-          raise Floe::InvalidWorkflowError, "Missing \"Next\" field in state [#{name}]" if @next.nil? && !@end
-          raise Floe::InvalidWorkflowError, "\"Next\" [#{@next}] not in \"States\" for state [#{name}]" if @next && !workflow.payload["States"].key?(@next)
+          workflow.validator.for_state(name).validate_state_ref!("Next", @next, :optional => @end)
         end
       end
     end

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -10,10 +10,6 @@ module Floe
 
           super
         end
-
-        def validate_state_next!
-          workflow.validator.for_state(name).validate_state_ref!("Next", @next, :optional => @end)
-        end
       end
     end
   end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -29,7 +29,7 @@ module Floe
           super
         end
 
-        def running?
+        def running?(_)
           false
         end
 

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -25,7 +25,7 @@ module Floe
         end
 
         def finish(context)
-          context.output = process_output(context.input.dup, result)
+          context.output = process_output(context, result)
           super
         end
 

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -12,16 +12,16 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @next        = payload["Next"]
+          validator = workflow.validator.for_state(name)
+
           @end         = !!payload["End"]
+          @next        = validator.validate_state_ref!("Next", payload["Next"], :optional => @end)
           @result      = payload["Result"]
 
           @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]
           @input_path  = Path.new(payload.fetch("InputPath", "$"))
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
-
-          validate_state!
         end
 
         def finish
@@ -35,12 +35,6 @@ module Floe
 
         def end?
           @end
-        end
-
-        private
-
-        def validate_state!
-          validate_state_next!
         end
       end
     end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -9,10 +9,8 @@ module Floe
 
         attr_reader :end, :next, :result, :parameters, :input_path, :output_path, :result_path
 
-        def initialize(workflow, name, payload)
+        def initialize(validator, name, payload)
           super
-
-          validator = workflow.validator.for_state(name)
 
           @end         = !!payload["End"]
           @next        = validator.validate_state_ref!("Next", payload["Next"], :optional => @end)

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -24,7 +24,7 @@ module Floe
           @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
         end
 
-        def finish
+        def finish(context)
           context.output = process_output(context.input.dup, result)
           super
         end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -12,7 +12,7 @@ module Floe
           super
         end
 
-        def running?
+        def running?(_)
           false
         end
 

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -6,7 +6,7 @@ module Floe
       class Succeed < Floe::Workflow::State
         attr_reader :input_path, :output_path
 
-        def finish
+        def finish(context)
           context.next_state = nil
           context.output     = context.input
           super

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -11,10 +11,8 @@ module Floe
                     :result_selector, :resource, :timeout_seconds, :retry, :catch,
                     :input_path, :output_path, :result_path
 
-        def initialize(workflow, name, payload)
+        def initialize(validator, name, payload)
           super
-
-          validator = workflow.validator.for_state(name)
 
           validator.validate_list!("Retry", payload["Retry"], :optional => true)
           validator.validate_list!("Catch", payload["Catch"], :optional => true)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -100,10 +100,10 @@ module Floe
 
           return if context["State"]["RetryCount"] > retrier.max_attempts
 
-          wait_until!(:seconds => retrier.sleep_duration(context["State"]["RetryCount"]))
+          wait_until!(context, :seconds => retrier.sleep_duration(context["State"]["RetryCount"]))
           context.next_state = context.state_name
           context.output     = error
-          logger.info("Running state: [#{long_name}] with input [#{context.input}] got error[#{context.output}]...Retry - delay: #{wait_until}")
+          logger.info("Running state: [#{long_name}] with input [#{context.input}] got error[#{context.output}]...Retry - delay: #{wait_until(context)}")
           true
         end
 

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -59,8 +59,8 @@ module Floe
           runner.cleanup(context.state["RunnerContext"])
         end
 
-        def running?
-          return true if waiting?
+        def running?(context)
+          return true if waiting?(context)
 
           runner.status!(context.state["RunnerContext"])
           runner.running?(context.state["RunnerContext"])

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -35,16 +35,16 @@ module Floe
           @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
         end
 
-        def start(input)
+        def start(context)
           super
 
-          input          = process_input(input)
-          runner_context = runner.run_async!(resource, input, credentials&.value({}, workflow.context.credentials), context)
+          input          = process_input(context.input)
+          runner_context = runner.run_async!(resource, input, credentials&.value({}, context.credentials), context)
 
           context.state["RunnerContext"] = runner_context
         end
 
-        def finish
+        def finish(context)
           output = runner.output(context.state["RunnerContext"])
 
           if success?

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -38,7 +38,7 @@ module Floe
         def start(context)
           super
 
-          input          = process_input(context.input)
+          input          = process_input(context)
           runner_context = runner.run_async!(resource, input, credentials&.value({}, context.credentials), context)
 
           context.state["RunnerContext"] = runner_context
@@ -49,7 +49,7 @@ module Floe
 
           if success?(context)
             output = parse_output(output)
-            context.output = process_output(context.input.dup, output)
+            context.output = process_output(context, output)
           else
             error = parse_error(output)
             retry_state!(context, error) || catch_error!(context, error) || fail_workflow!(context, error)

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -43,8 +43,8 @@ module Floe
           super
         end
 
-        def running?
-          waiting?
+        def running?(context)
+          waiting?(context)
         end
 
         def end?

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -32,6 +32,7 @@ module Floe
           input = input_path.value(context, context.input)
 
           wait_until!(
+            context,
             :seconds => seconds_path ? seconds_path.value(context, input).to_i : seconds,
             :time    => timestamp_path ? timestamp_path.value(context, input) : timestamp
           )

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -10,10 +10,8 @@ module Floe
 
         attr_reader :input_path, :seconds, :seconds_path, :timestamp, :timestamp_path, :output_path
 
-        def initialize(workflow, name, payload)
+        def initialize(validator, name, payload)
           super
-
-          validator = workflow.validator.for_state(name)
 
           @end            = !!payload["End"]
           @next           = validator.validate_state_ref!("Next", payload["Next"], :optional => @end)

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -26,7 +26,7 @@ module Floe
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
         end
 
-        def start(input)
+        def start(context)
           super
 
           input = input_path.value(context, context.input)
@@ -37,7 +37,7 @@ module Floe
           )
         end
 
-        def finish
+        def finish(context)
           input          = input_path.value(context, context.input)
           context.output = output_path.value(context, input)
           super

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -1,11 +1,24 @@
 RSpec.describe Floe::Workflow::ChoiceRule do
+  let(:name)      { "FirstMatchState" }
+  let(:workflow)  { make_workflow({}, {name => {"Type" => "Choice", "Choices" => [payload], "Default" => name}}) }
+
+  describe ".build" do
+    let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
+    let(:subject) { described_class.build(payload) }
+
+    it "works with valid next" do
+      subject
+    end
+  end
+
   describe "#true?" do
     let(:subject) { described_class.build(payload).true?(context, input) }
     let(:context) { {} }
 
-    context "Abstract Interface" do
+    context "with abstract top level class" do
+      let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
       let(:input) { {} }
-      let(:subject) { described_class.new({}).true?(context, input) }
+      let(:subject) { described_class.new(payload).true?(context, input) }
       it "is not implemented" do
         expect { subject }.to raise_exception(NotImplementedError)
       end
@@ -84,7 +97,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsNull" do
-        let(:payload) { {"Variable" => "$.foo", "IsNull" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsNull" => true, "Next" => "FirstMatchState"} }
 
         context "with null" do
           let(:input) { {"foo" => nil} }
@@ -104,7 +117,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsPresent" do
-        let(:payload) { {"Variable" => "$.foo", "IsPresent" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsPresent" => true, "Next" => "FirstMatchState"} }
 
         context "with null" do
           let(:input) { {"foo" => nil} }
@@ -124,7 +137,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsNumeric" do
-        let(:payload) { {"Variable" => "$.foo", "IsNumeric" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsNumeric" => true, "Next" => "FirstMatchState"} }
 
         context "with an integer" do
           let(:input) { {"foo" => 1} }
@@ -152,7 +165,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsString" do
-        let(:payload) { {"Variable" => "$.foo", "IsString" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsString" => true, "Next" => "FirstMatchState"} }
 
         context "with a string" do
           let(:input) { {"foo" => "bar"} }
@@ -172,7 +185,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsBoolean" do
-        let(:payload) { {"Variable" => "$.foo", "IsBoolean" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsBoolean" => true, "Next" => "FirstMatchState"} }
 
         context "with a boolean" do
           let(:input) { {"foo" => true} }
@@ -192,7 +205,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsTimestamp" do
-        let(:payload) { {"Variable" => "$.foo", "IsTimestamp" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsTimestamp" => true, "Next" => "FirstMatchState"} }
 
         context "with a timestamp" do
           let(:input) { {"foo" => "2016-03-14T01:59:00Z"} }

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe Floe::Workflow::ChoiceRule do
   # these are needed for post validation
   let(:name)      { "FirstMatchState" }
   let(:workflow)  { make_workflow({}, {name => {"Type" => "Choice", "Choices" => [payload], "Default" => name}}) }
-  let(:validator) { workflow.validator }
+  let(:choice)    { workflow.start_workflow.current_state.choices.first }
 
   describe ".build" do
     let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
-    let(:subject) { described_class.build(validator, payload) }
+    let(:subject) { choice }
 
     it "works with valid next" do
       subject
@@ -26,13 +26,14 @@ RSpec.describe Floe::Workflow::ChoiceRule do
   end
 
   describe "#true?" do
-    let(:subject) { described_class.build(validator, payload).true?(context, input) }
+    let(:subject) { choice.true?(context, input) }
     let(:context) { {} }
 
+    # this test is only for code coverage
     context "with abstract top level class" do
       let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
       let(:input) { {} }
-      let(:subject) { described_class.new(validator, payload).true?(context, input) }
+      let(:subject) { described_class.new(double(:children => false, :validate_state_ref! => nil), payload).true?(context, input) }
       it "is not implemented" do
         expect { subject }.to raise_exception(NotImplementedError)
       end

--- a/spec/workflow/retrier_spec.rb
+++ b/spec/workflow/retrier_spec.rb
@@ -1,6 +1,25 @@
 RSpec.describe Floe::Workflow::Retrier do
-  let(:payload) { {"ErrorEquals" => ["States.ALL"]} }
-  subject { described_class.new(payload) }
+  let(:input) { {} }
+  let(:ctx) { Floe::Workflow::Context.new(:input => input) }
+  let(:resource) { "docker://hello-world:latest" }
+  let(:workflow) do
+    make_workflow(
+      ctx, {
+        "State"        => {
+          "Type"     => "Task",
+          "Resource" => resource,
+          "Retry"    => retriers,
+          "Next"     => "SuccessState"
+        }.compact,
+        "FirstState"   => {"Type" => "Succeed"},
+        "SuccessState" => {"Type" => "Succeed"},
+        "FailState"    => {"Type" => "Succeed"}
+      }
+    )
+  end
+
+  let(:retriers) { [{"ErrorEquals" => ["States.ALL"]}] }
+  subject { workflow.start_workflow.current_state.retry.first }
 
   {1 => 1, 2 => 2, 3 => 4}.each do |attempt, duration|
     it "try #{attempt} takes #{duration}" do
@@ -14,13 +33,13 @@ RSpec.describe Floe::Workflow::Retrier do
   # The second retry takes place six seconds after the first retry attempt.
   # While the third retry takes place 12 seconds after the second retry attempt.
   context "with values specified" do
-    let(:payload) do
-      {
+    let(:retriers) do
+      [{
         "IntervalSeconds" => 3,
         "BackoffRate"     => 2,
         "MaxAttempts"     => 3,
         "ErrorEquals"     => ["States.ALL"]
-      }
+      }]
     end
 
     {1 => 3, 2 => 6, 3 => 12}.each do |attempt, duration|

--- a/spec/workflow/state_spec.rb
+++ b/spec/workflow/state_spec.rb
@@ -7,39 +7,37 @@ RSpec.describe Floe::Workflow::State do
 
   describe "#started?" do
     it "is not started yet" do
-      expect(state.started?).to eq(false)
+      expect(ctx.state_started?).to eq(false)
     end
 
     it "is started" do
       state.start(ctx.input)
-      expect(state.started?).to eq(true)
+      expect(ctx.state_started?).to eq(true)
     end
 
     it "is finished" do
       state.start(ctx.input)
       state.finish
 
-      state.start(ctx.input)
-      expect(state.started?).to eq(true)
+      expect(ctx.state_started?).to eq(true)
     end
   end
 
   describe "#finished?" do
     it "is not started yet" do
-      expect(state.finished?).to eq(false)
+      expect(ctx.state_finished?).to eq(false)
     end
 
     it "is started" do
       state.start(ctx.input)
-      expect(state.finished?).to eq(false)
+      expect(ctx.state_finished?).to eq(false)
     end
 
     it "is finished" do
       state.start(ctx.input)
       state.finish
 
-      state.start(ctx.input)
-      expect(state.finished?).to eq(true)
+      expect(ctx.state_finished?).to eq(true)
     end
   end
 end

--- a/spec/workflow/state_spec.rb
+++ b/spec/workflow/state_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe Floe::Workflow::State do
     end
 
     it "is started" do
-      state.start(ctx.input)
+      state.start(ctx)
       expect(ctx.state_started?).to eq(true)
     end
 
     it "is finished" do
-      state.start(ctx.input)
-      state.finish
+      state.start(ctx)
+      state.finish(ctx)
 
       expect(ctx.state_started?).to eq(true)
     end
@@ -29,13 +29,13 @@ RSpec.describe Floe::Workflow::State do
     end
 
     it "is started" do
-      state.start(ctx.input)
+      state.start(ctx)
       expect(ctx.state_finished?).to eq(false)
     end
 
     it "is finished" do
-      state.start(ctx.input)
-      state.finish
+      state.start(ctx)
+      state.finish(ctx)
 
       expect(ctx.state_finished?).to eq(true)
     end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Floe::Workflow::States::Choice do
   describe "#run_nonblock!" do
     context "with a missing variable" do
       it "raises an exception" do
-        expect { state.run_nonblock! }.to raise_error(RuntimeError, "No such variable [$.foo]")
+        expect { state.run_nonblock!(ctx) }.to raise_error(RuntimeError, "No such variable [$.foo]")
       end
     end
 
@@ -63,7 +63,7 @@ RSpec.describe Floe::Workflow::States::Choice do
       let(:input) { {"foo" => 1} }
 
       it "returns the next state" do
-        state.run_nonblock!
+        state.run_nonblock!(ctx)
         expect(ctx.next_state).to eq("FirstMatchState")
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe Floe::Workflow::States::Choice do
       let(:input) { {"foo" => 4} }
 
       it "returns the default state" do
-        state.run_nonblock!
+        state.run_nonblock!(ctx)
         expect(ctx.next_state).to eq("DefaultState")
       end
     end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -29,23 +29,23 @@ RSpec.describe Floe::Workflow::States::Choice do
   end
 
   it "raises an exception if Choices is missing" do
-    payload = {"StartAt" => "Choice", "States" => {"Choice" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}}
-    expect { Floe::Workflow.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Choice state must have \"Choices\"")
+    payload = {"Choice1" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "State [Choice1] requires non-empty Array field \"Choices\"")
   end
 
   it "raises an exception if Choices is not an array" do
-    payload = {"StartAt" => "Choice", "States" => {"Choice" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}}
-    expect { Floe::Workflow.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    payload = {"Choice1" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "State [Choice1] requires non-empty Array field \"Choices\"")
   end
 
   it "raises an exception if Choices is an empty array" do
-    payload = {"StartAt" => "Choice", "States" => {"Choice" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}}
-    expect { Floe::Workflow.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    payload = {"Choice1" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "State [Choice1] requires non-empty Array field \"Choices\"")
   end
 
   it "raises an exception if Default isn't a valid state" do
-    payload = {"StartAt" => "Choice", "States" => {"Choice" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}}}
-    expect { Floe::Workflow.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Default\" not in \"States\"")
+    payload = {"Choice1" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Success"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "State [Choice1] requires field \"Default\" to be in \"States\" list but got [MissingState]")
   end
 
   it "#end?" do

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Floe::Workflow::States::Fail do
 
   describe "#run_nonblock!" do
     it "populates static values" do
-      state.run_nonblock!
+      state.run_nonblock!(ctx)
       expect(ctx.next_state).to eq(nil)
       expect(ctx.output).to eq("Error" => "FailStateError", "Cause" => "No Matches!")
     end
@@ -40,7 +40,7 @@ RSpec.describe Floe::Workflow::States::Fail do
       end
 
       it "populates dynamic values" do
-        state.run_nonblock!
+        state.run_nonblock!(ctx)
         expect(ctx.next_state).to eq(nil)
         expect(ctx.output).to eq("Error" => "DynamicError", "Cause" => "DynamicCause")
       end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Floe::Workflow::States::Pass do
 
   describe "#run_nonblock!" do
     it "sets the result to the result path" do
-      state.run_nonblock!
+      state.run_nonblock!(ctx)
       expect(ctx.output["result"]).to include({"foo" => "bar", "bar" => "baz"})
       expect(ctx.next_state).to eq("SuccessState")
     end
@@ -48,7 +48,7 @@ RSpec.describe Floe::Workflow::States::Pass do
       end
 
       it "sets the result in Credentials" do
-        state.run_nonblock!
+        state.run_nonblock!(ctx)
         expect(ctx.credentials).to include({"user" => "luggage", "password" => "1234"})
         expect(ctx.next_state).to eq("SuccessState")
       end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Floe::Workflow::States::Succeed do
 
   describe "#run_nonblock!" do
     it "has no next" do
-      state.run_nonblock!
+      state.run_nonblock!(ctx)
       expect(ctx.next_state).to eq(nil)
     end
   end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe Floe::Workflow::States::Task do
         end
 
         context "with multiple retriers" do
-          let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 3}, {"ErrorEquals" => ["Exception"], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}] }
+          let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 3}, {"ErrorEquals" => ["Exception"], "Next" => "SuccessState"}] }
 
           it "resets the retrier if a different exception is raised" do
             workflow.start_workflow

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -258,8 +258,8 @@ RSpec.describe Floe::Workflow::States::Task do
 
           it "resets the retrier if a different exception is raised" do
             workflow.start_workflow
-            expect(workflow.current_state).to receive(:wait_until!).twice.with(:seconds => 1)
-            expect(workflow.current_state).to receive(:wait_until!).with(:seconds => 2.0)
+            expect(workflow.current_state).to receive(:wait_until!).twice.with(ctx, :seconds => 1)
+            expect(workflow.current_state).to receive(:wait_until!).with(ctx, :seconds => 2.0)
 
             expect_run_async(input, :error => "States.Timeout")
             workflow.step_nonblock
@@ -287,8 +287,8 @@ RSpec.describe Floe::Workflow::States::Task do
         it "fails the workflow if the number of retries is greater than MaxAttempts" do
           workflow.start_workflow
           3.times { expect_run_async(input, :error => "States.Timeout") }
-          expect(workflow.current_state).to receive(:wait_until!).times.with(:seconds => 1)
-          expect(workflow.current_state).to receive(:wait_until!).times.with(:seconds => 2)
+          expect(workflow.current_state).to receive(:wait_until!).with(ctx, :seconds => 1)
+          expect(workflow.current_state).to receive(:wait_until!).with(ctx, :seconds => 2)
 
           3.times { workflow.step_nonblock }
 

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Floe::Workflow::States::Pass do
 
   describe "#start" do
     it "sets WaitUntil" do
-      state.start(ctx.input)
+      state.start(ctx)
 
       expect(state.waiting?(ctx)).to be_truthy
     end
@@ -20,8 +20,8 @@ RSpec.describe Floe::Workflow::States::Pass do
 
   describe "#finish" do
     it "transitions to the next state" do
-      state.start(ctx.input)
-      state.finish
+      state.start(ctx)
+      state.finish(ctx)
 
       expect(ctx.next_state).to eq("SuccessState")
     end
@@ -31,13 +31,13 @@ RSpec.describe Floe::Workflow::States::Pass do
     context "with seconds" do
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running before finished" do
-        state.start(ctx.input)
+        state.start(ctx)
         expect(state.running?(ctx)).to be_truthy
       end
 
       it "is not running after finished" do
         Timecop.travel(Time.now.utc - 10) do
-          state.start(ctx.input)
+          state.start(ctx)
         end
         expect(state.running?(ctx)).to be_falsey
       end
@@ -47,13 +47,13 @@ RSpec.describe Floe::Workflow::States::Pass do
       let(:input)    { {"expire" => "1"} }
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "SecondsPath" => "$.expire", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
-        state.start(ctx.input)
+        state.start(ctx)
         expect(state.running?(ctx)).to be_truthy
       end
 
       it "is not running after finished" do
         Timecop.travel(Time.now.utc - 10) do
-          state.start(ctx.input)
+          state.start(ctx)
         end
         expect(state.running?(ctx)).to be_falsey
       end
@@ -63,13 +63,13 @@ RSpec.describe Floe::Workflow::States::Pass do
       let(:expiry) { Time.now.utc + 1 }
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Timestamp" => expiry.iso8601, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
-        state.start(ctx.input)
+        state.start(ctx)
         expect(state.running?(ctx)).to be_truthy
       end
 
       it "is not running after finished" do
         Timecop.travel(Time.now.utc - 10) do
-          state.start(ctx.input)
+          state.start(ctx)
         end
         expect(state.running?(ctx)).to be_falsey
       end
@@ -80,13 +80,13 @@ RSpec.describe Floe::Workflow::States::Pass do
       let(:input) { {"expire" => expiry.iso8601} }
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "TimestampPath" => "$.expire", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
-        state.start(ctx.input)
+        state.start(ctx)
         expect(state.running?(ctx)).to be_truthy
       end
 
       it "is not running after finished" do
         Timecop.travel(Time.now.utc - 10) do
-          state.start(ctx.input)
+          state.start(ctx)
         end
         expect(state.running?(ctx)).to be_falsey
       end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Floe::Workflow::States::Pass do
     it "sets WaitUntil" do
       state.start(ctx.input)
 
-      expect(state.waiting?).to be_truthy
+      expect(state.waiting?(ctx)).to be_truthy
     end
   end
 
@@ -32,14 +32,14 @@ RSpec.describe Floe::Workflow::States::Pass do
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running before finished" do
         state.start(ctx.input)
-        expect(state.running?).to be_truthy
+        expect(state.running?(ctx)).to be_truthy
       end
 
       it "is not running after finished" do
         Timecop.travel(Time.now.utc - 10) do
           state.start(ctx.input)
         end
-        expect(state.running?).to be_falsey
+        expect(state.running?(ctx)).to be_falsey
       end
     end
 
@@ -48,14 +48,14 @@ RSpec.describe Floe::Workflow::States::Pass do
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "SecondsPath" => "$.expire", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
         state.start(ctx.input)
-        expect(state.running?).to be_truthy
+        expect(state.running?(ctx)).to be_truthy
       end
 
       it "is not running after finished" do
         Timecop.travel(Time.now.utc - 10) do
           state.start(ctx.input)
         end
-        expect(state.running?).to be_falsey
+        expect(state.running?(ctx)).to be_falsey
       end
     end
 
@@ -64,14 +64,14 @@ RSpec.describe Floe::Workflow::States::Pass do
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Timestamp" => expiry.iso8601, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
         state.start(ctx.input)
-        expect(state.running?).to be_truthy
+        expect(state.running?(ctx)).to be_truthy
       end
 
       it "is not running after finished" do
         Timecop.travel(Time.now.utc - 10) do
           state.start(ctx.input)
         end
-        expect(state.running?).to be_falsey
+        expect(state.running?(ctx)).to be_falsey
       end
     end
 
@@ -81,14 +81,14 @@ RSpec.describe Floe::Workflow::States::Pass do
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "TimestampPath" => "$.expire", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
         state.start(ctx.input)
-        expect(state.running?).to be_truthy
+        expect(state.running?(ctx)).to be_truthy
       end
 
       it "is not running after finished" do
         Timecop.travel(Time.now.utc - 10) do
           state.start(ctx.input)
         end
-        expect(state.running?).to be_falsey
+        expect(state.running?(ctx)).to be_falsey
       end
 
       it "runs" do

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Floe::Workflow do
       it "return 0" do
         workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Succeed"}})
         workflow.start_workflow
-        workflow.current_state.run_nonblock!
+        workflow.current_state.run_nonblock!(ctx)
         expect(workflow.step_nonblock_wait).to eq(0)
       end
     end

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -19,38 +19,39 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for missing States" do
       payload = {"StartAt" => "Nothing"}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"States\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires non-empty Hash field \"States\"")
     end
 
     it "raises an exception for invalid States" do
       payload = make_payload({"FirstState" => {"Type" => "Invalid"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Invalid state type: [Invalid]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State [FirstState] does not allow field \"Type\" with value [Invalid]")
     end
 
     it "raises an exception for missing StartAt" do
       payload = {"States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"StartAt\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires field \"StartAt\"")
     end
 
     it "raises an exception for StartAt not in States" do
       payload = {"StartAt" => "Foo", "States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"StartAt\" not in the \"States\" field")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires field \"StartAt\" to be in \"States\" list but got [Foo]")
     end
 
     it "raises an exception for a State missing a Type field" do
       payload = make_payload({"FirstState" => {}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing \"Type\" field in state [FirstState]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State [FirstState] requires field \"Type\"")
     end
 
     it "raises an exception for an invalid State name" do
       state_name = "a" * 81
-      payload    = make_payload({state_name => {"Type" => "Succeed"}})
+      truncated_state_name = "#{"a" * 80}..."
+      payload = make_payload({state_name => {"Type" => "Succeed"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State name [#{state_name}] must be less than or equal to 80 characters")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State name [#{truncated_state_name}] must be less than or equal to 80 characters")
     end
 
     it "raises an exception for invalid context" do

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Floe::Workflow do
     end
 
     it "raises an exception for invalid resource scheme in a Task state" do
-      payload = make_payload({"FirstState" => {"Type" => "Task", "Resource" => "invalid://foo"}})
+      payload = make_payload({"FirstState" => {"Type" => "Task", "Resource" => "invalid://foo", "End" => true}})
 
       expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Invalid resource scheme [invalid]")
     end


### PR DESCRIPTION
depends upon:
- [ ] #209 
- [x] #203

When you setup a `Parallel` state, a single `State` may be run with multiple `Context` values.

So this changes `State` to pass the `Context` on execute (so a single `State` can handle multiple flows. - a kind of command/flyweight pattern if you will.

This is split up into quite a few commits to try and make the progression more palatable.