### PR TITLE
Pass full path name to State.new for better errors

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -7,6 +7,7 @@ require_relative "floe/logging"
 
 require_relative "floe/runner"
 
+require_relative "floe/validation_mixin"
 require_relative "floe/workflow"
 require_relative "floe/workflow/error_matcher_mixin"
 require_relative "floe/workflow/catcher"

--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Floe
+  module ValidationMixin
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    def parser_error!(comment)
+      self.class.parser_error!(name, comment)
+    end
+
+    def missing_field_error!(field_name)
+      self.class.missing_field_error!(name, field_name)
+    end
+
+    def invalid_field_error!(field_name, field_value = nil, comment = nil)
+      self.class.invalid_field_error!(name, field_name, field_value, comment)
+    end
+
+    def workflow_state?(field_value, workflow)
+      workflow.payload["States"] ? workflow.payload["States"].include?(field_value) : true
+    end
+
+    def wrap_parser_error(field_name, field_value)
+      yield
+    rescue ArgumentError, InvalidWorkflowError => error
+      invalid_field_error!(field_name, field_value, error.message)
+    end
+
+    module ClassMethods
+      def parser_error!(name, comment)
+        name = name.join(".") if name.kind_of?(Array)
+        raise Floe::InvalidWorkflowError, "#{name} #{comment}"
+      end
+
+      def missing_field_error!(name, field_name)
+        parser_error!(name, "does not have required field \"#{field_name}\"")
+      end
+
+      def invalid_field_error!(name, field_name, field_value, comment)
+        # instead of displaying a large hash or array, just displaying the word Hash or Array
+        field_value = field_value.class if field_value.kind_of?(Hash) || field_value.kind_of?(Array)
+
+        parser_error!(name, "field \"#{field_name}\"#{" value \"#{field_value}\"" unless field_value.nil?} #{comment}")
+      end
+    end
+  end
+end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -6,6 +6,7 @@ require "json"
 module Floe
   class Workflow
     include Logging
+    include ValidationMixin
 
     class << self
       def load(path_or_io, context = nil, credentials = {}, name = nil)
@@ -96,10 +97,7 @@ module Floe
       # caller should really put credentials into context and not pass that variable
       context.credentials = credentials if credentials
 
-      raise Floe::InvalidWorkflowError, "Missing field \"States\""  if payload["States"].nil?
-      raise Floe::InvalidWorkflowError, "Missing field \"StartAt\"" if payload["StartAt"].nil?
-      raise Floe::InvalidWorkflowError, "\"StartAt\" not in the \"States\" field" unless payload["States"].key?(payload["StartAt"])
-
+      # NOTE: this is a string, and states use an array
       @name        = name || "State Machine"
       @payload     = payload
       @context     = context
@@ -108,7 +106,10 @@ module Floe
 
       # NOTE: Everywhere else we include our name (i.e.: parent name) when building the child name.
       #       When creating the states, we are dropping our name (i.e.: the workflow name)
-      @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, ["States", state_name], state) }
+      @states      = payload["States"].to_a.map { |state_name, state| State.build!(self, ["States", state_name], state) }
+
+      validate_workflow
+
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.short_name] = state }
     rescue Floe::InvalidWorkflowError
       raise
@@ -191,6 +192,12 @@ module Floe
     end
 
     private
+
+    def validate_workflow
+      missing_field_error!("States") if @states.empty?
+      missing_field_error!("StartAt") if @start_at.nil?
+      invalid_field_error!("StartAt", @start_at, "is not found in \"States\"") unless workflow_state?(@start_at, self)
+    end
 
     def step!
       next_state = {"Name" => context.next_state, "Guid" => SecureRandom.uuid, "PreviousStateGuid" => context.state["Guid"]}

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -5,10 +5,11 @@ module Floe
     class Catcher
       include Floe::Workflow::ErrorMatcherMixin
 
-      attr_reader :error_equals, :next, :result_path
+      attr_reader :error_equals, :next, :result_path, :name
 
-      def initialize(payload)
-        @payload = payload
+      def initialize(_workflow, name, payload)
+        @name         = name
+        @payload      = payload
 
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -3,7 +3,8 @@
 module Floe
   class Workflow
     class Catcher
-      include Floe::Workflow::ErrorMatcherMixin
+      include ErrorMatcherMixin
+      include ValidationMixin
 
       attr_reader :error_equals, :next, :result_path, :name
 
@@ -14,7 +15,8 @@ module Floe
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]
         @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
-        raise Floe::InvalidWorkflowError, "State requires ErrorEquals" if !@error_equals.kind_of?(Array) || @error_equals.empty?
+
+        missing_field_error!("ErrorEquals") if !@error_equals.kind_of?(Array) || @error_equals.empty?
       end
     end
   end

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -4,26 +4,31 @@ module Floe
   class Workflow
     class ChoiceRule
       class << self
-        def build(payload)
+        def build(workflow, name, payload)
           if (sub_payloads = payload["Not"])
-            Floe::Workflow::ChoiceRule::Not.new(payload, build_children([sub_payloads]))
+            name += ["Not"]
+            Floe::Workflow::ChoiceRule::Not.new(workflow, name, payload, build_children(workflow, name, [sub_payloads]))
           elsif (sub_payloads = payload["And"])
-            Floe::Workflow::ChoiceRule::And.new(payload, build_children(sub_payloads))
+            name += ["And"]
+            Floe::Workflow::ChoiceRule::And.new(workflow, name, payload, build_children(workflow, name, sub_payloads))
           elsif (sub_payloads = payload["Or"])
-            Floe::Workflow::ChoiceRule::Or.new(payload, build_children(sub_payloads))
+            name += ["Or"]
+            Floe::Workflow::ChoiceRule::Or.new(workflow, name, payload, build_children(workflow, name, sub_payloads))
           else
-            Floe::Workflow::ChoiceRule::Data.new(payload)
+            name += ["Data"]
+            Floe::Workflow::ChoiceRule::Data.new(workflow, name, payload)
           end
         end
 
-        def build_children(sub_payloads)
-          sub_payloads.map { |payload| build(payload) }
+        def build_children(workflow, name, sub_payloads)
+          sub_payloads.map.with_index { |payload, i| build(workflow, name + [i.to_s], payload) }
         end
       end
 
-      attr_reader :next, :payload, :variable, :children
+      attr_reader :next, :payload, :variable, :children, :name
 
-      def initialize(payload, children = nil)
+      def initialize(_workflow, name, payload, children = nil)
+        @name      = name
         @payload   = payload
         @children  = children
 

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -3,7 +3,8 @@
 module Floe
   class Workflow
     class Retrier
-      include Floe::Workflow::ErrorMatcherMixin
+      include ErrorMatcherMixin
+      include ValidationMixin
 
       attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate, :name
 
@@ -15,7 +16,8 @@ module Floe
         @interval_seconds = payload["IntervalSeconds"] || 1.0
         @max_attempts     = payload["MaxAttempts"] || 3
         @backoff_rate     = payload["BackoffRate"] || 2.0
-        raise Floe::InvalidWorkflowError, "State requires ErrorEquals" if !@error_equals.kind_of?(Array) || @error_equals.empty?
+
+        missing_field_error!("ErrorEquals") if !@error_equals.kind_of?(Array) || @error_equals.empty?
       end
 
       # @param [Integer] attempt 1 for the first attempt

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -5,10 +5,11 @@ module Floe
     class Retrier
       include Floe::Workflow::ErrorMatcherMixin
 
-      attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate
+      attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate, :name
 
-      def initialize(payload)
-        @payload = payload
+      def initialize(_workflow, name, payload)
+        @name             = name
+        @payload          = payload
 
         @error_equals     = payload["ErrorEquals"]
         @interval_seconds = payload["IntervalSeconds"] || 1.0

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -8,7 +8,7 @@ module Floe
       class << self
         def build!(workflow, name, payload)
           state_type = payload["Type"]
-          raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name}]" if payload["Type"].nil?
+          raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name.last}]" if payload["Type"].nil?
 
           begin
             klass = Floe::Workflow::States.const_get(state_type)
@@ -22,14 +22,14 @@ module Floe
 
       attr_reader :comment, :name, :type, :payload
 
-      def initialize(workflow, name, payload)
+      def initialize(_workflow, name, payload)
         @name     = name
         @payload  = payload
         @type     = payload["Type"]
         @comment  = payload["Comment"]
 
-        raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name}]" if payload["Type"].nil?
-        raise Floe::InvalidWorkflowError, "State name [#{name[..79]}...] must be less than or equal to 80 characters" if name.length > 80
+        raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{short_name}]" if payload["Type"].nil?
+        raise Floe::InvalidWorkflowError, "State name [#{short_name[..79]}...] must be less than or equal to 80 characters" if short_name.length > 80
       end
 
       def wait(context, timeout: nil)
@@ -86,8 +86,12 @@ module Floe
         context.state["WaitUntil"] && Time.parse(context.state["WaitUntil"])
       end
 
+      def short_name
+        name.last
+      end
+
       def long_name
-        "#{@type}:#{name}"
+        "#{type}:#{short_name}"
       end
 
       private

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -11,7 +11,7 @@ module Floe
 
           validate_state!(workflow)
 
-          @choices = payload["Choices"].map { |choice| ChoiceRule.build(choice) }
+          @choices = payload["Choices"].map.with_index { |choice, i| ChoiceRule.build(workflow, name + ["Choices", i.to_s], choice) }
           @default = payload["Default"]
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -44,12 +44,12 @@ module Floe
         end
 
         def validate_state_choices!
-          raise Floe::InvalidWorkflowError, "Choice state must have \"Choices\"" unless payload.key?("Choices")
-          raise Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array" unless payload["Choices"].kind_of?(Array) && !payload["Choices"].empty?
+          missing_field_error!("Choices") unless payload.key?("Choices")
+          invalid_field_error!("Choices", nil, "must be a non-empty array") unless payload["Choices"].kind_of?(Array) && !payload["Choices"].empty?
         end
 
         def validate_state_default!(workflow)
-          raise Floe::InvalidWorkflowError, "\"Default\" not in \"States\"" unless workflow.payload["States"].include?(payload["Default"])
+          invalid_field_error!("Default", payload["Default"], "is not found in \"States\"") if payload["Default"] && !workflow_state?(payload["Default"], workflow)
         end
       end
     end

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -12,8 +12,8 @@ module Floe
         end
 
         def validate_state_next!(workflow)
-          raise Floe::InvalidWorkflowError, "Missing \"Next\" field in state [#{name}]" if @next.nil? && !@end
-          raise Floe::InvalidWorkflowError, "\"Next\" [#{@next}] not in \"States\" for state [#{name}]" if @next && !workflow.payload["States"].key?(@next)
+          missing_field_error!("Next") if @next.nil? && !@end
+          invalid_field_error!("Next", @next, "is not found in \"States\"") if @next && !workflow_state?(@next, workflow)
         end
       end
     end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -20,8 +20,8 @@ module Floe
           @resource          = payload["Resource"]
           @runner            = Floe::Runner.for_resource(@resource)
           @timeout_seconds   = payload["TimeoutSeconds"]
-          @retry             = payload["Retry"].to_a.map { |retrier| Retrier.new(retrier) }
-          @catch             = payload["Catch"].to_a.map { |catcher| Catcher.new(catcher) }
+          @retry             = payload["Retry"].to_a.map.with_index { |retrier, i| Retrier.new(workflow, name + ["Retry", i.to_s], retrier) }
+          @catch             = payload["Catch"].to_a.map.with_index { |catcher, i| Catcher.new(workflow, name + ["Catch", i.to_s], catcher) }
           @input_path        = Path.new(payload.fetch("InputPath", "$"))
           @output_path       = Path.new(payload.fetch("OutputPath", "$"))
           @result_path       = ReferencePath.new(payload.fetch("ResultPath", "$"))

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
 
   describe ".build" do
     let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
-    let(:subject) { described_class.build(payload) }
+    let(:subject) { described_class.build(workflow, [name, "Choices", 1], payload) }
 
     it "works with valid next" do
       subject
@@ -12,13 +12,14 @@ RSpec.describe Floe::Workflow::ChoiceRule do
   end
 
   describe "#true?" do
-    let(:subject) { described_class.build(payload).true?(context, input) }
+    let(:subject) { described_class.build(workflow, [name, "Choices", 1], payload).true?(context, input) }
     let(:context) { {} }
 
     context "with abstract top level class" do
       let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
       let(:input) { {} }
-      let(:subject) { described_class.new(payload).true?(context, input) }
+      let(:subject) { described_class.new(workflow, [name, "Choices", 1], payload).true?(context, input) }
+
       it "is not implemented" do
         expect { subject }.to raise_exception(NotImplementedError)
       end

--- a/spec/workflow/error_matcher_mixin_spec.rb
+++ b/spec/workflow/error_matcher_mixin_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Floe::Workflow::ErrorMatcherMixin do
   describe "#match_error?" do
     context "with no ErrorEquals" do
       let(:retriers) { [{}] }
-      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, /requires.*ErrorEquals/) }
+      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, "State requires ErrorEquals") }
     end
 
     context "with empty ErrorEquals" do
       let(:retriers) { [{"ErrorEquals" => []}] }
-      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, /requires.*ErrorEquals/) }
+      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, "State requires ErrorEquals") }
     end
 
     context "when matching an error" do

--- a/spec/workflow/error_matcher_mixin_spec.rb
+++ b/spec/workflow/error_matcher_mixin_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Floe::Workflow::ErrorMatcherMixin do
   describe "#match_error?" do
     context "with no ErrorEquals" do
       let(:retriers) { [{}] }
-      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, "State requires ErrorEquals") }
+      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, "States.State.Retry.0 does not have required field \"ErrorEquals\"") }
     end
 
     context "with empty ErrorEquals" do
       let(:retriers) { [{"ErrorEquals" => []}] }
-      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, "State requires ErrorEquals") }
+      it { expect { subject }.to raise_error(Floe::InvalidWorkflowError, "States.State.Retry.0 does not have required field \"ErrorEquals\"") }
     end
 
     context "when matching an error" do

--- a/spec/workflow/state_spec.rb
+++ b/spec/workflow/state_spec.rb
@@ -3,7 +3,35 @@ RSpec.describe Floe::Workflow::State do
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
   let(:state)    { workflow.start_workflow.current_state }
   # picked a state that doesn't instantly finish
-  let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+  let(:workflow) { make_workflow(ctx, payload) }
+  let(:payload) do
+    {
+      "WaitState"    => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"},
+      "SuccessState" => {"Type" => "Succeed"}
+    }
+  end
+
+  describe "#initialize" do
+    context "with missing type" do
+      let(:payload) { {"FirstState" => {}} }
+      it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState does not have required field \"Type\"") }
+    end
+
+    context "with an invalid type" do
+      let(:payload) { {"FirstState" => {"Type" => "Bogus"}} }
+      it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState field \"Type\" value \"Bogus\" is not valid") }
+    end
+
+    context "with a long state name" do
+      let(:state_name) { "a" * 200 }
+      let(:payload) { {state_name => {"Type" => "Succeed"}} }
+
+      # NOTE: "#{state_name}" # will truncate the state_name per ruby rules
+      it "raises an exception for an invalid State name" do
+        expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States field \"Name\" value \"#{state_name}\" must be less than or equal to 80 characters")
+      end
+    end
+  end
 
   describe "#started?" do
     it "is not started yet" do

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -2,50 +2,45 @@ RSpec.describe Floe::Workflow::States::Choice do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
   let(:state)    { workflow.start_workflow.current_state }
-  let(:workflow) do
-    make_workflow(
-      ctx, {
-        "ChoiceState"      => {
-          "Type"    => "Choice",
-          "Choices" => [
-            {
-              "Variable"      => "$.foo",
-              "NumericEquals" => 1,
-              "Next"          => "FirstMatchState"
-            },
-            {
-              "Variable"      => "$.foo",
-              "NumericEquals" => 2,
-              "Next"          => "SecondMatchState"
-            },
-          ],
-          "Default" => "DefaultState"
-        },
-        "FirstMatchState"  => {"Type" => "Succeed"},
-        "SecondMatchState" => {"Type" => "Succeed"},
-        "DefaultState"     => {"Type" => "Succeed"}
-      }
-    )
+  let(:workflow) { make_workflow(ctx, payload) }
+  let(:choices) do
+    [
+      {"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"},
+      {"Variable" => "$.foo", "NumericEquals" => 2, "Next" => "SecondMatchState"},
+    ]
   end
 
-  it "raises an exception if Choices is missing" do
-    payload = {"Choice1" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 does not have required field \"Choices\"")
+  let(:payload) do
+    {
+      "Choice1"          => {
+        "Type"    => "Choice",
+        "Choices" => choices,
+        "Default" => "DefaultState"
+      },
+      "FirstMatchState"  => {"Type" => "Succeed"},
+      "SecondMatchState" => {"Type" => "Succeed"},
+      "DefaultState"     => {"Type" => "Succeed"}
+    }
   end
 
-  it "raises an exception if Choices is not an array" do
-    payload = {"Choice1" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Choices\" must be a non-empty array")
+  context "with missing Choices" do
+    let(:payload) { {"Choice1" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}} }
+    it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 does not have required field \"Choices\"") }
   end
 
-  it "raises an exception if Choices is an empty array" do
-    payload = {"Choice1" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Choices\" must be a non-empty array")
+  context "with non-array Choices" do
+    let(:choices) { {} }
+    it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Choices\" must be a non-empty array") }
   end
 
-  it "raises an exception if Default isn't a valid state" do
-    payload = {"Choice1" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Default\" value \"MissingState\" is not found in \"States\"")
+  context "with an empty Choices array" do
+    let(:choices) { [] }
+    it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Choices\" must be a non-empty array") }
+  end
+
+  context "with an invalid Default" do
+    let(:payload) { {"Choice1" => {"Type" => "Choice", "Choices" => choices, "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Succeed"}, "SecondMatchState" => {"Type" => "Succeed"}} }
+    it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Default\" value \"MissingState\" is not found in \"States\"") }
   end
 
   it "#end?" do

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -30,22 +30,22 @@ RSpec.describe Floe::Workflow::States::Choice do
 
   it "raises an exception if Choices is missing" do
     payload = {"Choice1" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "Choice state must have \"Choices\"")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 does not have required field \"Choices\"")
   end
 
   it "raises an exception if Choices is not an array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Choices\" must be a non-empty array")
   end
 
   it "raises an exception if Choices is an empty array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Choices\" must be a non-empty array")
   end
 
   it "raises an exception if Default isn't a valid state" do
-    payload = {"Choice1" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Success"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Default\" not in \"States\"")
+    payload = {"Choice1" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Succeed"}}
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 field \"Default\" value \"MissingState\" is not found in \"States\"")
   end
 
   it "#end?" do

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Floe::Workflow::States::Pass do
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
   let(:state)    { workflow.start_workflow.current_state }
   let(:workflow) { make_workflow(ctx, payload) }
-  let(:payload)  do
+  let(:payload) do
     {
       "PassState"    => {
         "Type"       => "Pass",
@@ -16,6 +16,76 @@ RSpec.describe Floe::Workflow::States::Pass do
       },
       "SuccessState" => {"Type" => "Succeed"}
     }
+  end
+
+  describe "#initialize" do
+    context "without no Next nor End" do
+      let(:payload)  do
+        {
+          "PassState" => {
+            "Type" => "Pass"
+          }
+        }
+      end
+
+      it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.PassState does not have required field \"Next\"") }
+    end
+
+    context "With a valid Next" do
+      let(:payload) do
+        {
+          "PassState"    => {
+            "Type" => "Pass",
+            "Next" => "SuccessState"
+          },
+          "SuccessState" => {"Type" => "Succeed"}
+        }
+      end
+
+      it { expect(workflow.states.first).not_to be_end }
+    end
+
+    context "With an unknown Next" do
+      let(:payload) do
+        {
+          "PassState" => {
+            "Type" => "Pass",
+            "Next" => "MissingState"
+          }
+        }
+      end
+
+      it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.PassState field \"Next\" value \"MissingState\" is not found in \"States\"") }
+    end
+
+    context "With an End" do
+      let(:payload) do
+        {
+          "PassState" => {
+            "Type" => "Pass",
+            "End"  => true
+          }
+        }
+      end
+
+      it { expect(workflow.states.first).to be_end }
+    end
+
+    # TODO: implement check for Next and End
+    # context "With both Next and End" do
+    #   let(:payload) do
+    #     {
+    #       "PassState"    => {
+    #         "Type" => "Pass",
+    #         "Next" => "SuccessState",
+    #         "End"  => true
+    #       },
+    #       "SuccessState" => {"Type" => "Succeed"}
+    #     }
+    #   end
+
+    #   it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.PassState error") }
+    # end
   end
 
   describe "#end?" do

--- a/spec/workflow/states/task_spec.rb
+++ b/spec/workflow/states/task_spec.rb
@@ -2,6 +2,23 @@ RSpec.describe Floe::Workflow::States::Task do
   let(:input)    { {"foo" => {"bar" => "baz"}, "bar" => {"baz" => "foo"}} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input) }
   let(:resource) { "docker://hello-world:latest" }
+  let(:workflow) { make_workflow(ctx, payload) }
+
+  describe "#initialize" do
+    context "with missing resource" do
+      let(:payload) { {"FirstState" => {"Type" => "Task", "End" => true}} }
+      it do
+        expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState does not have required field \"Resource\"")
+      end
+    end
+
+    context "with invalid resource scheme" do
+      let(:payload) { {"FirstState" => {"Type" => "Task", "Resource" => "invalid://foo", "End" => true}} }
+      it do
+        expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState field \"Resource\" value \"invalid://foo\" Invalid resource scheme [invalid]")
+      end
+    end
+  end
 
   describe "#run_async!" do
     let(:mock_runner) { double("Floe::Runner") }

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -40,31 +40,10 @@ RSpec.describe Floe::Workflow do
       expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State Machine field \"StartAt\" value \"Foo\" is not found in \"States\"")
     end
 
-    it "raises an exception for a State missing a Type field" do
-      payload = make_payload({"FirstState" => {}})
-
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState does not have required field \"Type\"")
-    end
-
-    it "raises an exception for an invalid State name" do
-      state_name = "a" * 200
-
-      # NOTE: "#{state_name}" # will truncate the state_name
-      payload = make_payload({state_name => {"Type" => "Succeed"}})
-
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States field \"Name\" value \"#{state_name}\" must be less than or equal to 80 characters")
-    end
-
     it "raises an exception for invalid context" do
       payload = make_payload({"FirstState" => {"Type" => "Success"}})
 
       expect { described_class.new(payload, "invalid context") }.to raise_error(Floe::InvalidWorkflowError, "unexpected token at 'invalid context'")
-    end
-
-    it "raises an exception for invalid resource scheme in a Task state" do
-      payload = make_payload({"FirstState" => {"Type" => "Task", "Resource" => "invalid://foo", "End" => true}})
-
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState field \"Resource\" value \"invalid://foo\" Invalid resource scheme [invalid]")
     end
   end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -19,39 +19,40 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for missing States" do
       payload = {"StartAt" => "Nothing"}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"States\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State Machine does not have required field \"States\"")
     end
 
     it "raises an exception for invalid States" do
       payload = make_payload({"FirstState" => {"Type" => "Invalid"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Invalid state type: [Invalid]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState field \"Type\" value \"Invalid\" is not valid")
     end
 
     it "raises an exception for missing StartAt" do
       payload = {"States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"StartAt\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State Machine does not have required field \"StartAt\"")
     end
 
     it "raises an exception for StartAt not in States" do
       payload = {"StartAt" => "Foo", "States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"StartAt\" not in the \"States\" field")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State Machine field \"StartAt\" value \"Foo\" is not found in \"States\"")
     end
 
     it "raises an exception for a State missing a Type field" do
       payload = make_payload({"FirstState" => {}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing \"Type\" field in state [FirstState]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState does not have required field \"Type\"")
     end
 
     it "raises an exception for an invalid State name" do
-      state_name = "a" * 81
-      truncated_state_name = "#{"a" * 80}..."
+      state_name = "a" * 200
+
+      # NOTE: "#{state_name}" # will truncate the state_name
       payload = make_payload({state_name => {"Type" => "Succeed"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State name [#{truncated_state_name}] must be less than or equal to 80 characters")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States field \"Name\" value \"#{state_name}\" must be less than or equal to 80 characters")
     end
 
     it "raises an exception for invalid context" do
@@ -63,7 +64,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for invalid resource scheme in a Task state" do
       payload = make_payload({"FirstState" => {"Type" => "Task", "Resource" => "invalid://foo", "End" => true}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Invalid resource scheme [invalid]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState field \"Resource\" value \"invalid://foo\" Invalid resource scheme [invalid]")
     end
   end
 


### PR DESCRIPTION
## Overview

`statelint` passes around the path to the states instead of just the name.

If we pass a full path to `State` and `ChoiceRule` we can improve validations

I want to go through each of the states to check all fields, but that just fixed up the existing errors and added a little bit of structure to help me fix ChoiceState

## Changes:

```diff
- State requires ErrorEquals
+ States.State.Retry.0 does not have required field "ErrorEquals"
- State requires ErrorEquals
+ States.State.Retry.0 does not have required field "ErrorEquals"
- Choice state must have "Choices"
+ States.Choice1 does not have required field "Choices"
- "Choices" must be a non-empty array
+ States.Choice1 field "Choices" must be a non-empty array
- "Choices" must be a non-empty array
+ States.Choice1 field "Choices" must be a non-empty array
- "Default" not in "States"
+ States.Choice1 field "Default" value "MissingState" is not found in "States"
- Missing field "States"
+ State Machine does not have required field "States"
- Invalid state type: [Invalid]
+ States.FirstState field "Type" value "Invalid" is not valid
- Missing field "StartAt"
+ State Machine does not have required field "StartAt"
- "StartAt" not in the "States" field
+ State Machine field "StartAt" value "Foo" is not found in "States"
- Missing "Type" field in state [FirstState]
+ States.FirstState does not have required field "Type"
- State name [#{truncated_state_name}] must be less than or equal to 80 characters
+ States field "Name" value "#{state_name}" must be less than or equal to 80 characters
- Invalid resource scheme [invalid]
+ States.FirstState field "Resource" value "invalid://foo" Invalid resource scheme [invalid]
```