### PR TITLE
Common Error messages alt

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -7,6 +7,7 @@ require_relative "floe/logging"
 
 require_relative "floe/runner"
 
+require_relative "floe/payload_validator"
 require_relative "floe/workflow"
 require_relative "floe/workflow/catcher"
 require_relative "floe/workflow/choice_rule"

--- a/lib/floe/payload_validator.rb
+++ b/lib/floe/payload_validator.rb
@@ -21,17 +21,8 @@ module Floe
       @children    = children
     end
 
-    # payload accessors
-    def fetch(key, default)
-      payload.fetch(key, default)
-    end
-
     def keys
       payload.keys
-    end
-
-    def key?(name)
-      payload.key?(name)
     end
 
     def [](key)

--- a/lib/floe/payload_validator.rb
+++ b/lib/floe/payload_validator.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module Floe
+  class PayloadValidator
+    # @attr_reader [Array<String>] state_names list of valid state names
+    attr_accessor :state_names
+    # @attr_reader [String] state_name currently processed state. nil for workflow.
+    attr_reader :state_name
+    # @attr_reader [String] rule currently processed rule. e.g.: "Choice"
+    attr_reader :rule
+    # @attr_reader [Boolean] children. true when processing "Choice" sub children (level 2+)
+    attr_reader :children
+    # @attr_reader [Hash] data that is currently being parsed.
+    attr_reader :payload
+
+    def initialize(payload, state_names = [], state_name = nil, rule: nil, children: nil)
+      @payload     = payload
+      @state_names = state_names
+      @state_name  = state_name
+      @rule        = rule
+      @children    = children
+    end
+
+    # payload accessors
+    def fetch(key, default)
+      payload.fetch(key, default)
+    end
+
+    def keys
+      payload.keys
+    end
+
+    def key?(name)
+      payload.key?(name)
+    end
+
+    def [](key)
+      payload[key]
+    end
+
+    # @param [Class] klass the class of the field
+    def field!(field_name, klass: String, default: :required)
+      field_value = self[field_name]
+
+      if default == :required && (field_value.nil? || field_value.empty?)
+        raise Floe::InvalidWorkflowError, "#{src_reference} requires field \"#{field_name}\""
+      end
+
+      field_value ||= default
+
+      if !field_value.nil? && !field_value.kind_of?(klass)
+        raise Floe::InvalidWorkflowError, "#{src_reference} requires #{klass} field \"#{field_name}\" got [#{field_value}]"
+      end
+
+      field_value
+    end
+
+    def boolean!(field_name, default: :required, klass: "Boolean")
+      field_value = self[field_name] || default
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires boolean field \"#{field_name}\"" if !payload.key?(field_name) && default == :required
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires #{klass} field \"#{field_name}\" got [#{field_value}]" unless [true, false].include?(field_value)
+
+      field_value
+    end
+
+    def state_ref!(field_name, optional: false)
+      field_value = self[field_name]
+
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires field \"#{field_name}\"" if field_value.nil? && !optional
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires field \"#{field_name}\" to be in \"States\" list but got [#{field_value}]" if field_value && !state?(field_value)
+
+      field_value
+    end
+
+    def list!(field_name, klass: Array, default: :required)
+      field_value = self[field_name]
+
+      return field_value || default if default != :required && field_value.nil?
+      return field_value if field_value.kind_of?(klass) && !field_value.empty?
+
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires non-empty #{klass.name} field \"#{field_name}\""
+    end
+
+    def path!(field_name, default: :required)
+      field_value = self[field_name]
+
+      return if field_value.nil? && default.nil?
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires Path field \"#{field_name}\" to exist" if field_value.nil? && default == :required
+
+      field_value ||= default
+
+      begin
+        Workflow::Path.new(field_value)
+      rescue Floe::InvalidWorkflowError => err
+        bad_type!(field_name, field_value, err.message, :type => "Path")
+      end
+    end
+
+    def reference_path!(field_name, default: :required)
+      field_value = self[field_name]
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires ReferencePath field \"#{field_name}\" to exist" if field_value.nil? && default == :required
+
+      field_value ||= default
+
+      begin
+        Workflow::ReferencePath.new(field_value)
+      rescue Floe::InvalidWorkflowError => err
+        bad_type!(field_name, field_value, err.message, :type => "ReferencePath")
+      end
+    end
+
+    def payload_template!(field_name, default: nil)
+      field_value = self[field_name] || default
+      Workflow::PayloadTemplate.new(field_value) if field_value
+    end
+
+    # Similar to validate_field! but much of the logic is external
+    def bad_type!(field_name, field_value, comment = nil, type:)
+      comment ||= "got [#{field_value}]"
+      raise Floe::InvalidWorkflowError, "#{src_reference} requires #{type} field \"#{field_name}\"#{" " if comment}#{comment}"
+    end
+
+    # an unexpected field was found
+    def reject!(field_name, comment = nil)
+      field_value = self[field_name]
+      raise Floe::InvalidWorkflowError, "#{src_reference} does not allow field \"#{field_name}\" with value [#{field_value}]#{" " if comment}#{comment}" if field_value
+    end
+
+    def with_states(state_names)
+      self.class.new(payload, state_names)
+    end
+
+    def for_state(name, new_payload = nil)
+      self.class.new(new_payload, state_names, name)
+    end
+
+    def for_rule(rule, new_payload)
+      self.class.new(new_payload, state_names, state_name, :rule => rule)
+    end
+
+    def for_children(new_payload)
+      self.class.new(new_payload, state_names, state_name, :rule => rule, :children => true)
+    end
+
+    private
+
+    def state?(name)
+      @state_names.include?(name)
+    end
+
+    def src_reference
+      "#{state_name ? "State [#{state_name}]" : "Workflow"}#{" " if rule}#{rule}#{" child rule" if children}"
+    end
+  end
+end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -108,6 +108,8 @@ module Floe
 
       @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, state_name, state) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
+    rescue Floe::InvalidWorkflowError
+      raise
     rescue => err
       raise Floe::InvalidWorkflowError, err.message
     end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -96,17 +96,17 @@ module Floe
       # caller should really put credentials into context and not pass that variable
       context.credentials = credentials if credentials
 
-      raise Floe::InvalidWorkflowError, "Missing field \"States\""  if payload["States"].nil?
-      raise Floe::InvalidWorkflowError, "Missing field \"StartAt\"" if payload["StartAt"].nil?
-      raise Floe::InvalidWorkflowError, "\"StartAt\" not in the \"States\" field" unless payload["States"].key?(payload["StartAt"])
+      pv          = PayloadValidator.new(payload)
+      states      = pv.list!("States", :klass => Hash)
+      pv          = pv.with_states(states.keys)
 
       @name        = name
       @payload     = payload
       @context     = context
-      @comment     = payload["Comment"]
-      @start_at    = payload["StartAt"]
+      @comment     = pv.field!("Comment", :default => nil)
+      @start_at    = pv.state_ref!("StartAt")
 
-      @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, state_name, state) }
+      @states         = states.map { |state_name, state_payload| State.build!(self, state_name, pv.for_state(state_name, state_payload)) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
     rescue Floe::InvalidWorkflowError
       raise

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -8,9 +8,9 @@ module Floe
       def initialize(payload)
         @payload = payload
 
-        @error_equals = payload["ErrorEquals"]
-        @next         = payload["Next"]
-        @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
+        @error_equals = payload.list!("ErrorEquals")
+        @next         = payload.state_ref!("Next")
+        @result_path  = payload.reference_path!("ResultPath", :default => "$")
       end
     end
   end

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -11,6 +11,8 @@ module Floe
         @error_equals = payload.list!("ErrorEquals")
         @next         = payload.state_ref!("Next")
         @result_path  = payload.reference_path!("ResultPath", :default => "$")
+
+        payload.no_unreferenced_fields!
       end
     end
   end

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -22,6 +22,8 @@ module Floe
         self["Task"]               ||= {}
 
         @credentials = credentials || {}
+      rescue JSON::ParserError => err
+        raise Floe::InvalidWorkflowError, err.message
       end
 
       def execution

--- a/lib/floe/workflow/path.rb
+++ b/lib/floe/workflow/path.rb
@@ -30,6 +30,10 @@ module Floe
 
         results.count < 2 ? results.first : results
       end
+
+      def to_s
+        @payload
+      end
     end
   end
 end

--- a/lib/floe/workflow/reference_path.rb
+++ b/lib/floe/workflow/reference_path.rb
@@ -8,7 +8,7 @@ module Floe
       def initialize(*)
         super
 
-        raise Floe::InvalidWorkflowError, "Invalid Reference Path" if payload.match?(/@|,|:|\?/)
+        raise Floe::InvalidWorkflowError, "Reference Path [#{payload}] is invalid" if payload.match?(/@|,|:|\?/)
 
         @path = JsonPath.new(payload)
                         .path[1..]

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -8,7 +8,7 @@ module Floe
       def initialize(payload)
         @payload = payload
 
-        @error_equals     = payload["ErrorEquals"]
+        @error_equals     = payload.list!("ErrorEquals")
         @interval_seconds = payload["IntervalSeconds"] || 1.0
         @max_attempts     = payload["MaxAttempts"] || 3
         @backoff_rate     = payload["BackoffRate"] || 2.0

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -30,7 +30,7 @@ module Floe
         @comment  = payload["Comment"]
 
         raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name}]" if payload["Type"].nil?
-        raise Floe::InvalidWorkflowError, "State name [#{name}] must be less than or equal to 80 characters" if name.length > 80
+        raise Floe::InvalidWorkflowError, "State name [#{name[..79]}...] must be less than or equal to 80 characters" if name.length > 80
       end
 
       def wait(timeout: nil)

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -7,13 +7,12 @@ module Floe
 
       class << self
         def build!(workflow, name, payload)
-          state_type = payload["Type"]
-          raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name}]" if payload["Type"].nil?
+          state_type = payload.field!("Type")
 
           begin
             klass = Floe::Workflow::States.const_get(state_type)
           rescue NameError
-            raise Floe::InvalidWorkflowError, "Invalid state type: [#{state_type}]"
+            payload.bad_type!("Type", state_type, "but got invalid value [#{state_type}]", :type => String)
           end
 
           klass.new(workflow, name, payload)
@@ -26,10 +25,10 @@ module Floe
         @workflow = workflow
         @name     = name
         @payload  = payload
-        @type     = payload["Type"]
-        @comment  = payload["Comment"]
+        @type     = payload.field!("Type")
+        @comment  = payload.field!("Comment", :default => nil)
 
-        raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name}]" if payload["Type"].nil?
+        # We should be using build so this should never get hit
         raise Floe::InvalidWorkflowError, "State name [#{name[..79]}...] must be less than or equal to 80 characters" if name.length > 80
       end
 
@@ -96,7 +95,7 @@ module Floe
       end
 
       def long_name
-        "#{payload["Type"]}:#{name}"
+        "#{type}:#{name}"
       end
 
       private

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -9,13 +9,11 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          validate_state!
+          @choices = payload.list!("Choices").map { |choice_payload| ChoiceRule.build(payload.for_rule("Choices", choice_payload)) }
+          @default = payload.state_ref!("Default")
 
-          @choices = payload["Choices"].map { |choice| ChoiceRule.build(choice) }
-          @default = payload["Default"]
-
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @input_path  = payload.path!("InputPath", :default => "$")
+          @output_path = payload.path!("OutputPath", :default => "$")
         end
 
         def finish
@@ -33,22 +31,6 @@ module Floe
 
         def end?
           false
-        end
-
-        private
-
-        def validate_state!
-          validate_state_choices!
-          validate_state_default!
-        end
-
-        def validate_state_choices!
-          raise Floe::InvalidWorkflowError, "Choice state must have \"Choices\"" unless payload.key?("Choices")
-          raise Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array" unless payload["Choices"].kind_of?(Array) && !payload["Choices"].empty?
-        end
-
-        def validate_state_default!
-          raise Floe::InvalidWorkflowError, "\"Default\" not in \"States\"" unless workflow.payload["States"].include?(payload["Default"])
         end
       end
     end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -14,6 +14,8 @@ module Floe
 
           @input_path  = payload.path!("InputPath", :default => "$")
           @output_path = payload.path!("OutputPath", :default => "$")
+
+          payload.no_unreferenced_fields!
         end
 
         def finish

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -11,8 +11,8 @@ module Floe
 
           @cause      = payload["Cause"]
           @error      = payload["Error"]
-          @cause_path = Path.new(payload["CausePath"]) if payload["CausePath"]
-          @error_path = Path.new(payload["ErrorPath"]) if payload["ErrorPath"]
+          @cause_path = payload.path!("CausePath", :default => nil)
+          @error_path = payload.path!("ErrorPath", :default => nil)
         end
 
         def finish

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -13,6 +13,8 @@ module Floe
           @error      = payload["Error"]
           @cause_path = payload.path!("CausePath", :default => nil)
           @error_path = payload.path!("ErrorPath", :default => nil)
+
+          payload.no_unreferenced_fields!
         end
 
         def finish

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -10,11 +10,6 @@ module Floe
 
           super
         end
-
-        def validate_state_next!
-          raise Floe::InvalidWorkflowError, "Missing \"Next\" field in state [#{name}]" if @next.nil? && !@end
-          raise Floe::InvalidWorkflowError, "\"Next\" [#{@next}] not in \"States\" for state [#{name}]" if @next && !workflow.payload["States"].key?(@next)
-        end
       end
     end
   end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -12,16 +12,14 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @next        = payload["Next"]
-          @end         = !!payload["End"]
+          @end         = payload.boolean!("End", :default => false)
+          @next        = payload.state_ref!("Next", :optional => @end)
           @result      = payload["Result"]
 
-          @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
-          @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
-
-          validate_state!
+          @parameters  = payload.payload_template!("Parameters", :default => nil)
+          @input_path  = payload.path!("InputPath", :default => "$")
+          @output_path = payload.path!("OutputPath", :default => "$")
+          @result_path = payload.reference_path!("ResultPath", :default => "$")
         end
 
         def finish
@@ -35,12 +33,6 @@ module Floe
 
         def end?
           @end
-        end
-
-        private
-
-        def validate_state!
-          validate_state_next!
         end
       end
     end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -20,6 +20,8 @@ module Floe
           @input_path  = payload.path!("InputPath", :default => "$")
           @output_path = payload.path!("OutputPath", :default => "$")
           @result_path = payload.reference_path!("ResultPath", :default => "$")
+
+          payload.no_unreferenced_fields!
         end
 
         def finish

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -11,6 +11,8 @@ module Floe
 
           @input_path = payload.field!("InputPath", :default => nil)
           @output_path = payload.field!("OutputPath", :default => nil)
+
+          payload.no_unreferenced_fields!
         end
 
         def finish

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -6,6 +6,13 @@ module Floe
       class Succeed < Floe::Workflow::State
         attr_reader :input_path, :output_path
 
+        def initialize(workflow, name, payload)
+          super
+
+          @input_path = payload.field!("InputPath", :default => nil)
+          @output_path = payload.field!("OutputPath", :default => nil)
+        end
+
         def finish
           context.next_state = nil
           context.output     = context.input

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -30,6 +30,8 @@ module Floe
           @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
 
           validate_state!
+        rescue ArgumentError => err
+          raise Floe::InvalidWorkflowError, err.message
         end
 
         def start(input)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -28,6 +28,8 @@ module Floe
           @parameters        = payload.payload_template!("Parameters", :default => nil)
           @result_selector   = payload.payload_template!("ResultSelector", :default => nil)
           @credentials       = payload.payload_template!("Credentials", :default => nil)
+
+          payload.no_unreferenced_fields!
         rescue ArgumentError => err
           raise Floe::InvalidWorkflowError, err.message
         end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -22,6 +22,8 @@ module Floe
 
           @input_path  = payload.path!("InputPath", :default => "$")
           @output_path = payload.path!("OutputPath", :default => "$")
+
+          payload.no_unreferenced_fields!
         end
 
         def start(input)

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -13,17 +13,15 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @next           = payload["Next"]
-          @end            = !!payload["End"]
+          @end            = payload.boolean!("End", :default => false)
+          @next           = payload.state_ref!("Next", :optional => @end)
           @seconds        = payload["Seconds"]&.to_i
           @timestamp      = payload["Timestamp"]
-          @timestamp_path = Path.new(payload["TimestampPath"]) if payload.key?("TimestampPath")
-          @seconds_path   = Path.new(payload["SecondsPath"]) if payload.key?("SecondsPath")
+          @timestamp_path = payload.path!("TimestampPath", :default => nil)
+          @seconds_path   = payload.path!("SecondsPath", :default => nil)
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
-
-          validate_state!
+          @input_path  = payload.path!("InputPath", :default => "$")
+          @output_path = payload.path!("OutputPath", :default => "$")
         end
 
         def start(input)
@@ -49,12 +47,6 @@ module Floe
 
         def end?
           @end
-        end
-
-        private
-
-        def validate_state!
-          validate_state_next!
         end
       end
     end

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -1,11 +1,24 @@
 RSpec.describe Floe::Workflow::ChoiceRule do
+  let(:name)      { "FirstMatchState" }
+  let(:workflow)  { make_workflow({}, {name => {"Type" => "Choice", "Choices" => [payload], "Default" => name}}) }
+
+  describe ".build" do
+    let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
+    let(:subject) { described_class.build(payload) }
+
+    it "works with valid next" do
+      subject
+    end
+  end
+
   describe "#true?" do
     let(:subject) { described_class.build(payload).true?(context, input) }
     let(:context) { {} }
 
-    context "Abstract Interface" do
+    context "with abstract top level class" do
+      let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
       let(:input) { {} }
-      let(:subject) { described_class.new({}).true?(context, input) }
+      let(:subject) { described_class.new(payload).true?(context, input) }
       it "is not implemented" do
         expect { subject }.to raise_exception(NotImplementedError)
       end
@@ -84,7 +97,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsNull" do
-        let(:payload) { {"Variable" => "$.foo", "IsNull" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsNull" => true, "Next" => "FirstMatchState"} }
 
         context "with null" do
           let(:input) { {"foo" => nil} }
@@ -104,7 +117,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsPresent" do
-        let(:payload) { {"Variable" => "$.foo", "IsPresent" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsPresent" => true, "Next" => "FirstMatchState"} }
 
         context "with null" do
           let(:input) { {"foo" => nil} }
@@ -124,7 +137,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsNumeric" do
-        let(:payload) { {"Variable" => "$.foo", "IsNumeric" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsNumeric" => true, "Next" => "FirstMatchState"} }
 
         context "with an integer" do
           let(:input) { {"foo" => 1} }
@@ -152,7 +165,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsString" do
-        let(:payload) { {"Variable" => "$.foo", "IsString" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsString" => true, "Next" => "FirstMatchState"} }
 
         context "with a string" do
           let(:input) { {"foo" => "bar"} }
@@ -172,7 +185,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsBoolean" do
-        let(:payload) { {"Variable" => "$.foo", "IsBoolean" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsBoolean" => true, "Next" => "FirstMatchState"} }
 
         context "with a boolean" do
           let(:input) { {"foo" => true} }
@@ -192,7 +205,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with IsTimestamp" do
-        let(:payload) { {"Variable" => "$.foo", "IsTimestamp" => true} }
+        let(:payload) { {"Variable" => "$.foo", "IsTimestamp" => true, "Next" => "FirstMatchState"} }
 
         context "with a timestamp" do
           let(:input) { {"foo" => "2016-03-14T01:59:00Z"} }

--- a/spec/workflow/reference_path_spec.rb
+++ b/spec/workflow/reference_path_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Floe::Workflow::ReferencePath do
       let(:payload) { "$.foo@.bar" }
 
       it "raises an exception" do
-        expect { subject }.to raise_error(Floe::InvalidWorkflowError, "Invalid Reference Path")
+        expect { subject }.to raise_error(Floe::InvalidWorkflowError, "Reference Path [$.foo@.bar] is invalid")
       end
     end
   end

--- a/spec/workflow/retrier_spec.rb
+++ b/spec/workflow/retrier_spec.rb
@@ -1,6 +1,25 @@
 RSpec.describe Floe::Workflow::Retrier do
-  let(:payload) { {"ErrorEquals" => ["States.ALL"]} }
-  subject { described_class.new(payload) }
+  let(:input) { {} }
+  let(:ctx) { Floe::Workflow::Context.new(:input => input) }
+  let(:resource) { "docker://hello-world:latest" }
+  let(:workflow) do
+    make_workflow(
+      ctx, {
+        "State"        => {
+          "Type"     => "Task",
+          "Resource" => resource,
+          "Retry"    => retriers,
+          "Next"     => "SuccessState"
+        }.compact,
+        "FirstState"   => {"Type" => "Succeed"},
+        "SuccessState" => {"Type" => "Succeed"},
+        "FailState"    => {"Type" => "Succeed"}
+      }
+    )
+  end
+
+  let(:retriers) { [{"ErrorEquals" => ["States.ALL"]}] }
+  subject { workflow.start_workflow.current_state.retry.first }
 
   {1 => 1, 2 => 2, 3 => 4}.each do |attempt, duration|
     it "try #{attempt} takes #{duration}" do
@@ -14,13 +33,13 @@ RSpec.describe Floe::Workflow::Retrier do
   # The second retry takes place six seconds after the first retry attempt.
   # While the third retry takes place 12 seconds after the second retry attempt.
   context "with values specified" do
-    let(:payload) do
-      {
+    let(:retriers) do
+      [{
         "IntervalSeconds" => 3,
         "BackoffRate"     => 2,
         "MaxAttempts"     => 3,
         "ErrorEquals"     => ["States.ALL"]
-      }
+      }]
     end
 
     {1 => 3, 2 => 6, 3 => 12}.each do |attempt, duration|

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -29,23 +29,23 @@ RSpec.describe Floe::Workflow::States::Choice do
   end
 
   it "raises an exception if Choices is missing" do
-    payload = {"StartAt" => "Choice", "States" => {"Choice" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}}
-    expect { Floe::Workflow.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Choice state must have \"Choices\"")
+    payload = {"Choice1" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "Choice state must have \"Choices\"")
   end
 
   it "raises an exception if Choices is not an array" do
-    payload = {"StartAt" => "Choice", "States" => {"Choice" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}}
-    expect { Floe::Workflow.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    payload = {"Choice1" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
   end
 
   it "raises an exception if Choices is an empty array" do
-    payload = {"StartAt" => "Choice", "States" => {"Choice" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}}
-    expect { Floe::Workflow.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    payload = {"Choice1" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
   end
 
   it "raises an exception if Default isn't a valid state" do
-    payload = {"StartAt" => "Choice", "States" => {"Choice" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}}}
-    expect { Floe::Workflow.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Default\" not in \"States\"")
+    payload = {"Choice1" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Success"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Default\" not in \"States\"")
   end
 
   it "#end?" do

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -30,22 +30,22 @@ RSpec.describe Floe::Workflow::States::Choice do
 
   it "raises an exception if Choices is missing" do
     payload = {"Choice1" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "Choice state must have \"Choices\"")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "State [Choice1] requires non-empty Array field \"Choices\"")
   end
 
   it "raises an exception if Choices is not an array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "State [Choice1] requires non-empty Array field \"Choices\"")
   end
 
   it "raises an exception if Choices is an empty array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "State [Choice1] requires non-empty Array field \"Choices\"")
   end
 
   it "raises an exception if Default isn't a valid state" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Success"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Default\" not in \"States\"")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "State [Choice1] requires field \"Default\" to be in \"States\" list but got [MissingState]")
   end
 
   it "#end?" do

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe Floe::Workflow::States::Task do
         end
 
         context "with multiple retriers" do
-          let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 3}, {"ErrorEquals" => ["Exception"], "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}] }
+          let(:retriers) { [{"ErrorEquals" => ["States.Timeout"], "MaxAttempts" => 3}, {"ErrorEquals" => ["Exception"], "Next" => "SuccessState"}] }
 
           it "resets the retrier if a different exception is raised" do
             workflow.start_workflow

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Floe::Workflow do
     end
 
     it "raises an exception for invalid resource scheme in a Task state" do
-      payload = make_payload({"FirstState" => {"Type" => "Task", "Resource" => "invalid://foo"}})
+      payload = make_payload({"FirstState" => {"Type" => "Task", "Resource" => "invalid://foo", "End" => true}})
 
       expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Invalid resource scheme [invalid]")
     end
@@ -301,7 +301,7 @@ RSpec.describe Floe::Workflow do
 
   describe "#wait_until" do
     it "reads when the workflow will be ready to continue" do
-      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}})
       workflow.run_nonblock
 
       expect(workflow.wait_until).to be_within(1).of(Time.now.utc + 10)
@@ -317,7 +317,7 @@ RSpec.describe Floe::Workflow do
 
   describe "#waiting?" do
     it "reads when the workflow will be ready to continue" do
-      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}})
       workflow.run_nonblock
 
       expect(workflow.waiting?).to be_truthy

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -48,9 +48,10 @@ RSpec.describe Floe::Workflow do
 
     it "raises an exception for an invalid State name" do
       state_name = "a" * 81
-      payload    = make_payload({state_name => {"Type" => "Succeed"}})
+      truncated_state_name = "#{"a" * 80}..."
+      payload = make_payload({state_name => {"Type" => "Succeed"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State name [#{state_name}] must be less than or equal to 80 characters")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State name [#{truncated_state_name}] must be less than or equal to 80 characters")
     end
 
     it "raises an exception for invalid context" do

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for missing States" do
       payload = {"StartAt" => "Nothing"}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"States\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires non-empty Hash field \"States\"")
     end
 
     it "raises an exception for invalid States" do
@@ -31,13 +31,13 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for missing StartAt" do
       payload = {"States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"StartAt\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires field \"StartAt\"")
     end
 
     it "raises an exception for StartAt not in States" do
       payload = {"StartAt" => "Foo", "States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"StartAt\" not in the \"States\" field")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires field \"StartAt\" to be in \"States\" list but got [Foo]")
     end
 
     it "raises an exception for a State missing a Type field" do

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for invalid States" do
       payload = make_payload({"FirstState" => {"Type" => "Invalid"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Invalid state type: [Invalid]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State [FirstState] requires String field \"Type\" but got invalid value [Invalid]")
     end
 
     it "raises an exception for missing StartAt" do
@@ -43,7 +43,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for a State missing a Type field" do
       payload = make_payload({"FirstState" => {}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing \"Type\" field in state [FirstState]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State [FirstState] requires field \"Type\"")
     end
 
     it "raises an exception for an invalid State name" do


### PR DESCRIPTION
Alt to #209

This reads parameters, ensuring the data types, and no extra parameters.
The errors explain the exact location of the incorrect attribute.

Unlike 209, this wraps the params with an object that knows the location and has type checking.

Details
=======

- Fixes specs that don't define a `Next`.
- When state names are too long, display only the first 80 characters.
- All classes throws `InvalidWorkflowError` instead of relying upon later states to wrap unknown exceptions.
- Use `PayloadValidator` (instead of payload) to read values
- Detects unknown attributes.
- Enforces attribute types.
- All fields with validations. Separate PR for Choice, but now validates Paths
- Full context defined for `Path` or `ReferencePath` errors.
