### PR TITLE
Set StateHistory in Workflow not State

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -120,8 +120,11 @@ module Floe
       return Errno::EPERM if end?
 
       result = current_state.run_nonblock!
-      step_next
-      end_workflow
+
+      if context.state_finished?
+        step_next
+        end_workflow
+      end
 
       result
     end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -184,15 +184,20 @@ module Floe
     private
 
     def step_next
+      context.state_history << context.state
+
       return if context.next_state.nil?
 
+      next_state = {"Name" => context.next_state}
+
       # if rerunning due to an error (and we are using Retry)
-      context.state =
-        if context.state_name == context.next_state && context.failed? && context.state.key?("Retrier")
-          context.state.slice("Name", "RetryCount", "Input", "Retrier")
-        else
-          {"Name" => context.next_state, "Input" => context.output}
-        end
+      if context.state_name == context.next_state && context.failed? && context.state.key?("Retrier")
+        next_state.merge!(context.state.slice("RetryCount", "Input", "Retrier"))
+      else
+        next_state["Input"] = context.output
+      end
+
+      context.state = next_state
     end
   end
 end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -52,8 +52,8 @@ module Floe
       end
 
       def start(_input)
-        context.state["Guid"]            = SecureRandom.uuid
-        context.state["EnteredTime"]     = Time.now.utc.iso8601
+        context.state["Guid"]        = SecureRandom.uuid
+        context.state["EnteredTime"] = Time.now.utc.iso8601
 
         logger.info("Running state: [#{long_name}] with input [#{context.input}]...")
       end
@@ -67,8 +67,6 @@ module Floe
 
         level = context.output&.[]("Error") ? :error : :info
         logger.public_send(level, "Running state: [#{long_name}] with input [#{context.input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.output}]")
-
-        context.state_history << context.state
 
         0
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -44,6 +44,7 @@ module Floe
         end
       end
 
+      # @return for incomplete Errno::EAGAIN, for completed 0
       def run_nonblock!
         start(context.input) unless started?
         return Errno::EAGAIN unless ready?

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -264,21 +264,21 @@ RSpec.describe Floe::Workflow::States::Task do
             expect_run_async(input, :error => "States.Timeout")
             workflow.step_nonblock
 
-            expect(ctx.state["Name"]).to       eq("State")
+            expect(ctx.state_name).to          eq("State")
             expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
             expect(ctx.state["RetryCount"]).to eq(1)
 
             expect_run_async(input, :error => "States.Timeout")
             workflow.step_nonblock
 
-            expect(ctx.state["Name"]).to       eq("State")
+            expect(ctx.state_name).to          eq("State")
             expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
             expect(ctx.state["RetryCount"]).to eq(2)
 
             expect_run_async(input, :error => "Exception")
             workflow.step_nonblock
 
-            expect(ctx.state["Name"]).to       eq("State")
+            expect(ctx.state_name).to          eq("State")
             expect(ctx.state["Retrier"]).to    eq(["Exception"])
             expect(ctx.state["RetryCount"]).to eq(1)
           end

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -264,21 +264,21 @@ RSpec.describe Floe::Workflow::States::Task do
             expect_run_async(input, :error => "States.Timeout")
             workflow.step_nonblock
 
-            expect(ctx.next_state).to          eq("State")
+            expect(ctx.state["Name"]).to       eq("State")
             expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
             expect(ctx.state["RetryCount"]).to eq(1)
 
             expect_run_async(input, :error => "States.Timeout")
             workflow.step_nonblock
 
-            expect(ctx.next_state).to          eq("State")
+            expect(ctx.state["Name"]).to       eq("State")
             expect(ctx.state["Retrier"]).to    eq(["States.Timeout"])
             expect(ctx.state["RetryCount"]).to eq(2)
 
             expect_run_async(input, :error => "Exception")
             workflow.step_nonblock
 
-            expect(ctx.next_state).to          eq("State")
+            expect(ctx.state["Name"]).to       eq("State")
             expect(ctx.state["Retrier"]).to    eq(["Exception"])
             expect(ctx.state["RetryCount"]).to eq(1)
           end

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -90,6 +90,19 @@ RSpec.describe Floe::Workflow::States::Pass do
         end
         expect(state.running?).to be_falsey
       end
+
+      it "runs" do
+        workflow.run_nonblock
+        expect(workflow.end?).to eq(false)
+        expect(workflow.context.state_history.size).to eq(0)
+
+        Timecop.travel(Time.now.utc + 10) do
+          workflow.run_nonblock
+        end
+
+        expect(workflow.end?).to eq(true)
+        expect(workflow.context.state_history.size).to eq(2)
+      end
     end
   end
 end


### PR DESCRIPTION
NOTE I moved step_next after the run, since we have a dedicated start_workflow which sets the initial state context we no longer need step_next to pull double-duty here 
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
