### PR TITLE
Handle non-json input/output values

### DIFF
--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -39,7 +39,7 @@ module Floe
       end
 
       def failed?
-        output&.key?("Error") || false
+        (output.kind_of?(Hash) && output.key?("Error")) || false
       end
 
       def ended?

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -64,7 +64,7 @@ module Floe
         context.state["FinishedTime"] ||= finished_time.iso8601
         context.state["Duration"]       = finished_time - entered_time
 
-        level = context.output&.[]("Error") ? :error : :info
+        level = context.failed? ? :error : :info
         logger.public_send(level, "Running state: [#{long_name}] with input [#{context.input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.output}]")
 
         0

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Floe::Workflow::Context do
     it "defaults credentials to {}" do
       expect(ctx.credentials).to eq({})
     end
+
+    context "with a simple string input" do
+      let(:input) { "\"foo\"" }
+
+      it "sets the input" do
+        expect(ctx.execution["Input"]).to eq("foo")
+        expect(ctx.state).not_to eq(nil)
+      end
+    end
   end
 
   describe "#started?" do


### PR DESCRIPTION
We currently assume that input/output have to be a JSON/hash payload, however while looking at some map examples it seems like it is possible for simple strings as well (and I assume by extension integers, etc...).

Example:
https://docs.aws.amazon.com/step-functions/latest/dg/tutorial-use-inline-map.html

Input to Map state:
```json
{
  "foo": "bar",
  "colors": [
    "red",
    "green",
    "blue",
    "yellow",
    "white"
  ]
}
```

So with `"ItemsPath": "$.colors"` the input to the `"ItemProcessor"` would be e.g. `"red"` and the output would be a simple UUID string.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
