### PR TITLE
Output should be in json

### DIFF
--- a/lib/floe/cli.rb
+++ b/lib/floe/cli.rb
@@ -30,7 +30,7 @@ module Floe
       # Display status
       workflows.each do |workflow|
         puts "", "#{workflow.name}#{" (#{workflow.status})" unless workflow.context.success?}", "===" if workflows.size > 1
-        puts workflow.output.inspect
+        puts workflow.output
       end
 
       workflows.all? { |workflow| workflow.context.success? }

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -157,7 +157,7 @@ module Floe
     end
 
     def output
-      context.output if end?
+      context.json_output if end?
     end
 
     def end?

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -54,8 +54,16 @@ module Floe
         state["Input"]
       end
 
+      def json_input
+        input.to_json
+      end
+
       def output
         state["Output"]
+      end
+
+      def json_output
+        output.to_json
       end
 
       def output=(val)

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -54,7 +54,7 @@ module Floe
       def start(context)
         context.state["EnteredTime"] = Time.now.utc.iso8601
 
-        logger.info("Running state: [#{long_name}] with input [#{context.input}]...")
+        logger.info("Running state: [#{long_name}] with input [#{context.json_input}]...")
       end
 
       def finish(context)
@@ -65,7 +65,7 @@ module Floe
         context.state["Duration"]       = finished_time - entered_time
 
         level = context.failed? ? :error : :info
-        logger.public_send(level, "Running state: [#{long_name}] with input [#{context.input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.output}]")
+        logger.public_send(level, "Running state: [#{long_name}] with input [#{context.json_input}]...Complete #{context.next_state ? "- next state [#{context.next_state}]" : "workflow -"} output: [#{context.json_output}]")
 
         0
       end

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -106,7 +106,7 @@ module Floe
           wait_until!(context, :seconds => retrier.sleep_duration(context["State"]["RetryCount"]))
           context.next_state = context.state_name
           context.output     = error
-          logger.info("Running state: [#{long_name}] with input [#{context.input}] got error[#{context.output}]...Retry - delay: #{wait_until(context)}")
+          logger.info("Running state: [#{long_name}] with input [#{context.json_input}] got error[#{context.json_output}]...Retry - delay: #{wait_until(context)}")
           true
         end
 
@@ -116,7 +116,7 @@ module Floe
 
           context.next_state = catcher.next
           context.output     = catcher.result_path.set(context.input, error)
-          logger.info("Running state: [#{long_name}] with input [#{context.input}]...CatchError - next state: [#{context.next_state}] output: [#{context.output}]")
+          logger.info("Running state: [#{long_name}] with input [#{context.json_input}]...CatchError - next state: [#{context.next_state}] output: [#{context.json_output}]")
 
           true
         end
@@ -126,7 +126,7 @@ module Floe
           # keeping in here for completeness
           context.next_state = nil
           context.output = error
-          logger.error("Running state: [#{long_name}] with input [#{context.input}]...Complete workflow - output: [#{context.output}]")
+          logger.error("Running state: [#{long_name}] with input [#{context.json_input}]...Complete workflow - output: [#{context.json_output}]")
         end
 
         def parse_error(output)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("checking 1 workflows...")
-      expect(lines.last).to eq('{"foo"=>1}')
+      expect(lines.last).to eq('{"foo":1}')
     end
 
     it "with a bare workflow and --input" do
@@ -48,7 +48,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("checking 1 workflows...")
-      expect(lines.last).to eq('{"foo"=>1}')
+      expect(lines.last).to eq('{"foo":1}')
     end
 
     it "with --workflow and no input" do
@@ -66,7 +66,7 @@ RSpec.describe Floe::CLI do
 
       lines = output.lines(:chomp => true)
       expect(lines.first).to include("checking 1 workflows...")
-      expect(lines.last).to eq('{"foo"=>1}')
+      expect(lines.last).to eq('{"foo":1}')
     end
 
     it "with a bare workflow and --workflow" do
@@ -94,11 +94,11 @@ RSpec.describe Floe::CLI do
       expect(lines.last(7).join("\n")).to eq(<<~OUTPUT.chomp)
         workflow
         ===
-        {"foo"=>1}
+        {"foo":1}
 
         workflow
         ===
-        {"foo"=>2}
+        {"foo":2}
       OUTPUT
     end
 
@@ -111,11 +111,11 @@ RSpec.describe Floe::CLI do
       expect(lines.last(7).join("\n")).to eq(<<~OUTPUT.chomp)
         workflow
         ===
-        {"foo"=>1}
+        {"foo":1}
 
         workflow
         ===
-        {"foo"=>1}
+        {"foo":1}
       OUTPUT
     end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Floe::Workflow do
       expect(ctx.ended?).to eq(true)
 
       # final results
-      expect(workflow.output).to eq(input)
+      expect(workflow.output).to eq(input.to_json)
       expect(workflow.status).to eq("success")
       expect(workflow.end?).to eq(true)
     end
@@ -113,7 +113,7 @@ RSpec.describe Floe::Workflow do
       expect(ctx.ended?).to eq(true)
 
       # final results
-      expect(workflow.output).to eq({"Cause" => "Bad Stuff", "Error" => "Issue"})
+      expect(workflow.output).to eq('{"Error":"Issue","Cause":"Bad Stuff"}')
       expect(workflow.status).to eq("failure")
       expect(workflow.end?).to eq(true)
     end
@@ -148,7 +148,7 @@ RSpec.describe Floe::Workflow do
       workflow.start_workflow
       workflow.step_nonblock
 
-      expect(workflow.output).to eq(input)
+      expect(workflow.output).to eq(input.to_json)
       expect(workflow.status).to eq("success")
       expect(workflow.end?).to eq(true)
       expect(ctx.output).to eq(input)
@@ -187,7 +187,7 @@ RSpec.describe Floe::Workflow do
         # step_nonblock should return 0 and mark the workflow as completed
         expect(workflow.step_nonblock).to eq(0)
 
-        expect(workflow.output).to eq(input)
+        expect(workflow.output).to eq(input.to_json)
         expect(workflow.status).to eq("success")
         expect(workflow.end?).to eq(true)
         expect(ctx.output).to eq(input)
@@ -243,7 +243,7 @@ RSpec.describe Floe::Workflow do
       expect(ctx.running?).to eq(false)
       expect(ctx.ended?).to eq(true)
 
-      expect(workflow.output).to eq(input)
+      expect(workflow.output).to eq(input.to_json)
     end
   end
 


### PR DESCRIPTION
## Overview

Extracts/Overlaps with:
- #228
- #222

Changes tests to ensure our `$stdout` and logs are producing json and not ruby.

## Tangent

What we do know:

- Input should be in JSON.
- Output should be in JSON.
- Logs should use JSON.
- Task input and output should use JSON.
- We need better error messaging around bad `input` and `context`, specifically handling `JSON::ParserError`.

What we don't know:

- Who converts `input` from JSON to ruby? (`CLI`, `Context#initialize`, `State`)
- Should the `Context#input` hold JSON or ruby?
- Should the `Context#output` hold JSON or ruby?
- Should `Context` in the database be JSON or ruby?

