### PR TITLE
Validate that state machine input is valid JSON

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -42,6 +42,7 @@ require "time"
 module Floe
   class Error < StandardError; end
   class InvalidWorkflowError < Error; end
+  class InvalidExecutionInput < Error; end
 
   def self.logger
     @logger ||= NullLogger.new

--- a/lib/floe/cli.rb
+++ b/lib/floe/cli.rb
@@ -35,6 +35,8 @@ module Floe
       end
 
       workflows.all? { |workflow| workflow.context.success? }
+    rescue Floe::Error => err
+      abort(err.message)
     end
 
     private

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -111,7 +111,7 @@ module Floe
       validate_workflow
 
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.short_name] = state }
-    rescue Floe::InvalidWorkflowError
+    rescue Floe::Error
       raise
     rescue => err
       raise Floe::InvalidWorkflowError, err.message

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -9,9 +9,7 @@ module Floe
       # @param input [Hash] (default: {})
       def initialize(context = nil, input: nil, credentials: {})
         context = JSON.parse(context) if context.kind_of?(String)
-
-        input ||= {}
-        input = JSON.parse(input) if input.kind_of?(String)
+        input   = JSON.parse(input || "{}")
 
         @context = context || {}
         self["Execution"]          ||= {}
@@ -23,7 +21,7 @@ module Floe
 
         @credentials = credentials || {}
       rescue JSON::ParserError => err
-        raise Floe::InvalidWorkflowError, err.message
+        raise Floe::InvalidExecutionInput, "Invalid State Machine Execution Input: #{err}: was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')"
       end
 
       def execution

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Floe::Workflow::Context do
-  let(:ctx) { described_class.new(:input => input) }
+  let(:ctx) { described_class.new(:input => input.to_json) }
   let(:input) { {"x" => "y"}.freeze }
 
   describe "#new" do
@@ -9,7 +9,7 @@ RSpec.describe Floe::Workflow::Context do
     end
 
     it "with a context, sets input and keeps context" do
-      ctx = described_class.new({"Execution" => {"api" => "http://localhost/"}}, :input => input)
+      ctx = described_class.new({"Execution" => {"api" => "http://localhost/"}}, :input => input.to_json)
       expect(ctx.execution["api"]).to eq("http://localhost/")
       expect(ctx.state).not_to eq(nil)
     end
@@ -19,7 +19,7 @@ RSpec.describe Floe::Workflow::Context do
     end
 
     context "with a simple string input" do
-      let(:input) { "\"foo\"" }
+      let(:input) { "foo" }
 
       it "sets the input" do
         expect(ctx.execution["Input"]).to eq("foo")

--- a/spec/workflow/error_matcher_mixin_spec.rb
+++ b/spec/workflow/error_matcher_mixin_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::ErrorMatcherMixin do
   let(:input) { {} }
-  let(:ctx) { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx) { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:resource) { "docker://hello-world:latest" }
   # we could have used catchers
   let(:retriers) { {"ErrorEquals" => ["States.ALL"]} }

--- a/spec/workflow/retrier_spec.rb
+++ b/spec/workflow/retrier_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::Retrier do
   let(:input) { {} }
-  let(:ctx) { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx) { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:resource) { "docker://hello-world:latest" }
   let(:workflow) do
     make_workflow(

--- a/spec/workflow/state_spec.rb
+++ b/spec/workflow/state_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::State do
   let(:input)    { {} }
-  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:state)    { workflow.start_workflow.current_state }
   # picked a state that doesn't instantly finish
   let(:workflow) { make_workflow(ctx, payload) }

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::States::Choice do
   let(:input)    { {} }
-  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) { make_workflow(ctx, payload) }
   let(:choices) do

--- a/spec/workflow/states/fail_spec.rb
+++ b/spec/workflow/states/fail_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::States::Fail do
   let(:input)    { {} }
-  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) do
     make_workflow(

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::States::Pass do
   let(:input)    { {} }
-  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) { make_workflow(ctx, payload) }
   let(:payload) do

--- a/spec/workflow/states/succeed_spec.rb
+++ b/spec/workflow/states/succeed_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::States::Succeed do
   let(:input)    { {} }
-  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:state)    { workflow.start_workflow.current_state }
   let(:payload)  { {"SuccessState" => {"Type" => "Succeed"}} }
   let(:workflow) { make_workflow(ctx, payload) }

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::States::Task do
   let(:input)    { {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}} }
-  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:resource) { "docker://hello-world:latest" }
   let(:workflow) { make_workflow(ctx, payload) }
 

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Floe::Workflow::States::Pass do
   let(:input)    { {} }
-  let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
+  let(:ctx)      { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 


### PR DESCRIPTION
When running a workflow validate that the state-machine input is valid JSON.  We were a little lax with specs passing Hashes in for convenience but it isn't hard to ensure we're passing JSON in to context input.

When running with ASL passing invalid input:
```
$ aws stepfunctions --endpoint-url http://localhost:8083 start-execution --state-machine-arn arn:aws:states:us-east-1:123456789012:stateMachine:Pass --input 'foo'

An error occurred (InvalidExecutionInput) when calling the StartExecution operation: Invalid State Machine Execution Input: 'Unrecognized token 'foo': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (String)"foo"; line: 1, column: 4]'
```

With this PR:
```
$ exe/floe examples/workflow.asl 'foo'
Invalid State Machine Execution Input: unexpected token at 'foo': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
