### PR TITLE
[WIP] [POS] Common Error message dsl

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -7,6 +7,7 @@ require_relative "floe/logging"
 
 require_relative "floe/runner"
 
+require_relative "floe/validation_mixin"
 require_relative "floe/workflow"
 require_relative "floe/workflow/catcher"
 require_relative "floe/workflow/choice_rule"

--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -7,6 +7,7 @@ require_relative "floe/logging"
 
 require_relative "floe/runner"
 
+require_relative "floe/basic_class_attribute"
 require_relative "floe/validation_mixin"
 require_relative "floe/workflow"
 require_relative "floe/workflow/catcher"

--- a/lib/floe/basic_class_attribute.rb
+++ b/lib/floe/basic_class_attribute.rb
@@ -1,0 +1,22 @@
+module BasicClassAttribute
+  # you probably want to use active support class_attribute instead:
+  # https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/module/redefine_method.rb
+  # https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/class/attribute.rb#L89
+  def basic_class_attribute(name, default: nil)
+    # may need to add line in RUBY to silence redefinition:
+    # alias #{name} #{name}
+    class_method = <<~RUBY
+      def #{name} ; end
+      def #{name}=(value)
+        define_method(:#{name}) { value } if singleton_class?
+        singleton_class.define_method(:#{name}) { value }
+        value
+      end
+    RUBY
+
+    location = caller_locations(1, 1).first
+    class_eval(["class << self", class_method, "end"].join(";").tr("\n", ";"), location.path, location.lineno)
+
+    public_send(:"#{name}=", default)
+  end
+end

--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -2,8 +2,114 @@
 
 module Floe
   module ValidationMixin
+    class ValidationField
+      # NOTE: default only used for number, path, reference_path, payload_template
+      attr_accessor :attribute_name, :field_name, :type, :default, :block
+
+      def initialize(attribute_name, field_name, type, default: nil, block: nil)
+        default ||= false if type == :boolean
+
+        @attribute_name = attribute_name
+        @field_name     = field_name
+        @type           = type
+        @block          = block
+        @default        = default
+      end
+
+      def klass
+        {:string => String, :number => Numeric, :list => Array, :hash => Hash, :timestamp => Date, :state_ref => String}[type] || type
+      end
+
+      def set_value(record, payload, workflow)
+        field_value = payload[field_name] || default
+        # could go with string! or field! -- generic seems to work for now
+        converted_value =
+          case type
+          when :boolean          then record.boolean!(field_name, field_value)
+          when :string           then record.string!(field_name, field_value)
+          when :number           then record.number!(field_name, field_value)
+          when :list             then record.list!(field_name, field_value, workflow, &block)
+          when :hash             then record.hash!(field_name, field_value, workflow, &block)
+          when :timestamp        then record.timestamp!(field_name, field_value || default)
+          when :state_ref        then record.state_ref!(field_name, field_value, workflow)
+          when :path             then record.path!(field_name, field_value)
+          when :reference_path   then record.reference_path!(field_name, field_value)
+          when :payload_template then record.payload_template!(field_name, field_value)
+          when :raw              then field_value
+          else
+            raise "what is a #{type}"
+          end
+        record.instance_variable_set(:"@#{attribute_name}", converted_value)
+      end
+
+      def current_value(record)
+        record.public_send(attribute_name)
+      end
+
+      def value?(record)
+        field_value = current_value(record)
+        field_value && !(field_value.respond_to?(:empty?) && field_value.empty?)
+      end
+    end
+
+    # validation dsl
+    class ValidationHandler
+      attr_accessor :klass
+
+      def initialize(klass)
+        @klass = klass
+      end
+
+      def field(type, field_name, attribute_name: nil, required: false, default: nil, &block)
+        # snake case the field
+        attribute_name ||= field_name.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase.to_sym
+
+        klass.attr_accessor attribute_name
+
+        klass.validation_fields = klass.validation_fields.merge(field_name => ValidationField.new(attribute_name, field_name, type, :default => default, :block => block))
+        require_set(field_name) if required
+      end
+
+      def require_set(*field_names)
+        invalid_fields = field_names.reject { |field_name| klass.validation_fields.key?(field_name) }
+        raise "unknown require_set fields: #{invalid_fields.join(", ")}" unless invalid_fields.empty?
+
+        klass.validation_set += [field_names]
+      end
+
+      # TODO: change from hash to a non-reserved word
+      def hash_list(...)
+        field(:hash, ...)
+      end
+
+      # TODO: verify type
+      def method_missing(type, ...)
+        field(type, ...)
+      end
+
+      # TODO: verify type
+      def respond_to_missing?(_type, *)
+        true
+      end
+    end
+
     def self.included(base)
+      base.extend(BasicClassAttribute)
+      base.basic_class_attribute(:validation_fields, :default => {})
+      base.basic_class_attribute(:validation_set, :default => [])
+
       base.extend(ClassMethods)
+    end
+
+    # validation dsl
+    def load_fields(payload, workflow)
+      self.class.validation_fields.each_value do |vf|
+        vf.set_value(self, payload, workflow)
+      end
+
+      self.class.validation_set.each do |field_name_list|
+        require_one_alt!(field_name_list)
+      end
     end
 
     def string!(field_name, field_value)
@@ -89,6 +195,20 @@ module Floe
       end
     end
 
+    def require_one_alt!(field_list)
+      # NOTE: intentionally using field_value and not field_value.nil?
+      #       false will act like it is not defined
+      present_fields = field_list.select do |field_name|
+        self.class.validation_fields[field_name].value?(self)
+      end
+
+      if present_fields.empty?
+        error!("requires #{"one " if field_list.size > 1}field \"#{field_list.join(", ")}\"")
+      elsif present_fields.size > 1
+        error!("requires only one field: #{present_fields.join(", ")}")
+      end
+    end
+
     def field!(field_name, field_value, type: String)
       type_str = type.to_s.split('::').last
 
@@ -116,6 +236,10 @@ module Floe
     end
 
     module ClassMethods
+      def fields(&block)
+        ValidationHandler.new(self).instance_eval(&block)
+      end
+
       def error!(full_name, comment)
         raise Floe::InvalidWorkflowError, "#{full_name.join(".")} #{comment}"
       end

--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -108,7 +108,7 @@ module Floe
       end
 
       self.class.validation_set.each do |field_name_list|
-        require_one_alt!(field_name_list)
+        require_field!(field_name_list)
       end
     end
 
@@ -178,33 +178,19 @@ module Floe
     end
 
     # this ensures one and only 1 of the listed fields are present
-    def require_fields!(field_values)
-      # NOTE: intentionally using field_value and not field_value.nil?
-      #       false will act like it is not defined
-      present_fields = field_values.filter_map do |name, value|
-        name unless !value || (value.respond_to?(:empty?) && value.empty?)
-      end
-
-      case present_fields.count
-      when 0
-        error!("requires #{"one " if field_values.size > 1}field \"#{field_values.keys.join(", ")}\"")
-      when 1
-        nil
-      else
-        error!("requires only one field: #{present_fields.join(", ")}")
-      end
-    end
-
-    def require_one_alt!(field_list)
+    def require_field!(field_list)
       # NOTE: intentionally using field_value and not field_value.nil?
       #       false will act like it is not defined
       present_fields = field_list.select do |field_name|
         self.class.validation_fields[field_name].value?(self)
       end
 
-      if present_fields.empty?
+      case present_fields.count
+      when 0
         error!("requires #{"one " if field_list.size > 1}field \"#{field_list.join(", ")}\"")
-      elsif present_fields.size > 1
+      when 1
+        nil
+      else
         error!("requires only one field: #{present_fields.join(", ")}")
       end
     end

--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -6,6 +6,49 @@ module Floe
       base.extend(ClassMethods)
     end
 
+    def string!(field_name, field_value)
+      field!(field_name, field_value, :type => String)
+    end
+
+    def boolean!(field_name, field_value)
+      field_value ||= false
+
+      error!("requires field \"#{field_name}\" to be a Boolean but got [#{field_value}]") unless [true, false].include?(field_value)
+
+      field_value
+    end
+
+    def number!(field_name, field_value)
+      field!(field_name, field_value, :type => Numeric)
+    end
+
+    def list!(field_name, field_value, workflow = nil)
+      param = field!(field_name, field_value, :type => Array)
+      return param.to_a if param.nil? || !block_given?
+
+      param.each_with_index.map do |child_payload, i|
+        yield workflow, full_name + [field_name, i.to_s], child_payload
+      end
+    end
+
+    def hash!(field_name, field_value, workflow = nil)
+      param = field!(field_name, field_value, :type => Hash)
+      return param if param.nil? || !block_given?
+
+      param.map do |child_name, child_payload|
+        yield workflow, full_name + [field_name, child_name], child_payload
+      end
+    end
+
+    def timestamp!(field_name, field_value)
+      require "date"
+      DateTime.rfc3339(field_value) if field_value
+
+      field_value
+    rescue TypeError, Date::Error
+      error!("requires field \"#{field_name}\" to be a Date but got [#{field_value}]")
+    end
+
     def state_ref!(field_name, field_value, workflow)
       error!("requires field \"#{field_name}\" to be in \"States\" list but got [#{field_value}]") if field_value && !state?(field_value, workflow)
 
@@ -45,6 +88,16 @@ module Floe
         error!("requires only one field: #{present_fields.join(", ")}")
       end
     end
+
+    def field!(field_name, field_value, type: String)
+      type_str = type.to_s.split('::').last
+
+      error!("requires #{type_str} field \"#{field_name}\" but got #{field_value.class}") if !field_value.nil? && !field_value.kind_of?(type)
+
+      field_value
+    end
+
+    # errors
 
     def reject_field!(field_name, field_value)
       error!("does not recognize field \"#{field_name}\"") if field_value

--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Floe
+  module ValidationMixin
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    def state_ref!(field_name, field_value, workflow)
+      error!("requires field \"#{field_name}\" to be in \"States\" list but got [#{field_value}]") if field_value && !state?(field_value, workflow)
+
+      field_value
+    end
+
+    def path!(field_name, field_value)
+      Workflow::Path.new(field_value) if field_value
+    rescue Floe::InvalidWorkflowError => err
+      error!("requires field \"#{field_name}\" #{err.message}")
+    end
+
+    def reference_path!(field_name, field_value)
+      Workflow::ReferencePath.new(field_value)
+    rescue Floe::InvalidWorkflowError => err
+      error!("requires field \"#{field_name}\" #{err.message}")
+    end
+
+    def payload_template!(_field_name, field_value)
+      Workflow::PayloadTemplate.new(field_value) if field_value
+    end
+
+    # this ensures one and only 1 of the listed fields are present
+    def require_fields!(field_values)
+      # NOTE: intentionally using field_value and not field_value.nil?
+      #       false will act like it is not defined
+      present_fields = field_values.filter_map do |name, value|
+        name if value && !(value.respond_to?(:empty?) && value.empty?)
+      end
+
+      if present_fields.empty?
+        error!("requires #{"one " if field_values.size > 1}field \"#{field_values.keys.join(", ")}\"")
+      elsif present_fields.size > 1
+        error!("requires only one field: #{present_fields.join(", ")}")
+      end
+    end
+
+    def reject_field!(field_name, field_value)
+      error!("does not recognize field \"#{field_name}\"") if field_value
+    end
+
+    def error!(comment)
+      raise Floe::InvalidWorkflowError, "#{full_name.empty? ? "Workflow" : full_name.join(".")} #{comment}"
+    end
+
+    private
+
+    # Yes, it is an issue if there are no states to search in.
+    # This suppresses that error assuming that the more important error (there are no states) be present
+    def state?(field_value, workflow)
+      workflow.payload["States"] ? workflow.payload["States"].include?(field_value) : true
+    end
+
+    module ClassMethods
+      def error!(full_name, comment)
+        raise Floe::InvalidWorkflowError, "#{full_name.join(".")} #{comment}"
+      end
+    end
+  end
+end

--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -33,12 +33,15 @@ module Floe
       # NOTE: intentionally using field_value and not field_value.nil?
       #       false will act like it is not defined
       present_fields = field_values.filter_map do |name, value|
-        name if value && !(value.respond_to?(:empty?) && value.empty?)
+        name unless !value || (value.respond_to?(:empty?) && value.empty?)
       end
 
-      if present_fields.empty?
+      case present_fields.count
+      when 0
         error!("requires #{"one " if field_values.size > 1}field \"#{field_values.keys.join(", ")}\"")
-      elsif present_fields.size > 1
+      when 1
+        nil
+      else
         error!("requires only one field: #{present_fields.join(", ")}")
       end
     end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -6,6 +6,7 @@ require "json"
 module Floe
   class Workflow
     include Logging
+    include ValidationMixin
 
     class << self
       def load(path_or_io, context = nil, credentials = {}, name = nil)
@@ -96,15 +97,13 @@ module Floe
       # caller should really put credentials into context and not pass that variable
       context.credentials = credentials if credentials
 
-      raise Floe::InvalidWorkflowError, "Missing field \"States\""  if payload["States"].nil?
-      raise Floe::InvalidWorkflowError, "Missing field \"StartAt\"" if payload["StartAt"].nil?
-      raise Floe::InvalidWorkflowError, "\"StartAt\" not in the \"States\" field" unless payload["States"].key?(payload["StartAt"])
-
       @name        = name
       @payload     = payload
       @context     = context
       @comment     = payload["Comment"]
       @start_at    = payload["StartAt"]
+
+      validate_workflow!
 
       @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, ["States", state_name], state) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
@@ -187,6 +186,7 @@ module Floe
     def credentials
       @context.credentials
     end
+
     private
 
     def step!
@@ -204,6 +204,16 @@ module Floe
 
     def end_workflow!
       context.execution["EndTime"] = context.state["FinishedTime"]
+    end
+
+    def full_name
+      %w[]
+    end
+
+    def validate_workflow!
+      require_fields!("States" => payload["States"])
+      state_ref!("StartAt", @start_at, self)
+      require_fields!("StartAt" => @start_at)
     end
   end
 end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -106,7 +106,7 @@ module Floe
       @comment     = payload["Comment"]
       @start_at    = payload["StartAt"]
 
-      @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, state_name, state) }
+      @states         = payload["States"].to_a.map { |state_name, state| State.build!(self, ["States", state_name], state) }
       @states_by_name = @states.each_with_object({}) { |state, result| result[state.name] = state }
     rescue Floe::InvalidWorkflowError
       raise

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -3,10 +3,11 @@
 module Floe
   class Workflow
     class Catcher
-      attr_reader :error_equals, :next, :result_path
+      attr_reader :error_equals, :next, :result_path, :full_name
 
-      def initialize(payload)
-        @payload = payload
+      def initialize(full_name, payload)
+        @full_name    = full_name
+        @payload      = payload
 
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -13,7 +13,6 @@ module Floe
 
       def initialize(workflow, full_name, payload)
         @full_name = full_name
-        @payload   = payload
 
         load_fields(payload, workflow)
       end

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -5,17 +5,17 @@ module Floe
     class Catcher
       include ValidationMixin
 
-      attr_reader :error_equals, :next, :result_path, :full_name
+      fields do
+        list           "ErrorEquals", :required => true
+        state_ref      "Next"
+        reference_path "ResultPath", :default => "$"
+      end
 
       def initialize(workflow, full_name, payload)
-        @full_name    = full_name
-        @payload      = payload
+        @full_name = full_name
+        @payload   = payload
 
-        @error_equals = list!("ErrorEquals", payload["ErrorEquals"], workflow)
-        @next         = state_ref!("Next", payload["Next"], workflow)
-        @result_path  = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
-
-        require_fields!("ErrorEquals" => @error_equals)
+        load_fields(payload, workflow)
       end
     end
   end

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -7,13 +7,15 @@ module Floe
 
       attr_reader :error_equals, :next, :result_path, :full_name
 
-      def initialize(_workflow, full_name, payload)
+      def initialize(workflow, full_name, payload)
         @full_name    = full_name
         @payload      = payload
 
-        @error_equals = payload["ErrorEquals"]
-        @next         = payload["Next"]
+        @error_equals = list!("ErrorEquals", payload["ErrorEquals"], workflow)
+        @next         = state_ref!("Next", payload["Next"], workflow)
         @result_path  = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
+
+        require_fields!("ErrorEquals" => @error_equals)
       end
     end
   end

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -3,15 +3,17 @@
 module Floe
   class Workflow
     class Catcher
+      include ValidationMixin
+
       attr_reader :error_equals, :next, :result_path, :full_name
 
-      def initialize(full_name, payload)
+      def initialize(_workflow, full_name, payload)
         @full_name    = full_name
         @payload      = payload
 
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]
-        @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
+        @result_path  = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
       end
     end
   end

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -3,37 +3,41 @@
 module Floe
   class Workflow
     class ChoiceRule
+      include ValidationMixin
+
       class << self
-        def build(full_name, payload)
+        def build(workflow, full_name, payload)
           if (sub_payloads = payload["Not"])
             name = full_name + ["Not"]
-            Floe::Workflow::ChoiceRule::Not.new(name, payload, build_children(name, [sub_payloads]))
+            Floe::Workflow::ChoiceRule::Not.new(workflow, name, payload, build_children(workflow, name, [sub_payloads]))
           elsif (sub_payloads = payload["And"])
             name = full_name + ["And"]
-            Floe::Workflow::ChoiceRule::And.new(name, payload, build_children(name, sub_payloads))
+            Floe::Workflow::ChoiceRule::And.new(workflow, name, payload, build_children(workflow, name, sub_payloads))
           elsif (sub_payloads = payload["Or"])
             name = full_name + ["Or"]
-            Floe::Workflow::ChoiceRule::Or.new(name, payload, build_children(name, sub_payloads))
+            Floe::Workflow::ChoiceRule::Or.new(workflow, name, payload, build_children(workflow, name, sub_payloads))
           else
             name = full_name + ["Data"]
-            Floe::Workflow::ChoiceRule::Data.new(name, payload)
+            Floe::Workflow::ChoiceRule::Data.new(workflow, name, payload)
           end
         end
 
-        def build_children(full_name, sub_payloads)
-          sub_payloads.each_with_index.map { |payload, i| build(full_name + [i.to_s], payload) }
+        def build_children(workflow, full_name, sub_payloads)
+          sub_payloads.each_with_index.map { |payload, i| build(workflow, full_name + [i.to_s], payload) }
         end
       end
 
       attr_reader :next, :payload, :variable, :children, :full_name
 
-      def initialize(full_name, payload, children = nil)
+      def initialize(workflow, full_name, payload, children = nil)
         @full_name = full_name
         @payload   = payload
         @children  = children
 
-        @next     = payload["Next"]
-        @variable = payload["Variable"]
+        @next      = state_ref!("Next", payload["Next"], workflow)
+        @variable  = path!("Variable", payload["Variable"])
+
+        validate_rule!(children)
       end
 
       def true?(*)
@@ -42,8 +46,26 @@ module Floe
 
       private
 
+      def validate_rule!(children)
+        if children
+          reject_field!("Variable", @variable)
+        else
+          require_fields!("Variable" => @variable)
+        end
+
+        if is_child?
+          reject_field!("Next", @next)
+        else
+          require_fields!("Next" => @next)
+        end
+      end
+
+      def is_child? # rubocop:disable Naming/PredicateName
+        %w[And Or Not].include?(full_name[-3])
+      end
+
       def variable_value(context, input)
-        Path.value(variable, context, input)
+        variable.value(context, input)
       end
     end
   end

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -27,16 +27,19 @@ module Floe
         end
       end
 
-      attr_reader :next, :payload, :variable, :children, :full_name
+      attr_reader :payload, :children, :full_name
+
+      fields do
+        state_ref "Next"
+        path      "Variable"
+      end
 
       def initialize(workflow, full_name, payload, children = nil)
         @full_name = full_name
         @payload   = payload
         @children  = children
 
-        @next      = state_ref!("Next", payload["Next"], workflow)
-        @variable  = path!("Variable", payload["Variable"])
-
+        load_fields(payload, workflow)
         validate_rule!(children)
       end
 

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -52,13 +52,13 @@ module Floe
         if children
           reject_field!("Variable", @variable)
         else
-          require_fields!("Variable" => @variable)
+          require_field!(["Variable"])
         end
 
         if is_child?
           reject_field!("Next", @next)
         else
-          require_fields!("Next" => @next)
+          require_field!(["Next"])
         end
       end
 

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -27,7 +27,7 @@ module Floe
         end
       end
 
-      attr_reader :payload, :children, :full_name
+      attr_reader :children, :full_name
 
       fields do
         state_ref "Next"
@@ -36,7 +36,6 @@ module Floe
 
       def initialize(workflow, full_name, payload, children = nil)
         @full_name = full_name
-        @payload   = payload
         @children  = children
 
         load_fields(payload, workflow)

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -4,26 +4,31 @@ module Floe
   class Workflow
     class ChoiceRule
       class << self
-        def build(payload)
+        def build(full_name, payload)
           if (sub_payloads = payload["Not"])
-            Floe::Workflow::ChoiceRule::Not.new(payload, build_children([sub_payloads]))
+            name = full_name + ["Not"]
+            Floe::Workflow::ChoiceRule::Not.new(name, payload, build_children(name, [sub_payloads]))
           elsif (sub_payloads = payload["And"])
-            Floe::Workflow::ChoiceRule::And.new(payload, build_children(sub_payloads))
+            name = full_name + ["And"]
+            Floe::Workflow::ChoiceRule::And.new(name, payload, build_children(name, sub_payloads))
           elsif (sub_payloads = payload["Or"])
-            Floe::Workflow::ChoiceRule::Or.new(payload, build_children(sub_payloads))
+            name = full_name + ["Or"]
+            Floe::Workflow::ChoiceRule::Or.new(name, payload, build_children(name, sub_payloads))
           else
-            Floe::Workflow::ChoiceRule::Data.new(payload)
+            name = full_name + ["Data"]
+            Floe::Workflow::ChoiceRule::Data.new(name, payload)
           end
         end
 
-        def build_children(sub_payloads)
-          sub_payloads.map { |payload| build(payload) }
+        def build_children(full_name, sub_payloads)
+          sub_payloads.each_with_index.map { |payload, i| build(full_name + [i.to_s], payload) }
         end
       end
 
-      attr_reader :next, :payload, :variable, :children
+      attr_reader :next, :payload, :variable, :children, :full_name
 
-      def initialize(payload, children = nil)
+      def initialize(full_name, payload, children = nil)
+        @full_name = full_name
         @payload   = payload
         @children  = children
 

--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -4,6 +4,17 @@ module Floe
   class Workflow
     class ChoiceRule
       class Data < Floe::Workflow::ChoiceRule
+        COMPARE_KEYS = %w[IsNull IsPresent IsNumeric IsString IsBoolean IsTimestamp String Numeric Boolean Timestamp].freeze
+
+        attr_reader :compare_key
+
+        def initialize(*)
+          super
+          @compare_key = payload.keys.detect { |key| key.match?(/^(#{COMPARE_KEYS.join("|")})/) }
+
+          raise Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key" if @compare_key.nil?
+        end
+
         def true?(context, input)
           lhs = variable_value(context, input)
           rhs = compare_value(context, input)
@@ -78,10 +89,6 @@ module Floe
           true
         rescue TypeError, Date::Error
           false
-        end
-
-        def compare_key
-          @compare_key ||= payload.keys.detect { |key| key.match?(/^(IsNull|IsPresent|IsNumeric|IsString|IsBoolean|IsTimestamp|String|Numeric|Boolean|Timestamp)/) }
         end
 
         def compare_value(context, input)

--- a/lib/floe/workflow/path.rb
+++ b/lib/floe/workflow/path.rb
@@ -32,6 +32,10 @@ module Floe
         results = JsonPath.on(obj, path)
         results.count < 2 ? results.first : results
       end
+
+      def to_s
+        @payload
+      end
     end
   end
 end

--- a/lib/floe/workflow/reference_path.rb
+++ b/lib/floe/workflow/reference_path.rb
@@ -8,7 +8,7 @@ module Floe
       def initialize(*)
         super
 
-        raise Floe::InvalidWorkflowError, "Invalid Reference Path" if payload.match?(/@|,|:|\?/)
+        raise Floe::InvalidWorkflowError, "Reference Path [#{payload}] is invalid" if payload.match?(/@|,|:|\?/)
 
         @path = JsonPath.new(payload)
                         .path[1..]

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -5,18 +5,20 @@ module Floe
     class Retrier
       include ValidationMixin
 
-      attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate, :full_name
+      attr_reader :full_name
+
+      fields do
+        list   "ErrorEquals", :required => true
+        number "IntervalSeconds", :default => 1.0
+        number "MaxAttempts", :default => 3
+        number "BackoffRate", :default => 2.0
+      end
 
       def initialize(workflow, full_name, payload)
-        @full_name        = full_name
-        @payload          = payload
+        @full_name = full_name
+        @payload   = payload
 
-        @error_equals     = list!("ErrorEquals", payload["ErrorEquals"], workflow)
-        @interval_seconds = number!("IntervalSeconds", payload.fetch("IntervalSeconds", 1.0))
-        @max_attempts     = number!("MaxAttempts", payload.fetch("MaxAttempts", 3))
-        @backoff_rate     = number!("BackoffRate", payload.fetch("BackoffRate", 2.0))
-
-        require_fields!("ErrorEquals" => @error_equals)
+        load_fields(payload, workflow)
       end
 
       # @param [Integer] attempt 1 for the first attempt

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -3,10 +3,11 @@
 module Floe
   class Workflow
     class Retrier
-      attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate
+      attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate, :full_name
 
-      def initialize(payload)
-        @payload = payload
+      def initialize(full_name, payload)
+        @full_name        = full_name
+        @payload          = payload
 
         @error_equals     = payload["ErrorEquals"]
         @interval_seconds = payload["IntervalSeconds"] || 1.0

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -16,7 +16,6 @@ module Floe
 
       def initialize(workflow, full_name, payload)
         @full_name = full_name
-        @payload   = payload
 
         load_fields(payload, workflow)
       end

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -3,9 +3,11 @@
 module Floe
   class Workflow
     class Retrier
+      include ValidationMixin
+
       attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate, :full_name
 
-      def initialize(full_name, payload)
+      def initialize(_workflow, full_name, payload)
         @full_name        = full_name
         @payload          = payload
 

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -7,14 +7,16 @@ module Floe
 
       attr_reader :error_equals, :interval_seconds, :max_attempts, :backoff_rate, :full_name
 
-      def initialize(_workflow, full_name, payload)
+      def initialize(workflow, full_name, payload)
         @full_name        = full_name
         @payload          = payload
 
-        @error_equals     = payload["ErrorEquals"]
-        @interval_seconds = payload["IntervalSeconds"] || 1.0
-        @max_attempts     = payload["MaxAttempts"] || 3
-        @backoff_rate     = payload["BackoffRate"] || 2.0
+        @error_equals     = list!("ErrorEquals", payload["ErrorEquals"], workflow)
+        @interval_seconds = number!("IntervalSeconds", payload.fetch("IntervalSeconds", 1.0))
+        @max_attempts     = number!("MaxAttempts", payload.fetch("MaxAttempts", 3))
+        @backoff_rate     = number!("BackoffRate", payload.fetch("BackoffRate", 2.0))
+
+        require_fields!("ErrorEquals" => @error_equals)
       end
 
       # @param [Integer] attempt 1 for the first attempt

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -34,16 +34,15 @@ module Floe
         end
       end
 
-      attr_reader :full_name, :payload
+      attr_reader :full_name
 
       fields do
         string "Type"
         string "Comment"
       end
 
-      def initialize(_workflow, full_name, payload)
+      def initialize(_workflow, full_name, _payload)
         @full_name = full_name
-        @payload   = payload
 
         # NOTE: requires child class to call: load_fields(payload, workflow)
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -41,10 +41,10 @@ module Floe
         string "Comment"
       end
 
-      def initialize(_workflow, full_name, _payload)
+      def initialize(workflow, full_name, payload)
         @full_name = full_name
 
-        # NOTE: requires child class to call: load_fields(payload, workflow)
+        load_fields(payload, workflow)
       end
 
       def wait(context, timeout: nil)

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -22,6 +22,11 @@ module Floe
         private
 
         def build_validate_type!(full_name, state_type)
+          if full_name.last.length > 80
+            full_name[-1] = "#{full_name.last[0..79]}..."
+            error!(full_name, "State name must be less than or equal to 80 characters")
+          end
+
           error!(full_name, "requires field \"Type\"") if state_type.nil? || state_type.empty?
           error!(full_name, "requires String field \"Type\" but got #{state_type.class}") unless state_type.kind_of?(String)
 
@@ -29,15 +34,18 @@ module Floe
         end
       end
 
-      attr_reader :comment, :full_name, :type, :payload
+      attr_reader :full_name, :payload
+
+      fields do
+        string "Type"
+        string "Comment"
+      end
 
       def initialize(_workflow, full_name, payload)
         @full_name = full_name
-        @payload  = payload
-        @type     = string!("Type", payload["Type"])
-        @comment  = string!("Comment", payload["Comment"])
+        @payload   = payload
 
-        raise Floe::InvalidWorkflowError, "State name [#{name[..79]}...] must be less than or equal to 80 characters" if name.length > 80
+        # NOTE: requires child class to call: load_fields(payload, workflow)
       end
 
       def wait(context, timeout: nil)

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -34,8 +34,8 @@ module Floe
       def initialize(_workflow, full_name, payload)
         @full_name = full_name
         @payload  = payload
-        @type     = payload["Type"]
-        @comment  = payload["Comment"]
+        @type     = string!("Type", payload["Type"])
+        @comment  = string!("Comment", payload["Comment"])
 
         raise Floe::InvalidWorkflowError, "State name [#{name[..79]}...] must be less than or equal to 80 characters" if name.length > 80
       end

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -6,9 +6,9 @@ module Floe
       include Logging
 
       class << self
-        def build!(workflow, name, payload)
+        def build!(workflow, full_name, payload)
           state_type = payload["Type"]
-          raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{name}]" if payload["Type"].nil?
+          raise Floe::InvalidWorkflowError, "Missing \"Type\" field in state [#{full_name.last}]" if payload["Type"].nil?
 
           begin
             klass = Floe::Workflow::States.const_get(state_type)
@@ -16,14 +16,14 @@ module Floe
             raise Floe::InvalidWorkflowError, "Invalid state type: [#{state_type}]"
           end
 
-          klass.new(workflow, name, payload)
+          klass.new(workflow, full_name, payload)
         end
       end
 
-      attr_reader :comment, :name, :type, :payload
+      attr_reader :comment, :full_name, :type, :payload
 
-      def initialize(workflow, name, payload)
-        @name     = name
+      def initialize(_workflow, full_name, payload)
+        @full_name = full_name
         @payload  = payload
         @type     = payload["Type"]
         @comment  = payload["Comment"]
@@ -86,8 +86,12 @@ module Floe
         context.state["WaitUntil"] && Time.parse(context.state["WaitUntil"])
       end
 
+      def name
+        full_name.last
+      end
+
       def long_name
-        "#{@type}:#{name}"
+        "#{type}:#{name}"
       end
 
       private

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -10,7 +10,7 @@ module Floe
           super
 
           validate_state!(workflow)
-          @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(full_name + ["Choices", i.to_s], choice) }
+          @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(workflow, full_name + ["Choices", i.to_s], choice) }
           @default = payload["Default"]
 
           @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -10,12 +10,11 @@ module Floe
           super
 
           validate_state!(workflow)
-
           @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(full_name + ["Choices", i.to_s], choice) }
           @default = payload["Default"]
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
+          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
         end
 
         def finish(context)
@@ -44,12 +43,11 @@ module Floe
         end
 
         def validate_state_choices!
-          raise Floe::InvalidWorkflowError, "Choice state must have \"Choices\"" unless payload.key?("Choices")
-          raise Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array" unless payload["Choices"].kind_of?(Array) && !payload["Choices"].empty?
+          require_fields!("Choices" => payload["Choices"])
         end
 
         def validate_state_default!(workflow)
-          raise Floe::InvalidWorkflowError, "\"Default\" not in \"States\"" unless workflow.payload["States"].include?(payload["Default"])
+          state_ref!("Default", payload["Default"], workflow)
         end
       end
     end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -9,12 +9,13 @@ module Floe
         def initialize(workflow, full_name, payload)
           super
 
-          validate_state!(workflow)
-          @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(workflow, full_name + ["Choices", i.to_s], choice) }
-          @default = payload["Default"]
+          @choices     = list!("Choices", payload["Choices"], workflow) { |wf, choice_name, choice_payload| ChoiceRule.build(wf, choice_name, choice_payload) }
+          @default     = state_ref!("Default", payload["Default"], workflow)
 
           @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
           @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
+
+          require_fields!("Choices" => payload["Choices"])
         end
 
         def finish(context)
@@ -33,21 +34,6 @@ module Floe
 
         def end?
           false
-        end
-
-        private
-
-        def validate_state!(workflow)
-          validate_state_choices!
-          validate_state_default!(workflow)
-        end
-
-        def validate_state_choices!
-          require_fields!("Choices" => payload["Choices"])
-        end
-
-        def validate_state_default!(workflow)
-          state_ref!("Default", payload["Default"], workflow)
         end
       end
     end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -11,12 +11,6 @@ module Floe
           path "OutputPath", :default => "$"
         end
 
-        def initialize(workflow, full_name, payload)
-          super
-
-          load_fields(payload, workflow)
-        end
-
         def finish(context)
           input      = input_path.value(context, context.input)
           output     = output_path.value(context, input)

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -6,12 +6,12 @@ module Floe
       class Choice < Floe::Workflow::State
         attr_reader :choices, :default, :input_path, :output_path
 
-        def initialize(workflow, name, payload)
+        def initialize(workflow, full_name, payload)
           super
 
           validate_state!(workflow)
 
-          @choices = payload["Choices"].map { |choice| ChoiceRule.build(choice) }
+          @choices = payload["Choices"].each_with_index.map { |choice, i| ChoiceRule.build(full_name + ["Choices", i.to_s], choice) }
           @default = payload["Default"]
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -4,18 +4,17 @@ module Floe
   class Workflow
     module States
       class Choice < Floe::Workflow::State
-        attr_reader :choices, :default, :input_path, :output_path
+        fields do
+          list("Choices", :required => true) { |wf, choice_name, choice_payload| ChoiceRule.build(wf, choice_name, choice_payload) }
+          state_ref "Default"
+          path "InputPath", :default => "$"
+          path "OutputPath", :default => "$"
+        end
 
         def initialize(workflow, full_name, payload)
           super
 
-          @choices     = list!("Choices", payload["Choices"], workflow) { |wf, choice_name, choice_payload| ChoiceRule.build(wf, choice_name, choice_payload) }
-          @default     = state_ref!("Default", payload["Default"], workflow)
-
-          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
-          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
-
-          require_fields!("Choices" => payload["Choices"])
+          load_fields(payload, workflow)
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -13,12 +13,6 @@ module Floe
           require_set "Error", "ErrorPath"
         end
 
-        def initialize(workflow, name, payload)
-          super
-
-          load_fields(payload, workflow)
-        end
-
         def finish(context)
           context.next_state = nil
           # TODO: support intrinsic functions here

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -4,15 +4,19 @@ module Floe
   class Workflow
     module States
       class Fail < Floe::Workflow::State
-        attr_reader :cause, :error
+        fields do
+          string "Cause"
+          string "Error"
+          path "CausePath"
+          path "ErrorPath"
+
+          require_set "Error", "ErrorPath"
+        end
 
         def initialize(workflow, name, payload)
           super
 
-          @cause      = string!("Cause", payload["Cause"])
-          @error      = string!("Error", payload["Error"])
-          @cause_path = path!("CausePath", payload["CausePath"])
-          @error_path = path!("ErrorPath", payload["ErrorPath"])
+          load_fields(payload, workflow)
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -11,8 +11,8 @@ module Floe
 
           @cause      = payload["Cause"]
           @error      = payload["Error"]
-          @cause_path = Path.new(payload["CausePath"]) if payload["CausePath"]
-          @error_path = Path.new(payload["ErrorPath"]) if payload["ErrorPath"]
+          @cause_path = path!("CausePath", payload["CausePath"])
+          @error_path = path!("ErrorPath", payload["ErrorPath"])
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -9,8 +9,8 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @cause      = payload["Cause"]
-          @error      = payload["Error"]
+          @cause      = string!("Cause", payload["Cause"])
+          @error      = string!("Error", payload["Error"])
           @cause_path = path!("CausePath", payload["CausePath"])
           @error_path = path!("ErrorPath", payload["ErrorPath"])
         end

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -10,11 +10,6 @@ module Floe
 
           super
         end
-
-        def validate_state_next!(workflow)
-          state_ref!("Next", @next, workflow)
-          require_fields!("Next" => @next, "End" => @end)
-        end
       end
     end
   end

--- a/lib/floe/workflow/states/non_terminal_mixin.rb
+++ b/lib/floe/workflow/states/non_terminal_mixin.rb
@@ -12,8 +12,8 @@ module Floe
         end
 
         def validate_state_next!(workflow)
-          raise Floe::InvalidWorkflowError, "Missing \"Next\" field in state [#{name}]" if @next.nil? && !@end
-          raise Floe::InvalidWorkflowError, "\"Next\" [#{@next}] not in \"States\" for state [#{name}]" if @next && !workflow.payload["States"].key?(@next)
+          state_ref!("Next", @next, workflow)
+          require_fields!("Next" => @next, "End" => @end)
         end
       end
     end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -7,21 +7,22 @@ module Floe
         include InputOutputMixin
         include NonTerminalMixin
 
-        attr_reader :end, :next, :result, :parameters, :input_path, :output_path, :result_path
+        fields do
+          state_ref        "Next"
+          boolean          "End"
+          raw              "Result"
+          payload_template "Parameters"
+          path             "InputPath", :default => "$"
+          path             "OutputPath", :default => "$"
+          reference_path   "ResultPath", :default => "$"
+
+          require_set "Next", "End"
+        end
 
         def initialize(workflow, name, payload)
           super
 
-          @next        = state_ref!("Next", payload["Next"], workflow)
-          @end         = boolean!("End", payload["End"])
-          @result      = payload["Result"]
-
-          @parameters  = payload_template!("Parameters", payload["Parameters"])
-          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
-          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
-          @result_path = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
-
-          require_fields!("Next" => @next, "End" => @end)
+          load_fields(payload, workflow)
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -16,10 +16,10 @@ module Floe
           @end         = !!payload["End"]
           @result      = payload["Result"]
 
-          @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
-          @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
+          @parameters  = payload_template!("Parameters", payload["Parameters"])
+          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
+          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
+          @result_path = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
 
           validate_state!(workflow)
         end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -19,12 +19,6 @@ module Floe
           require_set "Next", "End"
         end
 
-        def initialize(workflow, name, payload)
-          super
-
-          load_fields(payload, workflow)
-        end
-
         def finish(context)
           input = result.nil? ? process_input(context) : result
           context.output = process_output(context, input)

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -12,8 +12,8 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @next        = payload["Next"]
-          @end         = !!payload["End"]
+          @next        = state_ref!("Next", payload["Next"], workflow)
+          @end         = boolean!("End", payload["End"])
           @result      = payload["Result"]
 
           @parameters  = payload_template!("Parameters", payload["Parameters"])
@@ -21,7 +21,7 @@ module Floe
           @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
           @result_path = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
 
-          validate_state!(workflow)
+          require_fields!("Next" => @next, "End" => @end)
         end
 
         def finish(context)
@@ -36,12 +36,6 @@ module Floe
 
         def end?
           @end
-        end
-
-        private
-
-        def validate_state!(workflow)
-          validate_state_next!(workflow)
         end
       end
     end

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -9,12 +9,6 @@ module Floe
           path "OutputPath", :default => "$"
         end
 
-        def initialize(workflow, name, payload)
-          super
-
-          load_fields(payload, workflow)
-        end
-
         def finish(context)
           input              = input_path.value(context, context.input)
           context.output     = output_path.value(context, input)

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -4,13 +4,15 @@ module Floe
   class Workflow
     module States
       class Succeed < Floe::Workflow::State
-        attr_reader :input_path, :output_path
+        fields do
+          path "InputPath", :default => "$"
+          path "OutputPath", :default => "$"
+        end
 
         def initialize(workflow, name, payload)
           super
 
-          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
-          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
+          load_fields(payload, workflow)
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -9,8 +9,8 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
+          @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -21,13 +21,13 @@ module Floe
           @runner            = Floe::Runner.for_resource(@resource)
           @timeout_seconds   = payload["TimeoutSeconds"]
           @retry             = payload["Retry"].to_a.each_with_index.map { |retrier, i| Retrier.new(full_name + ["Retry", i.to_s], retrier) }
-          @catch             = payload["Catch"].to_a.each_with_index.map { |catcher, i| Catcher.new(full_name + ["Catch", i.to_s], catcher) }
-          @input_path        = Path.new(payload.fetch("InputPath", "$"))
-          @output_path       = Path.new(payload.fetch("OutputPath", "$"))
-          @result_path       = ReferencePath.new(payload.fetch("ResultPath", "$"))
-          @parameters        = PayloadTemplate.new(payload["Parameters"])     if payload["Parameters"]
-          @result_selector   = PayloadTemplate.new(payload["ResultSelector"]) if payload["ResultSelector"]
-          @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
+          @catch             = payload["Catch"].to_a.each_with_index.map { |catcher, i| Catcher.new(full_name + ["Retry", i.to_s], catcher) }
+          @input_path        = path!("InputPath", payload.fetch("InputPath", "$"))
+          @output_path       = path!("OutputPath", payload.fetch("OutputPath", "$"))
+          @result_path       = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
+          @parameters        = payload_template!("Parameters", payload["Parameters"])
+          @result_selector   = payload_template!("ResultSelector", payload["ResultSelector"])
+          @credentials       = payload_template!("Credentials", payload["Credentials"])
 
           validate_state!(workflow)
         rescue ArgumentError => err

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -11,7 +11,7 @@ module Floe
                     :result_selector, :resource, :timeout_seconds, :retry, :catch,
                     :input_path, :output_path, :result_path
 
-        def initialize(workflow, name, payload)
+        def initialize(workflow, full_name, payload)
           super
 
           @heartbeat_seconds = payload["HeartbeatSeconds"]
@@ -20,8 +20,8 @@ module Floe
           @resource          = payload["Resource"]
           @runner            = Floe::Runner.for_resource(@resource)
           @timeout_seconds   = payload["TimeoutSeconds"]
-          @retry             = payload["Retry"].to_a.map { |retrier| Retrier.new(retrier) }
-          @catch             = payload["Catch"].to_a.map { |catcher| Catcher.new(catcher) }
+          @retry             = payload["Retry"].to_a.each_with_index.map { |retrier, i| Retrier.new(full_name + ["Retry", i.to_s], retrier) }
+          @catch             = payload["Catch"].to_a.each_with_index.map { |catcher, i| Catcher.new(full_name + ["Catch", i.to_s], catcher) }
           @input_path        = Path.new(payload.fetch("InputPath", "$"))
           @output_path       = Path.new(payload.fetch("OutputPath", "$"))
           @result_path       = ReferencePath.new(payload.fetch("ResultPath", "$"))

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -20,8 +20,8 @@ module Floe
           @resource          = payload["Resource"]
           @runner            = Floe::Runner.for_resource(@resource)
           @timeout_seconds   = payload["TimeoutSeconds"]
-          @retry             = payload["Retry"].to_a.each_with_index.map { |retrier, i| Retrier.new(full_name + ["Retry", i.to_s], retrier) }
-          @catch             = payload["Catch"].to_a.each_with_index.map { |catcher, i| Catcher.new(full_name + ["Retry", i.to_s], catcher) }
+          @retry             = payload["Retry"].to_a.each_with_index.map { |retrier, i| Retrier.new(workflow, full_name + ["Retry", i.to_s], retrier) }
+          @catch             = payload["Catch"].to_a.each_with_index.map { |catcher, i| Catcher.new(workflow, full_name + ["Catch", i.to_s], catcher) }
           @input_path        = path!("InputPath", payload.fetch("InputPath", "$"))
           @output_path       = path!("OutputPath", payload.fetch("OutputPath", "$"))
           @result_path       = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -14,14 +14,14 @@ module Floe
         def initialize(workflow, full_name, payload)
           super
 
-          @heartbeat_seconds = payload["HeartbeatSeconds"]
-          @next              = payload["Next"]
-          @end               = !!payload["End"]
-          @resource          = payload["Resource"]
+          @heartbeat_seconds = number!("HeartbeatSeconds", payload["HeartbeatSeconds"])
+          @next              = state_ref!("Next", payload["Next"], workflow)
+          @end               = boolean!("End", payload["End"])
+          @resource          = string!("Resource", payload["Resource"])
           @runner            = Floe::Runner.for_resource(@resource)
-          @timeout_seconds   = payload["TimeoutSeconds"]
-          @retry             = payload["Retry"].to_a.each_with_index.map { |retrier, i| Retrier.new(workflow, full_name + ["Retry", i.to_s], retrier) }
-          @catch             = payload["Catch"].to_a.each_with_index.map { |catcher, i| Catcher.new(workflow, full_name + ["Catch", i.to_s], catcher) }
+          @timeout_seconds   = number!("TimeoutSeconds", payload["TimeoutSeconds"])
+          @retry             = list!("Retry", payload["Retry"], workflow) { |wf, retry_name, retry_payload| Retrier.new(wf, retry_name, retry_payload) }
+          @catch             = list!("Catch", payload["Catch"], workflow) { |wf, catch_name, catch_payload| Catcher.new(wf, catch_name, catch_payload) }
           @input_path        = path!("InputPath", payload.fetch("InputPath", "$"))
           @output_path       = path!("OutputPath", payload.fetch("OutputPath", "$"))
           @result_path       = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))
@@ -29,7 +29,7 @@ module Floe
           @result_selector   = payload_template!("ResultSelector", payload["ResultSelector"])
           @credentials       = payload_template!("Credentials", payload["Credentials"])
 
-          validate_state!(workflow)
+          require_fields!("Next" => @next, "End" => @end)
         rescue ArgumentError => err
           raise Floe::InvalidWorkflowError, err.message
         end
@@ -72,10 +72,6 @@ module Floe
         private
 
         attr_reader :runner
-
-        def validate_state!(workflow)
-          validate_state_next!(workflow)
-        end
 
         def success?(context)
           runner.success?(context.state["RunnerContext"])

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -28,8 +28,6 @@ module Floe
 
         def initialize(workflow, full_name, payload)
           super
-
-          load_fields(payload, workflow)
           @runner = Floe::Runner.for_resource(@resource)
         rescue ArgumentError => err
           raise Floe::InvalidWorkflowError, err.message

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -17,11 +17,11 @@ module Floe
           @end            = !!payload["End"]
           @seconds        = payload["Seconds"]&.to_i
           @timestamp      = payload["Timestamp"]
-          @timestamp_path = Path.new(payload["TimestampPath"]) if payload.key?("TimestampPath")
-          @seconds_path   = Path.new(payload["SecondsPath"]) if payload.key?("SecondsPath")
+          @timestamp_path = path!("TimestampPath", payload["TimestampPath"])
+          @seconds_path   = path!("SecondsPath", payload["SecondsPath"])
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @input_path     = path!("InputPath", payload.fetch("InputPath", "$"))
+          @output_path    = path!("OutputPath", payload.fetch("OutputPath", "$"))
 
           validate_state!(workflow)
         end
@@ -56,6 +56,10 @@ module Floe
 
         def validate_state!(workflow)
           validate_state_next!(workflow)
+
+          if [seconds, timestamp, timestamp_path, seconds_path].compact.size != 1
+            error!("requires one field: \"Seconds\", \"Timestamp\", \"TimestampPath\", or \"SecondsPath\"")
+          end
         end
       end
     end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -22,12 +22,6 @@ module Floe
           require_set "Seconds", "Timestamp", "TimestampPath", "SecondsPath"
         end
 
-        def initialize(workflow, name, payload)
-          super
-
-          load_fields(payload, workflow)
-        end
-
         def start(context)
           super
 

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -13,8 +13,8 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @next           = payload["Next"]
-          @end            = !!payload["End"]
+          @next           = state_ref!("Next", payload["Next"], workflow)
+          @end            = boolean!("End", payload["End"])
           @seconds        = payload["Seconds"]&.to_i
           @timestamp      = payload["Timestamp"]
           @timestamp_path = path!("TimestampPath", payload["TimestampPath"])
@@ -23,7 +23,8 @@ module Floe
           @input_path     = path!("InputPath", payload.fetch("InputPath", "$"))
           @output_path    = path!("OutputPath", payload.fetch("OutputPath", "$"))
 
-          validate_state!(workflow)
+          require_fields!("Next" => @next, "End" => @end)
+          require_fields!("Seconds" => @seconds, "Timestamp" => @timestamp, "TimestampPath" => @timestamp_path, "SecondsPath" => @seconds_path)
         end
 
         def start(context)
@@ -50,16 +51,6 @@ module Floe
 
         def end?
           @end
-        end
-
-        private
-
-        def validate_state!(workflow)
-          validate_state_next!(workflow)
-
-          if [seconds, timestamp, timestamp_path, seconds_path].compact.size != 1
-            error!("requires one field: \"Seconds\", \"Timestamp\", \"TimestampPath\", or \"SecondsPath\"")
-          end
         end
       end
     end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -8,23 +8,24 @@ module Floe
       class Wait < Floe::Workflow::State
         include NonTerminalMixin
 
-        attr_reader :end, :input_path, :next, :seconds, :seconds_path, :timestamp, :timestamp_path, :output_path
+        fields do
+          state_ref "Next"
+          boolean "End"
+          number "Seconds"
+          timestamp "Timestamp"
+          path "TimestampPath"
+          path "SecondsPath"
+          path "InputPath", :default => "$"
+          path "OutputPath", :default => "$"
+
+          require_set "Next", "End"
+          require_set "Seconds", "Timestamp", "TimestampPath", "SecondsPath"
+        end
 
         def initialize(workflow, name, payload)
           super
 
-          @next           = state_ref!("Next", payload["Next"], workflow)
-          @end            = boolean!("End", payload["End"])
-          @seconds        = payload["Seconds"]&.to_i
-          @timestamp      = payload["Timestamp"]
-          @timestamp_path = path!("TimestampPath", payload["TimestampPath"])
-          @seconds_path   = path!("SecondsPath", payload["SecondsPath"])
-
-          @input_path     = path!("InputPath", payload.fetch("InputPath", "$"))
-          @output_path    = path!("OutputPath", payload.fetch("OutputPath", "$"))
-
-          require_fields!("Next" => @next, "End" => @end)
-          require_fields!("Seconds" => @seconds, "Timestamp" => @timestamp, "TimestampPath" => @timestamp_path, "SecondsPath" => @seconds_path)
+          load_fields(payload, workflow)
         end
 
         def start(context)

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
         let(:input) { {"foo" => "bar"} }
 
         it "raises an exception" do
-          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key")
+          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "States.FirstMatchState.Choices.0.Data requires a compare_key")
         end
       end
 

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
 
   describe ".build" do
     let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
-    let(:subject) { described_class.build(payload) }
+    let(:subject) { described_class.build([name, "Choices", 1], payload) }
 
     it "works with valid next" do
       subject
@@ -12,13 +12,14 @@ RSpec.describe Floe::Workflow::ChoiceRule do
   end
 
   describe "#true?" do
-    let(:subject) { described_class.build(payload).true?(context, input) }
+    let(:subject) { described_class.build([name, "Choices", 1], payload).true?(context, input) }
     let(:context) { {} }
 
     context "with abstract top level class" do
       let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
       let(:input) { {} }
-      let(:subject) { described_class.new(payload).true?(context, input) }
+      let(:subject) { described_class.new([name, "Choices", 1], payload).true?(context, input) }
+
       it "is not implemented" do
         expect { subject }.to raise_exception(NotImplementedError)
       end

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -121,6 +121,24 @@ RSpec.describe Floe::Workflow::ChoiceRule do
         end
       end
 
+      context "with a missing compare key" do
+        let(:payload) { {"Variable" => "$.foo", "Next" => "FirstMatchState"} }
+        let(:input) { {"foo" => "bar"} }
+
+        it "raises an exception" do
+          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key")
+        end
+      end
+
+      context "with an invalid compare key" do
+        let(:payload) { {"Variable" => "$.foo", "InvalidCompare" => "$.bar", "Next" => "FirstMatchState"} }
+        let(:input)   { {"foo" => 0, "bar" => 1} }
+
+        it "fails" do
+          expect { subject }.to raise_exception(Floe::InvalidWorkflowError)
+        end
+      end
+
       context "with IsNull" do
         let(:payload) { {"Variable" => "$.foo", "IsNull" => true, "Next" => "FirstMatchState"} }
 

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -1,24 +1,42 @@
 RSpec.describe Floe::Workflow::ChoiceRule do
   let(:name)      { "FirstMatchState" }
+  let(:full_name) { ["States", name, "Choice", 1] }
   let(:workflow)  { make_workflow({}, {name => {"Type" => "Choice", "Choices" => [payload], "Default" => name}}) }
 
   describe ".build" do
     let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
-    let(:subject) { described_class.build([name, "Choices", 1], payload) }
+    let(:subject) { described_class.build(workflow, full_name, payload) }
 
     it "works with valid next" do
       subject
     end
+
+    context "with Variable missing" do
+      let(:payload) { {"Next" => name} }
+
+      it { expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "States.FirstMatchState.Choices.0.Data requires field \"Variable\"") }
+    end
+
+    context "with non-path Variable missing" do
+      let(:payload) { {"Variable" => "wrong", "Next" => name} }
+      it { expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "States.FirstMatchState.Choices.0.Data requires field \"Variable\" Path [wrong] must start with \"$\"") }
+    end
+
+    context "with second level Next" do
+      let(:payload) { {"Not" => {"Variable" => "$.foo", "StringEquals" => "bar", "Next" => "FirstMatchState"}, "Next" => "FirstMatchState"} }
+
+      it { expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "States.FirstMatchState.Choices.0.Not.0.Data does not recognize field \"Next\"") }
+    end
   end
 
   describe "#true?" do
-    let(:subject) { described_class.build([name, "Choices", 1], payload).true?(context, input) }
+    let(:subject) { described_class.build(workflow, full_name, payload).true?(context, input) }
     let(:context) { {} }
 
     context "with abstract top level class" do
       let(:payload) { {"Variable" => "$.foo", "StringEquals" => "foo", "Next" => name} }
       let(:input) { {} }
-      let(:subject) { described_class.new([name, "Choices", 1], payload).true?(context, input) }
+      let(:subject) { described_class.new(workflow, full_name + ["Data"], payload).true?(context, input) }
 
       it "is not implemented" do
         expect { subject }.to raise_exception(NotImplementedError)
@@ -28,6 +46,12 @@ RSpec.describe Floe::Workflow::ChoiceRule do
     context "Boolean Expression" do
       context "Not" do
         let(:payload) { {"Not" => {"Variable" => "$.foo", "StringEquals" => "bar"}, "Next" => "FirstMatchState"} }
+
+        context "with a second level next" do
+          let(:input) { {"foo" => "foo"} }
+          let(:payload) { {"Not" => {"Variable" => "$.foo", "StringEquals" => "bar", "Next" => "FirstMatchState"}, "Next" => "FirstMatchState"} }
+          it { expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "States.FirstMatchState.Choices.0.Not.0.Data does not recognize field \"Next\"") }
+        end
 
         context "that is not equal to 'bar'" do
           let(:input) { {"foo" => "foo"} }

--- a/spec/workflow/reference_path_spec.rb
+++ b/spec/workflow/reference_path_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Floe::Workflow::ReferencePath do
       let(:payload) { "$.foo@.bar" }
 
       it "raises an exception" do
-        expect { subject }.to raise_error(Floe::InvalidWorkflowError, "Invalid Reference Path")
+        expect { subject }.to raise_error(Floe::InvalidWorkflowError, "Reference Path [$.foo@.bar] is invalid")
       end
     end
   end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -30,22 +30,22 @@ RSpec.describe Floe::Workflow::States::Choice do
 
   it "raises an exception if Choices is missing" do
     payload = {"Choice1" => {"Type" => "Choice", "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "Choice state must have \"Choices\"")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires field \"Choices\"")
   end
 
   it "raises an exception if Choices is not an array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires field \"Choices\"")
   end
 
   it "raises an exception if Choices is an empty array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => [], "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Choices\" must be a non-empty array")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires field \"Choices\"")
   end
 
   it "raises an exception if Default isn't a valid state" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => [{"Variable" => "$.foo", "NumericEquals" => 1, "Next" => "FirstMatchState"}], "Default" => "MissingState"}, "FirstMatchState" => {"Type" => "Success"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "\"Default\" not in \"States\"")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires field \"Default\" to be in \"States\" list but got [MissingState]")
   end
 
   it "#end?" do

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Floe::Workflow::States::Choice do
 
   it "raises an exception if Choices is not an array" do
     payload = {"Choice1" => {"Type" => "Choice", "Choices" => {}, "Default" => "DefaultState"}, "DefaultState" => {"type" => "Succeed"}}
-    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires field \"Choices\"")
+    expect { make_workflow(ctx, payload) }.to raise_error(Floe::InvalidWorkflowError, "States.Choice1 requires Array field \"Choices\" but got Hash")
   end
 
   it "raises an exception if Choices is an empty array" do

--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Floe::Workflow::States::Pass do
     end
   end
 
+  describe "#initialize" do
+    it "requires a duration" do
+      expect do
+        make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}})
+      end.to raise_error(Floe::InvalidWorkflowError)
+    end
+  end
+
   describe "#running?" do
     context "with seconds" do
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for missing States" do
       payload = {"StartAt" => "Nothing"}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"States\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires field \"States\"")
     end
 
     it "raises an exception for invalid States" do
@@ -31,13 +31,13 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for missing StartAt" do
       payload = {"States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing field \"StartAt\"")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires field \"StartAt\"")
     end
 
     it "raises an exception for StartAt not in States" do
       payload = {"StartAt" => "Foo", "States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "\"StartAt\" not in the \"States\" field")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Workflow requires field \"StartAt\" to be in \"States\" list but got [Foo]")
     end
 
     it "raises an exception for a State missing a Type field" do

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Floe::Workflow do
       truncated_state_name = "#{"a" * 80}..."
       payload = make_payload({state_name => {"Type" => "Succeed"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State name [#{truncated_state_name}] must be less than or equal to 80 characters")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.#{truncated_state_name} State name must be less than or equal to 80 characters")
     end
 
     it "raises an exception for invalid context" do

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for invalid States" do
       payload = make_payload({"FirstState" => {"Type" => "Invalid"}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Invalid state type: [Invalid]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState requires field \"Type\" but got invalid value [Invalid]")
     end
 
     it "raises an exception for missing StartAt" do
@@ -43,7 +43,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for a State missing a Type field" do
       payload = make_payload({"FirstState" => {}})
 
-      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "Missing \"Type\" field in state [FirstState]")
+      expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "States.FirstState requires field \"Type\"")
     end
 
     it "raises an exception for an invalid State name" do
@@ -302,7 +302,7 @@ RSpec.describe Floe::Workflow do
 
   describe "#wait_until" do
     it "reads when the workflow will be ready to continue" do
-      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}})
       workflow.run_nonblock
 
       expect(workflow.wait_until).to be_within(1).of(Time.now.utc + 10)
@@ -318,7 +318,7 @@ RSpec.describe Floe::Workflow do
 
   describe "#waiting?" do
     it "reads when the workflow will be ready to continue" do
-      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "End" => true, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}})
+      workflow = make_workflow(ctx, {"FirstState" => {"Type" => "Wait", "Seconds" => 10, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}})
       workflow.run_nonblock
 
       expect(workflow.waiting?).to be_truthy


### PR DESCRIPTION
Yet another alternative to #209 

Built up #209 as 2 concepts: increase the error checking and add a dsl
Kinda overkill, but it is nice having all the validations in one place.

If we want to go forward, I can squash and make it work better with `ChoiceRule::Data`.

## Master

```ruby
class Pass
  attr_reader :end, :next, :result, :parameters, :input_path, :output_path, :result_path

  def initialize(workflow, name, payload)
    super

    @next        = payload["Next"]
    @end         = !!payload["End"]
    @result      = payload["Result"]

    @parameters  = payload_template!("Parameters", payload["Parameters"])
    @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
    @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
    @result_path = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))

    validate_state!(workflow)
  end

  def validate_state!(workflow)
    validate_state_next!(workflow)
  end
end
```

## 209+

First half of this PR validates every field:

```ruby
class Pass
  attr_reader :end, :next, :result, :parameters, :input_path, :output_path, :result_path

  def initialize(workflow, name, payload)
    super

    @next        = state_ref!("Next", payload["Next"], workflow)
    @end         = boolean!("End", payload["End"])
    @result      = payload["Result"]

    @parameters  = payload_template!("Parameters", payload["Parameters"])
    @input_path  = path!("InputPath", payload.fetch("InputPath", "$"))
    @output_path = path!("OutputPath", payload.fetch("OutputPath", "$"))
    @result_path = reference_path!("ResultPath", payload.fetch("ResultPath", "$"))

    require_field!(%w[Next End], [@next, @end])
  end
end
```

## After

Second half adds a DSL

```ruby
class Pass
  fields do
    state_ref        "Next"
    boolean          "End"
    raw              "Result"
    payload_template "Parameters"
    path             "InputPath",  default: "$"
    path             "OutputPath", default: "$"
    reference_path   "ResultPath", default: "$"

    # we require either the next or the end field
    requires "Next", "End"
  end
end
```