### PR TITLE
[WIP] Move parameters into parent Mixins

### DIFF
--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -5,7 +5,7 @@ module Floe
     class Catcher
       include Floe::Workflow::ErrorMatcherMixin
 
-      attr_reader :error_equals, :next, :result_path
+      attr_reader :next, :result_path
 
       def initialize(payload)
         @payload = payload
@@ -13,7 +13,8 @@ module Floe
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]
         @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
-        raise Floe::InvalidWorkflowError, "State requires ErrorEquals" if !@error_equals.kind_of?(Array) || @error_equals.empty?
+
+        super
       end
     end
   end

--- a/lib/floe/workflow/error_matcher_mixin.rb
+++ b/lib/floe/workflow/error_matcher_mixin.rb
@@ -4,6 +4,13 @@ module Floe
   class Workflow
     # Methods for common error handling
     module ErrorMatcherMixin
+      attr_reader :error_equals
+
+      def initialize(payload)
+        @error_equals = payload["ErrorEquals"]
+        raise Floe::InvalidWorkflowError, "State requires ErrorEquals" if !@error_equals.kind_of?(Array) || @error_equals.empty?
+      end
+
       # @param [String] error the error thrown
       def match_error?(error)
         return false if error == "States.Runtime"

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -5,16 +5,16 @@ module Floe
     class Retrier
       include Floe::Workflow::ErrorMatcherMixin
 
-      attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate
+      attr_reader :interval_seconds, :max_attempts, :backoff_rate
 
       def initialize(payload)
         @payload = payload
 
-        @error_equals     = payload["ErrorEquals"]
         @interval_seconds = payload["IntervalSeconds"] || 1.0
         @max_attempts     = payload["MaxAttempts"] || 3
         @backoff_rate     = payload["BackoffRate"] || 2.0
-        raise Floe::InvalidWorkflowError, "State requires ErrorEquals" if !@error_equals.kind_of?(Array) || @error_equals.empty?
+
+        super
       end
 
       # @param [Integer] attempt 1 for the first attempt

--- a/lib/floe/workflow/states/input_output_mixin.rb
+++ b/lib/floe/workflow/states/input_output_mixin.rb
@@ -3,7 +3,22 @@
 module Floe
   class Workflow
     module States
+      # Methods for common input output handling
       module InputOutputMixin
+        attr_reader :parameters, :input_path, :output_path, :result_path, :result_selector
+
+        def initialize(workflow, name, payload)
+          super
+
+          @input_path      = Path.new(payload.fetch("InputPath", "$"))
+          @output_path     = Path.new(payload.fetch("OutputPath", "$"))
+          @result_path     = ReferencePath.new(payload.fetch("ResultPath", "$"))
+          # NOTE: Map uses "ItemSelector" instead of "Parameters"
+          @parameters      = PayloadTemplate.new(payload["Parameters"])     if payload["Parameters"]
+          # NOTE: "ResultSelector" is not valid for Pass
+          @result_selector = PayloadTemplate.new(payload["ResultSelector"]) if payload["ResultSelector"]
+        end
+
         def process_input(context)
           input = input_path.value(context, context.input)
           input = parameters.value(context, input) if parameters

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -4,12 +4,29 @@ module Floe
   class Workflow
     module States
       module NonTerminalMixin
+        attr_reader :next, :end
+
+        def initialize(workflow, name, payload)
+          super
+
+          @next        = payload["Next"]
+          @end         = !!payload["End"]
+
+          validate_state_next!(workflow)
+        end
+
         def finish(context)
           # If this state is failed or this is an end state, next_state to nil
           context.next_state ||= end? || context.failed? ? nil : @next
 
           super
         end
+
+        def end?
+          @end
+        end
+
+        private
 
         def validate_state_next!(workflow)
           raise Floe::InvalidWorkflowError, "Missing \"Next\" field in state [#{name}]" if @next.nil? && !@end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -7,16 +7,12 @@ module Floe
         include InputOutputMixin
         include NonTerminalMixin
 
-        attr_reader :end, :next, :result
+        attr_reader :result
 
         def initialize(workflow, name, payload)
           super
 
-          @next        = payload["Next"]
-          @end         = !!payload["End"]
-          @result      = payload["Result"]
-
-          validate_state!(workflow)
+          @result = payload["Result"]
         end
 
         def finish(context)
@@ -27,16 +23,6 @@ module Floe
 
         def running?(_)
           false
-        end
-
-        def end?
-          @end
-        end
-
-        private
-
-        def validate_state!(workflow)
-          validate_state_next!(workflow)
         end
       end
     end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -7,7 +7,7 @@ module Floe
         include InputOutputMixin
         include NonTerminalMixin
 
-        attr_reader :end, :next, :result, :parameters, :input_path, :output_path, :result_path
+        attr_reader :end, :next, :result
 
         def initialize(workflow, name, payload)
           super
@@ -15,11 +15,6 @@ module Floe
           @next        = payload["Next"]
           @end         = !!payload["End"]
           @result      = payload["Result"]
-
-          @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
-          @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
 
           validate_state!(workflow)
         end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -7,9 +7,8 @@ module Floe
         include InputOutputMixin
         include NonTerminalMixin
 
-        attr_reader :credentials, :end, :heartbeat_seconds, :next, :parameters,
-                    :result_selector, :resource, :timeout_seconds, :retry, :catch,
-                    :input_path, :output_path, :result_path
+        attr_reader :credentials, :end, :heartbeat_seconds, :next,
+                    :resource, :timeout_seconds, :retry, :catch
 
         def initialize(workflow, name, payload)
           super
@@ -22,13 +21,7 @@ module Floe
           @timeout_seconds   = payload["TimeoutSeconds"]
           @retry             = payload["Retry"].to_a.map { |retrier| Retrier.new(retrier) }
           @catch             = payload["Catch"].to_a.map { |catcher| Catcher.new(catcher) }
-          @input_path        = Path.new(payload.fetch("InputPath", "$"))
-          @output_path       = Path.new(payload.fetch("OutputPath", "$"))
-          @result_path       = ReferencePath.new(payload.fetch("ResultPath", "$"))
-          @parameters        = PayloadTemplate.new(payload["Parameters"])     if payload["Parameters"]
-          @result_selector   = PayloadTemplate.new(payload["ResultSelector"]) if payload["ResultSelector"]
-          @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
-
+          @credentials       = PayloadTemplate.new(payload["Credentials"]) if payload["Credentials"]
           validate_state!(workflow)
         rescue ArgumentError => err
           raise Floe::InvalidWorkflowError, err.message

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -13,8 +13,6 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @next           = payload["Next"]
-          @end            = !!payload["End"]
           @seconds        = payload["Seconds"]&.to_i
           @timestamp      = payload["Timestamp"]
           @timestamp_path = Path.new(payload["TimestampPath"]) if payload.key?("TimestampPath")
@@ -22,8 +20,6 @@ module Floe
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
-
-          validate_state!(workflow)
         end
 
         def start(context)
@@ -46,16 +42,6 @@ module Floe
 
         def running?(context)
           waiting?(context)
-        end
-
-        def end?
-          @end
-        end
-
-        private
-
-        def validate_state!(workflow)
-          validate_state_next!(workflow)
         end
       end
     end


### PR DESCRIPTION
Style question:

> Do we like the idea of moving the parameter reading into the mixin?

This shows what it looks like if we do this.

Depends upon:

- [x] #186 
- last 3 commits

Note: `Pass` does not support `"ResultSelector"`. The old code was ignoring it. This is ignoring it as well. Since `InputOutputMixin#process_output` was already referencing `result_selector`,
seemed ok to fully define that here.

---

WIP: Added WIP to mark this as a lower priority. it is ready