### PR TITLE
Name path error

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -7,6 +7,7 @@ require_relative "floe/logging"
 
 require_relative "floe/runner"
 
+require_relative "floe/validation_mixin"
 require_relative "floe/workflow"
 require_relative "floe/workflow/catcher"
 require_relative "floe/workflow/choice_rule"

--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Floe
+  module ValidationMixin
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    def path!(field_name, field_value)
+      Workflow::Path.new(field_value) if field_value
+    rescue Floe::InvalidWorkflowError => err
+      error!("requires Path field \"#{field_name}\" #{err.message}")
+    end
+
+    def reference_path!(field_name, field_value)
+      Workflow::ReferencePath.new(field_value)
+    rescue Floe::InvalidWorkflowError => err
+      error!("requires ReferencePath field \"#{field_name}\" #{err.message}")
+    end
+
+    def payload_template!(_field_name, field_value)
+      Workflow::PayloadTemplate.new(field_value) if field_value
+    end
+
+    def require_field!(field_name, field_value, type: String)
+      error!("requires #{type} field \"#{field_name}\"") if field_value.nil? || (field_value.respond_to?(:empty?) && field_value.empty?)
+      error!("requires #{type} field \"#{field_name}\" but got [#{field_value}]") if !field_value.kind_of?(type)
+
+      field_value
+    end
+
+    def state_ref!(field_name, field_value, workflow)
+      error!("requires field \"#{field_name}\" to be in \"States\" list but got [#{field_value}]") if field_value && !workflow.payload["States"].include?(field_value)
+
+      field_value
+    end
+
+    def error!(comment)
+      raise Floe::InvalidWorkflowError, "#{full_name.join(".")} #{comment}"
+    end
+
+    module ClassMethods
+      def error!(full_name, comment)
+        raise Floe::InvalidWorkflowError, "#{full_name.join(".")} #{comment}"
+      end
+    end
+  end
+end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -106,7 +106,7 @@ module Floe
       @comment     = payload["Comment"]
       @start_at    = payload["StartAt"]
 
-      @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, state_name, state) }
+      @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, ["States", state_name], state) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
     rescue Floe::InvalidWorkflowError
       raise

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -3,10 +3,11 @@
 module Floe
   class Workflow
     class Catcher
-      attr_reader :error_equals, :next, :result_path
+      attr_reader :error_equals, :next, :result_path, :full_name
 
-      def initialize(payload)
-        @payload = payload
+      def initialize(full_name, payload)
+        @full_name    = full_name
+        @payload      = payload
 
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -3,6 +3,8 @@
 module Floe
   class Workflow
     class Catcher
+      include ValidationMixin
+
       attr_reader :error_equals, :next, :result_path, :full_name
 
       def initialize(full_name, payload)
@@ -11,7 +13,7 @@ module Floe
 
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]
-        @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
+        @result_path  = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
       end
     end
   end

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -3,37 +3,42 @@
 module Floe
   class Workflow
     class ChoiceRule
+      include ValidationMixin
+
       class << self
-        def build(full_name, payload)
+        def build(workflow, full_name, payload)
           if (sub_payloads = payload["Not"])
             name = full_name + ["Not"]
-            Floe::Workflow::ChoiceRule::Not.new(name, payload, build_children(name, [sub_payloads]))
+            Floe::Workflow::ChoiceRule::Not.new(workflow, name, payload, build_children(workflow, name, [sub_payloads]))
           elsif (sub_payloads = payload["And"])
             name = full_name + ["And"]
-            Floe::Workflow::ChoiceRule::And.new(name, payload, build_children(name, sub_payloads))
+            Floe::Workflow::ChoiceRule::And.new(workflow, name, payload, build_children(workflow, name, sub_payloads))
           elsif (sub_payloads = payload["Or"])
             name = full_name + ["Or"]
-            Floe::Workflow::ChoiceRule::Or.new(name, payload, build_children(name, sub_payloads))
+            Floe::Workflow::ChoiceRule::Or.new(workflow, name, payload, build_children(workflow, name, sub_payloads))
           else
             name = full_name + ["Data"]
-            Floe::Workflow::ChoiceRule::Data.new(name, payload)
+            Floe::Workflow::ChoiceRule::Data.new(workflow, name, payload)
           end
         end
 
-        def build_children(full_name, sub_payloads)
-          sub_payloads.each_with_index.map { |payload, i| build(full_name + [i.to_s], payload) }
+        def build_children(workflow, full_name, sub_payloads)
+          sub_payloads.each_with_index.map { |payload, i| build(workflow, full_name + [i.to_s], payload) }
         end
       end
 
       attr_reader :next, :payload, :variable, :children, :full_name
 
-      def initialize(full_name, payload, children = nil)
+      def initialize(workflow, full_name, payload, children = nil)
         @full_name = full_name
         @payload   = payload
         @children  = children
 
-        @next     = payload["Next"]
-        @variable = payload["Variable"]
+        # only valid when !is_child? but reading for validation later
+        @next      = payload["Next"]
+        @variable = path!("Variable", payload["Variable"])
+
+        validate_rule!(workflow, children)
       end
 
       def true?(*)
@@ -42,8 +47,21 @@ module Floe
 
       private
 
+      def validate_rule!(workflow, children)
+        error!("requires Path field \"Variable\"") if !@variable && !children
+        error!("does not recognize field \"Variable\"") if @variable && children
+
+        error!("requires field \"Next\"") if @next.nil? && !is_child?
+        error!("requires field \"Next\" to be in \"States\" list but got [#{@next}]") if @next && !workflow.payload["States"].key?(@next)
+        error!("does not recognize field \"Next\"") if @next && is_child?
+      end
+
+      def is_child?
+        %w[And Or Not].include?(full_name[-3])
+      end
+
       def variable_value(context, input)
-        Path.value(variable, context, input)
+        variable.value(context, input)
       end
     end
   end

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -4,26 +4,31 @@ module Floe
   class Workflow
     class ChoiceRule
       class << self
-        def build(payload)
+        def build(full_name, payload)
           if (sub_payloads = payload["Not"])
-            Floe::Workflow::ChoiceRule::Not.new(payload, build_children([sub_payloads]))
+            name = full_name + ["Not"]
+            Floe::Workflow::ChoiceRule::Not.new(name, payload, build_children(name, [sub_payloads]))
           elsif (sub_payloads = payload["And"])
-            Floe::Workflow::ChoiceRule::And.new(payload, build_children(sub_payloads))
+            name = full_name + ["And"]
+            Floe::Workflow::ChoiceRule::And.new(name, payload, build_children(name, sub_payloads))
           elsif (sub_payloads = payload["Or"])
-            Floe::Workflow::ChoiceRule::Or.new(payload, build_children(sub_payloads))
+            name = full_name + ["Or"]
+            Floe::Workflow::ChoiceRule::Or.new(name, payload, build_children(name, sub_payloads))
           else
-            Floe::Workflow::ChoiceRule::Data.new(payload)
+            name = full_name + ["Data"]
+            Floe::Workflow::ChoiceRule::Data.new(name, payload)
           end
         end
 
-        def build_children(sub_payloads)
-          sub_payloads.map { |payload| build(payload) }
+        def build_children(full_name, sub_payloads)
+          sub_payloads.each_with_index.map { |payload, i| build(full_name + [i.to_s], payload) }
         end
       end
 
-      attr_reader :next, :payload, :variable, :children
+      attr_reader :next, :payload, :variable, :children, :full_name
 
-      def initialize(payload, children = nil)
+      def initialize(full_name, payload, children = nil)
+        @full_name = full_name
         @payload   = payload
         @children  = children
 

--- a/lib/floe/workflow/path.rb
+++ b/lib/floe/workflow/path.rb
@@ -32,6 +32,10 @@ module Floe
         results = JsonPath.on(obj, path)
         results.count < 2 ? results.first : results
       end
+
+      def to_s
+        @payload
+      end
     end
   end
 end

--- a/lib/floe/workflow/reference_path.rb
+++ b/lib/floe/workflow/reference_path.rb
@@ -8,7 +8,7 @@ module Floe
       def initialize(*)
         super
 
-        raise Floe::InvalidWorkflowError, "Invalid Reference Path" if payload.match?(/@|,|:|\?/)
+        raise Floe::InvalidWorkflowError, "Reference Path [#{payload}] is invalid" if payload.match?(/@|,|:|\?/)
 
         @path = JsonPath.new(payload)
                         .path[1..]

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -3,10 +3,11 @@
 module Floe
   class Workflow
     class Retrier
-      attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate
+      attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate, :full_name
 
-      def initialize(payload)
-        @payload = payload
+      def initialize(full_name, payload)
+        @full_name        = full_name
+        @payload          = payload
 
         @error_equals     = payload["ErrorEquals"]
         @interval_seconds = payload["IntervalSeconds"] || 1.0

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -4,16 +4,18 @@ module Floe
   class Workflow
     class State
       include Logging
+      include ValidationMixin
 
       class << self
         def build!(workflow, full_name, payload)
           state_type = payload["Type"]
-          raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{full_name.last}]" if payload["Type"].nil?
+          error!(full_name, "requires String field \"Type\"") if state_type.nil? || state_type.empty?
+          error!(full_name, "requires String field \"Type\" but got [#{state_type}]") unless state_type.kind_of?(String)
 
           begin
             klass = Floe::Workflow::States.const_get(state_type)
           rescue NameError
-            raise Floe::InvalidWorkflowError, "Invalid state type: [#{state_type}]"
+            error!(full_name, "requires String field \"Type\" but got invalid value [#{state_type}]")
           end
 
           klass.new(workflow, full_name, payload)
@@ -28,7 +30,6 @@ module Floe
         @type     = payload["Type"]
         @comment  = payload["Comment"]
 
-        raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name}]" if payload["Type"].nil?
         raise Floe::InvalidWorkflowError, "State name [#{name[..79]}...] must be less than or equal to 80 characters" if name.length > 80
       end
 

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -6,9 +6,9 @@ module Floe
       include Logging
 
       class << self
-        def build!(workflow, name, payload)
+        def build!(workflow, full_name, payload)
           state_type = payload["Type"]
-          raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name}]" if payload["Type"].nil?
+          raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{full_name.last}]" if payload["Type"].nil?
 
           begin
             klass = Floe::Workflow::States.const_get(state_type)
@@ -16,14 +16,14 @@ module Floe
             raise Floe::InvalidWorkflowError, "Invalid state type: [#{state_type}]"
           end
 
-          klass.new(workflow, name, payload)
+          klass.new(workflow, full_name, payload)
         end
       end
 
-      attr_reader :comment, :name, :type, :payload
+      attr_reader :comment, :full_name, :type, :payload
 
-      def initialize(workflow, name, payload)
-        @name     = name
+      def initialize(_workflow, full_name, payload)
+        @full_name = full_name
         @payload  = payload
         @type     = payload["Type"]
         @comment  = payload["Comment"]
@@ -86,8 +86,12 @@ module Floe
         context.state["WaitUntil"] && Time.parse(context.state["WaitUntil"])
       end
 
+      def name
+        full_name.last
+      end
+
       def long_name
-        "#{@type}:#{name}"
+        "#{type}:#{name}"
       end
 
       private

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -9,13 +9,12 @@ module Floe
         def initialize(workflow, full_name, payload)
           super
 
-          validate_state!(workflow)
-
+          require_field!("Choices", payload["Choices"], type: Array)
           @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(full_name + ["Choices", i.to_s], choice) }
-          @default = payload["Default"]
+          @default = state_ref!("Default", payload["Default"], workflow)
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
+          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
         end
 
         def finish(context)
@@ -34,22 +33,6 @@ module Floe
 
         def end?
           false
-        end
-
-        private
-
-        def validate_state!(workflow)
-          validate_state_choices!
-          validate_state_default!(workflow)
-        end
-
-        def validate_state_choices!
-          raise Floe::InvalidWorkflowError, "Choice state must have \"Choices\"" unless payload.key?("Choices")
-          raise Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array" unless payload["Choices"].kind_of?(Array) && !payload["Choices"].empty?
-        end
-
-        def validate_state_default!(workflow)
-          raise Floe::InvalidWorkflowError, "\"Default\" not in \"States\"" unless workflow.payload["States"].include?(payload["Default"])
         end
       end
     end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -6,12 +6,12 @@ module Floe
       class Choice < Floe::Workflow::State
         attr_reader :choices, :default, :input_path, :output_path
 
-        def initialize(workflow, name, payload)
+        def initialize(workflow, full_name, payload)
           super
 
           validate_state!(workflow)
 
-          @choices = payload["Choices"].map { |choice| ChoiceRule.build(choice) }
+          @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(full_name + ["Choices", i.to_s], choice) }
           @default = payload["Default"]
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -10,7 +10,7 @@ module Floe
           super
 
           require_field!("Choices", payload["Choices"], type: Array)
-          @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(full_name + ["Choices", i.to_s], choice) }
+          @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(workflow, full_name + ["Choices", i.to_s], choice) }
           @default = state_ref!("Default", payload["Default"], workflow)
 
           @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -11,8 +11,8 @@ module Floe
 
           @cause      = payload["Cause"]
           @error      = payload["Error"]
-          @cause_path = Path.new(payload["CausePath"]) if payload["CausePath"]
-          @error_path = Path.new(payload["ErrorPath"]) if payload["ErrorPath"]
+          @cause_path = path!("CausePath", payload["CausePath"])
+          @error_path = path!("ErrorPath", payload["ErrorPath"])
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -10,11 +10,6 @@ module Floe
 
           super
         end
-
-        def validate_state_next!(workflow)
-          raise Floe::InvalidWorkflowError, "Missing \"Next\" field in state [#{name}]" if @next.nil? && !@end
-          raise Floe::InvalidWorkflowError, "\"Next\" [#{@next}] not in \"States\" for state [#{name}]" if @next && !workflow.payload["States"].key?(@next)
-        end
       end
     end
   end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -12,16 +12,16 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @next        = payload["Next"]
+          @next        = state_ref!("Next", payload["Next"], workflow)
           @end         = !!payload["End"]
           @result      = payload["Result"]
 
-          @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
-          @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
+          @parameters  = payload_template!("Parameters", payload["Parameters"])
+          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
+          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
+          @result_path = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
 
-          validate_state!(workflow)
+          validate_state!
         end
 
         def finish(context)
@@ -40,8 +40,8 @@ module Floe
 
         private
 
-        def validate_state!(workflow)
-          validate_state_next!(workflow)
+        def validate_state!
+          require_field!("Next", @next) unless @end
         end
       end
     end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -9,8 +9,8 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
+          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -11,7 +11,7 @@ module Floe
                     :result_selector, :resource, :timeout_seconds, :retry, :catch,
                     :input_path, :output_path, :result_path
 
-        def initialize(workflow, name, payload)
+        def initialize(workflow, full_name, payload)
           super
 
           @heartbeat_seconds = payload["HeartbeatSeconds"]
@@ -20,8 +20,8 @@ module Floe
           @resource          = payload["Resource"]
           @runner            = Floe::Runner.for_resource(@resource)
           @timeout_seconds   = payload["TimeoutSeconds"]
-          @retry             = payload["Retry"].to_a.map { |retrier| Retrier.new(retrier) }
-          @catch             = payload["Catch"].to_a.map { |catcher| Catcher.new(catcher) }
+          @retry             = payload["Retry"].to_a.each_with_index.map { |retrier, i| Retrier.new(full_name + ["Retry", i.to_s], retrier) }
+          @catch             = payload["Catch"].to_a.each_with_index.map { |catcher, i| Catcher.new(full_name + ["Retry", i.to_s], catcher) }
           @input_path        = Path.new(payload.fetch("InputPath", "$"))
           @output_path       = Path.new(payload.fetch("OutputPath", "$"))
           @result_path       = ReferencePath.new(payload.fetch("ResultPath", "$"))

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
 
   describe ".build" do
     let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
-    let(:subject) { described_class.build(payload) }
+    let(:subject) { described_class.build([name, "Choices", 1], payload) }
 
     it "works with valid next" do
       subject
@@ -12,13 +12,14 @@ RSpec.describe Floe::Workflow::ChoiceRule do
   end
 
   describe "#true?" do
-    let(:subject) { described_class.build(payload).true?(context, input) }
+    let(:subject) { described_class.build([name, "Choices", 1], payload).true?(context, input) }
     let(:context) { {} }
 
     context "with abstract top level class" do
       let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
       let(:input) { {} }
-      let(:subject) { described_class.new(payload).true?(context, input) }
+      let(:subject) { described_class.new([name, "Choices", 1], payload).true?(context, input) }
+
       it "is not implemented" do
         expect { subject }.to raise_exception(NotImplementedError)
       end

--- a/spec/workflow/reference_path_spec.rb
+++ b/spec/workflow/reference_path_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Floe::Workflow::ReferencePath do
       let(:payload) { "$.foo@.bar" }
 
       it "raises an exception" do
-        expect { subject }.to raise_error(Floe::InvalidWorkflowError, "Invalid Reference Path")
+        expect { subject }.to raise_error(Floe::InvalidWorkflowError, "Reference Path [$.foo@.bar] is invalid")
       end
     end
   end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -30,22 +30,22 @@ RSpec.describe Floe::Workflow::States::Choice do
 
   it "raises an exception if Choices is missing" do
     payload = {"Choice1" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "Choice state must have \"Choices\"")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires Array field \"Choices\"")
   end
 
   it "raises an exception if Choices is not an array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires Array field \"Choices\"")
   end
 
   it "raises an exception if Choices is an empty array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires Array field \"Choices\"")
   end
 
   it "raises an exception if Default isn't a valid state" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Success"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Default\" not in \"States\"")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires field \"Default\" to be in \"States\" list but got [MissingState]")
   end
 
   it "#end?" do

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Floe::Workflow::States::Pass do
     end
   end
 
+  describe "#initialize" do
+    it "requires a duration" do
+      expect do
+        make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}})
+      end.to raise_error(Floe::InvalidWorkflowError)
+    end
+  end
+
   describe "#running?" do
     context "with seconds" do
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for invalid States" do
       payload = make_payload({"FirstState" => {"Type" => "Invalid"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Invalid state type: [Invalid]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState requires String field \"Type\" but got invalid value [Invalid]")
     end
 
     it "raises an exception for missing StartAt" do
@@ -43,7 +43,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for a State missing a Type field" do
       payload = make_payload({"FirstState" => {}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing \"Type\" field in state [FirstState]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState requires String field \"Type\"")
     end
 
     it "raises an exception for an invalid State name" do

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for missing States" do
       payload = {"StartAt" => "Nothing"}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"States\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires non-empty Hash field \"States\"")
     end
 
     it "raises an exception for invalid States" do
@@ -31,13 +31,13 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for missing StartAt" do
       payload = {"States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"StartAt\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires String field \"StartAt\"")
     end
 
     it "raises an exception for StartAt not in States" do
       payload = {"StartAt" => "Foo", "States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"StartAt\" not in the \"States\" field")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires field \"StartAt\" to be in \"States\" list but got [Foo]")
     end
 
     it "raises an exception for a State missing a Type field" do


### PR DESCRIPTION
## Goals

- Present errors with exact location details.
- Detect if this `ChoiceRule` is in an `And/Not/Or` - so it does not allow a `Next`
- common validation rules for paths

## Based upon

This is an alternative to #209.
It adds validation methods directly to the `State` and doesn't add validation for booleans and others.

I can add `boolean`, `numeric`, and `String`, or I can go back to 209 with the validator.

## After

```
States.FirstMatchState.Choice.1.Data: requires Path field "Variable"
```