### PR TITLE
tweaking code climate test limits

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,3 +14,13 @@ plugins:
     config: ".rubocop_cc.yml"
     channel: rubocop-1-56-3
 version: '2'
+checks:
+  complexity-logic:
+    config:
+      threshold: 10
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  file-lines:
+    enabled: false


### PR DESCRIPTION
Possible Values can be found:
  https://docs.codeclimate.com/docs/default-analysis-configuration

A few limits I feel are off.
But this is here to start a conversation about what we want to modify.

- Drop `method-lines` and `file-lines` -- These issues would trigger a complexity issue.
- Drop `method-count` -- It does show complexity, so this is up to you all.
- Increase `complexity-logic` from 5 to 10.

For this repo, we have the following issues:

- `Workflow#initialize` complexity 17 > 5
- `Workflow#wait` complexity 34 > 5, ~~lines 45 > 25~~
- `Docker#wait` complexity 29 > 5, ~~lines 29 > 25~~
- `Kubernetes` methods 24 > 20, ~~lines 256 > 250~~
- `Kubernetes#initialize` complexity 13 > 5
- `Kubernetes#wait` complexity 21 > 5, ~~lines 36 > 25~~
- `Kubernetes#pod_spec` lines 40 > 25
- ~~`Kubernetes#cubeclient` complexity 9 > 5~~
- ~~`Context` methods 24 > 20~~
- `Context#initialize` complexity 14 > 5
- `Podman#global_docker_options` complexity 13 > 5
- ~~`Data#true?` lines 36 > 25~~
- ~~`ContainerRunner#resolve_cli_options!` complexity 7 > 5~~
- ~~`Task#initialize` complexity 7 > 5~~
- ~~`Task#parse_output` complexity 6 > 5~~
- ~~`State#wait` complexity 6 > 5~~

Striked out entries would go away.