### PR TITLE
Fix Input/Output handling for Pass, Choice, Succeed states

### DIFF
--- a/lib/floe/workflow/path.rb
+++ b/lib/floe/workflow/path.rb
@@ -26,8 +26,10 @@ module Floe
             [input, payload]
           end
 
-        results = JsonPath.on(obj, path)
+        # If path is $ then just return the entire input
+        return obj if path == "$"
 
+        results = JsonPath.on(obj, path)
         results.count < 2 ? results.first : results
       end
     end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -19,7 +19,8 @@ module Floe
         end
 
         def finish(context)
-          output     = output_path.value(context, context.input)
+          input      = input_path.value(context, context.input)
+          output     = output_path.value(context, input)
           next_state = choices.detect { |choice| choice.true?(context, output) }&.next || default
 
           context.next_state = next_state

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -25,7 +25,8 @@ module Floe
         end
 
         def finish(context)
-          context.output = process_output(context, result)
+          input = result.nil? ? process_input(context) : result
+          context.output = process_output(context, input)
           super
         end
 

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -6,9 +6,18 @@ module Floe
       class Succeed < Floe::Workflow::State
         attr_reader :input_path, :output_path
 
+        def initialize(workflow, name, payload)
+          super
+
+          @input_path  = Path.new(payload.fetch("InputPath", "$"))
+          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+        end
+
         def finish(context)
+          input              = input_path.value(context, context.input)
+          context.output     = output_path.value(context, input)
           context.next_state = nil
-          context.output     = context.input
+
           super
         end
 

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -121,6 +121,16 @@ RSpec.describe Floe::Workflow::States::Pass do
           expect(ctx.output).to eq("red")
         end
       end
+
+      context "with InputPath, ResultPath, and OutputPath" do
+        let(:input)   { {"color" => "red", "garbage" => nil} }
+        let(:payload) { {"Pass" => {"Type" => "Pass", "End" => true, "InputPath" => "$.color", "ResultPath" => "$.results", "OutputPath" => "$.results"}} }
+
+        it "Uses OutputPath to drop other keys" do
+          workflow.run_nonblock
+          expect(ctx.output).to eq("red")
+        end
+      end
     end
   end
 end

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -89,5 +89,38 @@ RSpec.describe Floe::Workflow::States::Pass do
         )
       end
     end
+
+    context "Without Results" do
+      let(:input) { {"color" => "red"} }
+      let(:payload) do
+        {"Pass" => {"Type" => "Pass", "End" => true}}
+      end
+
+      it "passes output through to input" do
+        workflow.run_nonblock
+        expect(ctx.output).to eq(input)
+      end
+
+      context "with InputPath" do
+        let(:payload) do
+          {"Pass" => {"Type" => "Pass", "End" => true, "InputPath" => "$.color"}}
+        end
+
+        it "Uses InputPath to select color" do
+          workflow.run_nonblock
+          expect(ctx.output).to eq("red")
+        end
+      end
+
+      context "with OutputPath" do
+        let(:input)   { {"color" => "red", "garbage" => nil} }
+        let(:payload) { {"Pass" => {"Type" => "Pass", "End" => true, "OutputPath" => "$.color"}} }
+
+        it "Uses OutputPath to drop other keys" do
+          workflow.run_nonblock
+          expect(ctx.output).to eq("red")
+        end
+      end
+    end
   end
 end

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe Floe::Workflow::States::Succeed do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
   let(:state)    { workflow.start_workflow.current_state }
-  let(:workflow) { make_workflow(ctx, {"SuccessState" => {"Type" => "Succeed"}}) }
+  let(:payload)  { {"SuccessState" => {"Type" => "Succeed"}} }
+  let(:workflow) { make_workflow(ctx, payload) }
 
   it "#end?" do
     expect(state.end?).to be true
@@ -12,6 +13,34 @@ RSpec.describe Floe::Workflow::States::Succeed do
     it "has no next" do
       state.run_nonblock!(ctx)
       expect(ctx.next_state).to eq(nil)
+    end
+
+    context "with input" do
+      let(:input) { {"color" => "red"} }
+
+      it "sets output to input" do
+        state.run_nonblock!(ctx)
+        expect(ctx.output).to eq(input)
+      end
+
+      context "with InputPath" do
+        let(:payload) { {"SuccessState" => {"Type" => "Succeed", "InputPath" => "$.color"}} }
+
+        it "sets the output to the selected input path" do
+          state.run_nonblock!(ctx)
+          expect(ctx.output).to eq(input["color"])
+        end
+      end
+
+      context "with OutputPath" do
+        let(:input)   { {"color" => "red", "garbage" => nil} }
+        let(:payload) { {"SuccessState" => {"Type" => "Succeed", "OutputPath" => "$.color"}} }
+
+        it "sets the output to the selected input path" do
+          state.run_nonblock!(ctx)
+          expect(ctx.output).to eq(input["color"])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Introduced by https://github.com/ManageIQ/floe/pull/191/files#diff-04416988853398624310337389715edeb1fed6c963a0a2a41ef882df8166dd6e

We're missing proper input processing for the Pass state if there is no Result attribute:

```
$ aws stepfunctions --endpoint-url http://localhost:8083 create-state-machine --name Pass --role-arn "arn:aws:iam::012345678901:role/DummyRole" --definition "{\"Comment\": \"Using Pass State\", \"StartAt\": \"Pass\", \"States\": {\"Pass\": {\"Type\": \"Pass\", \"End\": true, \"InputPath\": \"$.colors\"}}}"
$ aws stepfunctions --endpoint-url http://localhost:8083 start-execution --state-machine-arn arn:aws:states:us-east-1:123456789012:stateMachine:Pass --input '{"colors": "red"}'
$ aws stepfunctions --endpoint-url http://localhost:8083 describe-execution --execution-arn arn:aws:states:us-east-1:123456789012:execution:Pass:4747e8dd-c3ab-4124-bb45-1d7337018ddb
{
    "executionArn": "arn:aws:states:us-east-1:123456789012:execution:Pass:4747e8dd-c3ab-4124-bb45-1d7337018ddb",
    "stateMachineArn": "arn:aws:states:us-east-1:123456789012:stateMachine:Pass",
    "name": "4747e8dd-c3ab-4124-bb45-1d7337018ddb",
    "status": "SUCCEEDED",
    "startDate": "2024-06-19T12:59:05.702000-04:00",
    "stopDate": "2024-06-19T12:59:05.706000-04:00",
    "input": "{\"colors\": \"red\"}",
    "inputDetails": {
        "included": true
    },
    "output": "\"red\"",
    "outputDetails": {
        "included": true
    }
}
```

We should be getting `"red"` as the output, but currently we return the entire input payload:
```
Failures:

  1) Floe::Workflow::States::Pass#run_nonblock! Without Results Uses input
     Failure/Error: expect(ctx.output).to eq("red")
     
       expected: "red"
            got: {"color"=>"red"}
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -"red"
       +"color" => "red",
       
     # ./spec/workflow/states/pass_spec.rb:101:in `block (4 levels) in <top (required)>'
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
