### PR TITLE
Separate workflow/context with different loggers

### DIFF
--- a/lib/floe/cli.rb
+++ b/lib/floe/cli.rb
@@ -22,8 +22,7 @@ module Floe
 
       workflows =
         workflows_inputs.each_slice(2).map do |workflow, input|
-          context = Floe::Workflow::Context.new(opts[:context], :input => input, :credentials => credentials)
-          Floe::Workflow.load(workflow, context)
+          create_workflow(workflow, opts[:context], input, credentials)
         end
 
       Floe::Workflow.wait(workflows, &:run_nonblock)
@@ -81,6 +80,11 @@ module Floe
       Floe::ContainerRunner.resolve_cli_options!(opts)
 
       return workflows_inputs, opts
+    end
+
+    def create_workflow(workflow, context_payload, input, credentials)
+      context = Floe::Workflow::Context.new(context_payload, :input => input, :credentials => credentials)
+      Floe::Workflow.load(workflow, context)
     end
   end
 end

--- a/lib/floe/cli.rb
+++ b/lib/floe/cli.rb
@@ -1,9 +1,10 @@
+require "floe"
+require "floe/container_runner"
+
 module Floe
   class CLI
     def initialize
       require "optimist"
-      require "floe"
-      require "floe/container_runner"
       require "logger"
 
       Floe.logger = Logger.new($stdout)

--- a/lib/floe/cli.rb
+++ b/lib/floe/cli.rb
@@ -3,6 +3,8 @@ require "floe/container_runner"
 
 module Floe
   class CLI
+    include Logging
+
     def initialize
       require "optimist"
       require "logger"
@@ -21,12 +23,19 @@ module Floe
           create_workflow(workflow, opts[:context], input, credentials)
         end
 
-      Floe::Workflow.wait(workflows, &:run_nonblock)
+      logger.info("Checking #{workflows.count} workflows...")
+      ready = Floe::Workflow.wait(workflows, &:run_nonblock)
+      logger.info("Checking #{workflows.count} workflows...Complete - #{ready.count} ready")
 
       # Display status
       workflows.each do |workflow|
-        puts "", "#{workflow.name}#{" (#{workflow.status})" unless workflow.context.success?}", "===" if workflows.size > 1
-        puts workflow.output
+        if workflows.size > 1
+          logger.info("")
+          logger.info("#{workflow.name}#{" (#{workflow.status})" unless workflow.context.success?}")
+          logger.info("===")
+        end
+
+        logger.info(workflow.output)
       end
 
       workflows.all? { |workflow| workflow.context.success? }

--- a/lib/floe/cli.rb
+++ b/lib/floe/cli.rb
@@ -13,12 +13,7 @@ module Floe
     def run(args = ARGV)
       workflows_inputs, opts = parse_options!(args)
 
-      credentials =
-        if opts[:credentials_given]
-          opts[:credentials] == "-" ? $stdin.read : opts[:credentials]
-        elsif opts[:credentials_file_given]
-          File.read(opts[:credentials_file])
-        end
+      credentials = create_credentials(opts)
 
       workflows =
         workflows_inputs.each_slice(2).map do |workflow, input|
@@ -80,6 +75,14 @@ module Floe
       Floe::ContainerRunner.resolve_cli_options!(opts)
 
       return workflows_inputs, opts
+    end
+
+    def create_credentials(opts)
+      if opts[:credentials_given]
+        opts[:credentials] == "-" ? $stdin.read : opts[:credentials]
+      elsif opts[:credentials_file_given]
+        File.read(opts[:credentials_file])
+      end
     end
 
     def create_workflow(workflow, context_payload, input, credentials)

--- a/lib/floe/container_runner/docker.rb
+++ b/lib/floe/container_runner/docker.rb
@@ -30,7 +30,7 @@ module Floe
         end
 
         begin
-          runner_context["container_ref"] = run_container(image, env, execution_id, runner_context["secrets_ref"])
+          runner_context["container_ref"] = run_container(image, env, execution_id, runner_context["secrets_ref"], context.logger)
           runner_context
         rescue AwesomeSpawn::CommandResultError => err
           cleanup(runner_context)
@@ -123,7 +123,7 @@ module Floe
 
       attr_reader :network
 
-      def run_container(image, env, execution_id, secrets_file)
+      def run_container(image, env, execution_id, secrets_file, logger)
         params = run_container_params(image, env, execution_id, secrets_file)
 
         logger.debug("Running #{AwesomeSpawn.build_command_line(self.class::DOCKER_COMMAND, params)}")

--- a/lib/floe/container_runner/kubernetes.rb
+++ b/lib/floe/container_runner/kubernetes.rb
@@ -285,7 +285,8 @@ module Floe
         code    = notice.object&.code
         reason  = notice.object&.reason
 
-        logger.warn("Received [#{code} #{reason}], [#{message}]")
+        # This feels like a global concern and not an end user's concern
+        Floe.logger.warn("Received [#{code} #{reason}], [#{message}]")
 
         true
       end

--- a/lib/floe/logging.rb
+++ b/lib/floe/logging.rb
@@ -7,7 +7,11 @@ module Floe
     end
 
     def logger
-      Floe.logger
+      @logger || Floe.logger
+    end
+
+    def logger=(logger)
+      @logger = logger
     end
   end
 end

--- a/lib/floe/runner.rb
+++ b/lib/floe/runner.rb
@@ -2,8 +2,6 @@
 
 module Floe
   class Runner
-    include Logging
-
     OUTPUT_MARKER = "__FLOE_OUTPUT__\n"
 
     def initialize(_options = {}) # rubocop:disable Style/RedundantInitialize

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -18,7 +18,6 @@ module Floe
 
       def wait(workflows, timeout: nil, &block)
         workflows = [workflows] if workflows.kind_of?(self)
-        logger.info("Checking #{workflows.count} workflows...")
 
         run_until   = Time.now.utc + timeout if timeout.to_i > 0
         ready       = []
@@ -72,7 +71,6 @@ module Floe
           sleep_thread&.kill
         end
 
-        logger.info("Checking #{workflows.count} workflows...Complete - #{ready.count} ready")
         ready
       ensure
         wait_thread&.kill

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -3,6 +3,8 @@
 module Floe
   class Workflow
     class Context
+      include Logging
+
       attr_accessor :credentials
 
       # @param context [Json|Hash] (default, create another with input and execution params)

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -9,7 +9,7 @@ module Floe
 
       # @param context [Json|Hash] (default, create another with input and execution params)
       # @param input [Hash] (default: {})
-      def initialize(context = nil, input: nil, credentials: {})
+      def initialize(context = nil, input: nil, credentials: {}, logger: nil)
         context = JSON.parse(context) if context.kind_of?(String)
         input   = JSON.parse(input || "{}")
 
@@ -22,6 +22,8 @@ module Floe
         self["Task"]               ||= {}
 
         @credentials = credentials || {}
+
+        self.logger = logger if logger
       rescue JSON::ParserError => err
         raise Floe::InvalidExecutionInput, "Invalid State Machine Execution Input: #{err}: was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')"
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -3,7 +3,6 @@
 module Floe
   class Workflow
     class State
-      include Logging
       include ValidationMixin
 
       class << self
@@ -63,7 +62,7 @@ module Floe
       def mark_started(context)
         context.state["EnteredTime"] = Time.now.utc.iso8601
 
-        logger.info("Running state: [#{long_name}] with input [#{context.json_input}]...")
+        context.logger.info("Running state: [#{long_name}] with input [#{context.json_input}]...")
       end
 
       def mark_finished(context)
@@ -74,7 +73,7 @@ module Floe
         context.state["Duration"]       = finished_time - entered_time
 
         level = context.failed? ? :error : :info
-        logger.public_send(level, "Running state: [#{long_name}] with input [#{context.json_input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.json_output}]")
+        context.logger.public_send(level, "Running state: [#{long_name}] with input [#{context.json_input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.json_output}]")
 
         0
       end

--- a/lib/floe/workflow/states/retry_catch_mixin.rb
+++ b/lib/floe/workflow/states/retry_catch_mixin.rb
@@ -29,7 +29,7 @@ module Floe
           wait_until!(context, :seconds => retrier.sleep_duration(context["State"]["RetryCount"]))
           context.next_state = context.state_name
           context.output     = error
-          logger.info("Running state: [#{long_name}] with input [#{context.json_input}] got error[#{context.json_output}]...Retry - delay: #{wait_until(context)}")
+          context.logger.info("Running state: [#{long_name}] with input [#{context.json_input}] got error[#{context.json_output}]...Retry - delay: #{wait_until(context)}")
           true
         end
 
@@ -39,7 +39,7 @@ module Floe
 
           context.next_state = catcher.next
           context.output     = catcher.result_path.set(context.input, error)
-          logger.info("Running state: [#{long_name}] with input [#{context.json_input}]...CatchError - next state: [#{context.next_state}] output: [#{context.json_output}]")
+          context.logger.info("Running state: [#{long_name}] with input [#{context.json_input}]...CatchError - next state: [#{context.next_state}] output: [#{context.json_output}]")
 
           true
         end
@@ -49,7 +49,7 @@ module Floe
           # keeping in here for completeness
           context.next_state = nil
           context.output = error
-          logger.error("Running state: [#{long_name}] with input [#{context.json_input}]...Complete workflow - output: [#{context.json_output}]")
+          context.logger.error("Running state: [#{long_name}] with input [#{context.json_input}]...Complete workflow - output: [#{context.json_output}]")
         end
       end
     end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("Checking 1 workflows...")
-      expect(lines.last).to eq("{}")
+      expect(lines.last).to include("{}")
     end
 
     it "with a bare workflow and input" do
@@ -39,7 +39,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("Checking 1 workflows...")
-      expect(lines.last).to eq('{"foo":1}')
+      expect(lines.last).to include('{"foo":1}')
     end
 
     it "with a bare workflow and --input" do
@@ -48,7 +48,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("Checking 1 workflows...")
-      expect(lines.last).to eq('{"foo":1}')
+      expect(lines.last).to include('{"foo":1}')
     end
 
     it "with --workflow and no input" do
@@ -57,7 +57,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("Checking 1 workflows...")
-      expect(lines.last).to eq("{}")
+      expect(lines.last).to include("{}")
     end
 
     it "with --workflow and --input" do
@@ -66,7 +66,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("Checking 1 workflows...")
-      expect(lines.last).to eq('{"foo":1}')
+      expect(lines.last).to include('{"foo":1}')
     end
 
     it "with a bare workflow and --workflow" do
@@ -74,7 +74,7 @@ RSpec.describe Floe::CLI do
       expect(result).to be false
 
       lines = error.lines(:chomp => true)
-      expect(lines.first).to eq("Error: cannot specify both --workflow and bare workflows.")
+      expect(lines.first).to include("Error: cannot specify both --workflow and bare workflows.")
     end
 
     it "with --input but no workflows" do
@@ -82,7 +82,7 @@ RSpec.describe Floe::CLI do
       expect(result).to be false
 
       lines = error.lines(:chomp => true)
-      expect(lines.first).to eq("Error: workflow(s) must be specified.")
+      expect(lines.first).to include("Error: workflow(s) must be specified.")
     end
 
     it "with multiple bare workflow/input pairs" do
@@ -91,7 +91,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("Checking 2 workflows...")
-      expect(lines.last(7).join("\n")).to eq(<<~OUTPUT.chomp)
+      expect(lines.last(7).map { |line| line.gsub(/^.* INFO -- : /, "") }.join("\n")).to eq(<<~OUTPUT.chomp)
         workflow
         ===
         {"foo":1}
@@ -108,7 +108,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("Checking 2 workflows...")
-      expect(lines.last(7).join("\n")).to eq(<<~OUTPUT.chomp)
+      expect(lines.last(7).map { |line| line.gsub(/^.* INFO -- : /, "") }.join("\n")).to eq(<<~OUTPUT.chomp)
         workflow
         ===
         {"foo":1}
@@ -124,7 +124,7 @@ RSpec.describe Floe::CLI do
       expect(result).to be false
 
       lines = error.lines(:chomp => true)
-      expect(lines.first).to eq("Error: workflow/input pairs must be specified.")
+      expect(lines.first).to include("Error: workflow/input pairs must be specified.")
     end
 
     def run_cli(*args)


### PR DESCRIPTION
## Goal

The logging is global to all of floe. This means we do not associate certain logging information with each user/run.

Setting up a per execution log allows us to isolate the log per running instance and display it to the end user.

## Implementation

The `Context` is a per execution concept. It contains the user's information (in execution), the user's credentials, and the runtime context. (including credentials in context has conflated the db context and the runtime context)

Since we want a per execution logger, I added logger to the `Context`.

## Alternative

The `Workflow` currently contains the states and the runtime `Context`. The suggestion was to add the `logger` to the `Workflow`. Unfortunately, this does not work because while the various components have access to the `Context`, they do not have access to the `Workflow`.

So I propose we stay the course and use `Context#logger`

## Extracted

pulled out the following PRs:

- [ ] https://github.com/ManageIQ/floe/pull/289
