### PR TITLE
Example intergration tests

### DIFF
--- a/spec/fixtures/test-choice-fail.asl
+++ b/spec/fixtures/test-choice-fail.asl
@@ -1,0 +1,103 @@
+{
+  "Comment": "Testing Choice failures - sample input: {test: 1}",
+  "StartAt": "Setup",
+  "States": {
+    "Setup": {
+      "Comment": "(Implied test) Result => output:Result",
+      "Type": "Pass",
+      "Next": "ChooseTest",
+      "Parameters": {"test.$": "$.test", "num1": 1, "str1": "1", "num2": 1, "str2": "1"}
+    },
+    "ChooseTest": {
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.test", "NumericEquals": 1, "Next": "Test1"},
+        {"Variable": "$.test", "NumericEquals": 2, "Next": "Test2"},
+        {"Variable": "$.test", "NumericEquals": 3, "Next": "Test3"},
+        {"Variable": "$.test", "NumericEquals": 4, "Next": "Test4"},
+        {"Variable": "$.test", "NumericEquals": 5, "Next": "Test5"},
+        {"Variable": "$.test", "NumericEquals": 6, "Next": "Test6"},
+        {"Variable": "$.test", "NumericEquals": 7, "Next": "Test7"},
+        {"Variable": "$.test", "NumericEquals": 8, "Next": "Test8"},
+        {"Variable": "$.test", "NumericEquals": 9, "Next": "Test9"}
+      ]
+    },
+    "Test1": {
+      "Comment": "Variable missing -> Invalid path '$.foo'. The choice state's condition path references an invalid value.",
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.missing", "NumericEquals": 1, "Next": "Match"}
+      ]
+    },
+    "Test2": {
+      "Comment": "Variable wrong type -> nothing matched",
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.str1", "NumericEquals": 1, "Next": "Match"}
+      ],
+      "Default": "Default"
+    },
+    "Test3": {
+      "Comment": "Target missing -> Invalid path '$.missing': The choice state's condition path references an invalid value.",
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.num1", "NumericEqualsPath": "$.missing", "Next": "Match"}
+      ],
+      "Default": "Default"
+    },
+    "Test4": {
+      "Comment": "Target constant wrong type -> compilation fail floe and aws: {Variable: $.num1, NumericEquals: abc, Next: Fail}",
+      "Type":  "Pass",
+      "Next": "Match"
+    },
+    "Test5": {
+      "Comment": "equals Target wrong type -> Nothing matched",
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.num1", "NumericEqualsPath": "$.str2", "Next": "Match"}
+      ],
+      "Default": "Default"
+    },
+    "Test6": {
+      "Comment": "both wrong type -> Nothing matched",
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.str1", "NumericEqualsPath": "$.str2", "Next": "Match"}
+      ],
+      "Default": "Default"
+    },
+    "Test7": {
+      "Comment": "equals both wrong type -> Nothing matched",
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.num1", "StringEqualsPath": "$.num2", "Next": "Match"}
+      ],
+      "Default": "Default"
+    },
+    "Test8": {
+      "Comment": "GT with src wrong type -> Nothing matched",
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.num1", "StringGreaterThanPath": "$.str2", "Next": "Match"}
+      ],
+      "Default": "Default"
+    },
+    "Test9": {
+      "Comment": "GT with both wrong type -> Invalid value provided at path '$.num2'",
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.num1", "StringGreaterThanPath": "$.num2", "Next": "Match"}
+      ],
+      "Default": "Default"
+    },
+    "Match": {
+      "Type": "Pass",
+      "End": true
+    },
+    "Default": {
+      "Type": "Pass",
+      "End": true,
+      "Result": "Nothing matched"
+    }
+  }
+}

--- a/spec/fixtures/test-fail-fail.asl
+++ b/spec/fixtures/test-fail-fail.asl
@@ -1,0 +1,15 @@
+{
+  "StartAt": "Setup1x",
+  "States": {
+    "Setup1": {
+      "Type": "Pass",
+      "Next": "Fail",
+      "Result": {"test": "first", "data": "mine"}
+    },
+    "Fail": {
+      "Type": "Fail",
+      "Error": "Failed Test",
+      "CausePath": "$.test"
+   }
+  }
+}

--- a/spec/fixtures/test-invalid-bad-startat.asl
+++ b/spec/fixtures/test-invalid-bad-startat.asl
@@ -1,0 +1,15 @@
+{
+  "StartAt": "Setup1x",
+  "States": {
+    "Setup1": {
+      "Type": "Pass",
+      "Next": "Fail",
+      "Result": {"test": "first", "data": "mine"}
+    },
+    "Fail": {
+      "Type": "Fail",
+      "Error": "Failed Test",
+      "CausePath": "$.test"
+   }
+  }
+}

--- a/spec/fixtures/test-invalid-empty-states.asl
+++ b/spec/fixtures/test-invalid-empty-states.asl
@@ -1,0 +1,4 @@
+{
+  "StartAt": "Setup1x",
+  "States": {}
+}

--- a/spec/fixtures/test-invalid-missing-startat.asl
+++ b/spec/fixtures/test-invalid-missing-startat.asl
@@ -1,0 +1,14 @@
+{
+  "States": {
+    "Setup1": {
+      "Type": "Pass",
+      "Next": "Fail",
+      "Result": {"test": "first", "data": "mine"}
+    },
+    "Fail": {
+      "Type": "Fail",
+      "Error": "Failed Test",
+      "CausePath": "$.test"
+   }
+  }
+}

--- a/spec/fixtures/test-invalid-missing-states.asl
+++ b/spec/fixtures/test-invalid-missing-states.asl
@@ -1,0 +1,3 @@
+{
+  "StartAt": "Setup1x"
+}

--- a/spec/fixtures/test-pass-fail.asl
+++ b/spec/fixtures/test-pass-fail.asl
@@ -1,0 +1,44 @@
+{
+  "Comment": "Testing pass failures - sample input: {test: 1}",
+  "StartAt": "Setup",
+  "States": {
+    "Setup": {
+      "Type": "Pass",
+      "Next": "ChooseTest",
+      "Parameters": {"test.$": "$.test", "num1": 1, "str1": "1", "num2": 1, "str2": "1"}
+    },
+    "ChooseTest": {
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$.test", "NumericEquals": 1, "Next": "Test1"},
+        {"Variable": "$.test", "NumericEquals": 2, "Next": "Test2"}
+      ],
+      "Default": "Unknown"
+    },
+    "Test1": {
+      "Comment": "Parameter missing -> States.Runtime, cause: The JSONPath '$.missing' specified for the field 'param1.$' could not be found in the input ...",
+      "Type":  "Pass",
+      "Parameters": {
+        "param1.$": "$.missing"
+      },
+      "Next": "Match"
+    },
+    "Test2": {
+      "Comment": "Parameter missing -> Parse error: Field \"param1.$\" of Parameters at \"State Machine.Test2\" is not a JSONPath or intrinsic function expression",
+      "Type":  "Pass",
+      "Parameters": {
+        "param1.$": "missing"
+      },
+      "Next": "Match"
+    },
+    "Match": {
+      "Type": "Pass",
+      "End": true
+    },
+    "Unknown": {
+      "Type": "Fail",
+      "Error": "Unknown test number",
+      "End": true
+    }
+  }
+}

--- a/spec/fixtures/test-pass-fail.asl
+++ b/spec/fixtures/test-pass-fail.asl
@@ -5,13 +5,12 @@
     "Setup": {
       "Type": "Pass",
       "Next": "ChooseTest",
-      "Parameters": {"test.$": "$.test", "num1": 1, "str1": "1", "num2": 1, "str2": "1"}
+      "Parameters": {"test.$": "$.test", "num1": 1, "str1": "1"}
     },
     "ChooseTest": {
       "Type":  "Choice",
       "Choices": [
-        {"Variable": "$.test", "NumericEquals": 1, "Next": "Test1"},
-        {"Variable": "$.test", "NumericEquals": 2, "Next": "Test2"}
+        {"Variable": "$.test", "NumericEquals": 1, "Next": "Test1"}
       ],
       "Default": "Unknown"
     },
@@ -23,22 +22,13 @@
       },
       "Next": "Match"
     },
-    "Test2": {
-      "Comment": "Parameter missing -> Parse error: Field \"param1.$\" of Parameters at \"State Machine.Test2\" is not a JSONPath or intrinsic function expression",
-      "Type":  "Pass",
-      "Parameters": {
-        "param1.$": "missing"
-      },
-      "Next": "Match"
-    },
     "Match": {
       "Type": "Pass",
       "End": true
     },
     "Unknown": {
       "Type": "Fail",
-      "Error": "Unknown test number",
-      "End": true
+      "Error": "Unknown test number"
     }
   }
 }

--- a/spec/fixtures/test-pass-invalid-parameter.asl
+++ b/spec/fixtures/test-pass-invalid-parameter.asl
@@ -1,0 +1,23 @@
+{
+  "Comment": "statelint: Parse error: Field \"param1.$\" of Parameters at \"State Machine.Test2\" is not a JSONPath or intrinsic function expression",
+  "StartAt": "Setup",
+  "States": {
+    "Setup": {
+      "Type": "Pass",
+      "Next": "Test1",
+      "Result": {"num1": 1}
+    },
+    "Test1": {
+      "Comment": "Parameter not a path",
+      "Type":  "Pass",
+      "Parameters": {
+        "param1.$": "nonparam"
+      },
+      "Next": "Match"
+    },
+    "Match": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}

--- a/spec/fixtures/test-pass.asl
+++ b/spec/fixtures/test-pass.asl
@@ -1,0 +1,282 @@
+{
+  "Comment": "Testing how pass works with various inputs",
+  "StartAt": "Setup1",
+  "States": {
+    "Setup1": {
+      "Comment": "(Implied test) Result => output:Result",
+      "Type": "Pass",
+      "Next": "UnderTest1",
+      "Result": {"color": "test1"}
+    },
+    "UnderTest1": {
+      "Comment": "1: InputPath => output:InputPath applied to input. InputPath changed effective input. No result means use effective input",
+      "Type": "Pass",
+      "Next": "Verify1",
+      "InputPath": "$.color"
+    },
+    "Verify1": {
+      "Type":  "Choice",
+      "Choices": [
+        {"Variable": "$", "StringEquals": "test1", "Next": "Setup1b"}
+      ],
+      "Default": "Fail1"
+    },
+    "Fail1": {
+      "Type": "Fail",
+      "Error": "Test 1 Failure"
+    },
+    "Setup1b": {
+      "Type": "Pass",
+      "Next": "UnderTest1b",
+      "Result": {"color":{"passed_in": "test1b"}}
+    },
+    "UnderTest1b": {
+      "Comment": "1b: InputPath, Parameters => output: Parameters (values relative to effective input). No result means use effectyive input. (No remnants of Raw Input or Effective Input in output)",
+      "Type": "Pass",
+      "Next": "Verify1b",
+      "InputPath": "$.color",
+      "Parameters": {
+        "param1.$": "$.passed_in",
+        "param2": "param2"
+      }
+    },
+    "Verify1b": {
+      "Type":  "Choice",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.param1", "StringEquals": "test1b"},
+            {"Variable": "$.param2", "StringEquals": "param2"}
+          ], "Next": "Setup1c"
+        }
+      ],
+      "Default": "Fail1b"
+    },
+    "Fail1b": {
+      "Type": "Fail",
+      "Error": "Test 1b Failure"
+    },
+
+    "Setup1c": {
+      "Type": "Pass",
+      "Next": "UnderTest1c",
+      "Result": {"color":{"passed_in": "test1c"}}
+    },
+    "UnderTest1c": {
+      "Comment": "1c: InputPath, Parameters, ResultPath => output: raw input + Parameters (relative to effective input) at ResultPath",
+      "Type": "Pass",
+      "Next": "Verify1c",
+      "InputPath": "$.color",
+      "ResultPath": "$.result",
+      "Parameters": {
+        "param1.$": "$.passed_in",
+        "param2": "param2"
+      }
+    },
+    "Verify1c": {
+      "Type":  "Choice",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.color.passed_in", "StringEquals": "test1c"},
+            {"Variable": "$.result.param1", "StringEquals": "test1c"},
+            {"Variable": "$.result.param2", "StringEquals": "param2"}
+          ], "Next": "Setup1d"
+        }
+      ],
+      "Default": "Fail1c"
+    },
+    "Fail1c": {
+      "Type": "Fail",
+      "Error": "Test 1c Failure"
+    },
+    "Setup1d": {
+      "Type": "Pass",
+      "Next": "UnderTest1d",
+      "Result": {"color":{"passed_in": "test1d"}}
+    },
+    "UnderTest1d": {
+      "Comment": "1d: ResultPath => output: raw input + raw input at ResultPath",
+      "Type": "Pass",
+      "Next": "Verify1d",
+      "ResultPath": "$.result"
+    },
+    "Verify1d": {
+      "Type":  "Choice",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.color.passed_in", "StringEquals": "test1d"},
+            {"Variable": "$.result.color.passed_in", "StringEquals": "test1d"}
+          ], "Next": "Setup2"
+        }
+      ],
+      "Default": "Fail1d"
+    },
+    "Fail1d": {
+      "Type": "Fail",
+      "Error": "Test 1d Failure"
+    },
+
+    "Setup2": {
+      "Type": "Pass",
+      "Next": "UnderTest2",
+      "Result": {"color":{"passed_in": "test2"}}
+    },
+    "UnderTest2": {
+      "Comment": "2: InputPath, Result => output: Result. Effective input is ignored, and InputPath has no effect",
+      "Type": "Pass",
+      "Next": "Verify2",
+      "InputPath": "$.color",
+      "Result": {
+        "key": "result2"
+      }
+    },
+    "Verify2": {
+      "Type":  "Choice",
+      "Choices": [
+        {"And": [
+          {"Variable": "$.key", "StringEquals": "result2"}
+        ], "Next": "Setup2b"
+        }
+      ],
+      "Default": "Fail2"
+    },
+    "Fail2": {
+      "Type": "Fail",
+      "Error": "Test 2 Failure"
+    },
+
+    "Setup2b": {
+      "Type": "Pass",
+      "Next": "UnderTest2b",
+      "Result": {"color": {"passed_in": "test2b"}}
+    },
+    "UnderTest2b": {
+      "Comment": "2b: InputPath, Result, ResultPath => output: raw input + Result. Effective input is ignored, so InputPath has no effect.",
+      "Type": "Pass",
+      "Next": "Verify2b",
+      "InputPath": "$.color",
+      "Result": "result2b",
+      "ResultPath": "$.result"
+    },
+
+    "Verify2b": {
+      "Comment": "NOTE: $.passed_in failed",
+      "Type":  "Choice",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.color.passed_in", "StringEquals": "test2b"},
+            {"Variable": "$.result", "StringEquals": "result2b"}
+          ], "Next": "Setup3"
+        }
+      ],
+      "Default": "Fail2b"
+    },
+    "Fail2b": {
+      "Type": "Fail",
+      "Error": "Test 2b Failure"
+    },
+
+    "Setup3": {
+      "Type": "Pass",
+      "Next": "UnderTest3",
+      "Result": {"color": {"passed_in": "test3"}}
+    },
+    "UnderTest3": {
+      "Comment": "3: InputPath, Parameters, Result, ResultPath => raw input + Result. Effective input is ignored.",
+      "Type": "Pass",
+      "Next": "Verify3",
+      "InputPath": "$.color",
+      "Parameters": {
+        "param1.$": "$.passed_in",
+        "param2": "param2"
+      },
+      "Result": "result3",
+      "ResultPath": "$.result"
+    },
+    "Verify3": {
+      "Comment": "NOTE: $.passed_in failed",
+      "Type":  "Choice",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.color.passed_in", "StringEquals": "test3"},
+            {"Variable": "$.result", "StringEquals": "result3"}
+          ], "Next": "Setup4"
+        }
+      ],
+      "Default": "Fail3"
+    },
+    "Fail3": {
+      "Type": "Fail",
+      "Error": "Test 3 Failure"
+    },
+
+    "Setup4": {
+      "Type": "Pass",
+      "Next": "UnderTest4",
+      "Result": {"color":{"passed_in": "test4"}}
+    },
+    "UnderTest4": {
+      "Comment": "4: InputPath, Parameters, OutputPath",
+      "Type": "Pass",
+      "Next": "Verify4",
+      "InputPath": "$.color",
+      "OutputPath": "$.param1",
+      "Parameters": {
+        "param1.$": "$.passed_in",
+        "param2": "param2"
+      }
+    },
+    "Verify4": {
+      "Type":  "Choice",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$", "StringEquals": "test4"}
+          ], "Next": "Setup4b"
+        }
+      ],
+      "Default": "Fail4"
+    },
+    "Fail4": {
+      "Type": "Fail",
+      "Error": "Test 4 Failure"
+    },
+
+    "Setup4b": {
+      "Type": "Pass",
+      "Next": "UnderTest4b",
+      "Result": {"color":{"passed_in": "test4b"}}
+    },
+    "UnderTest4b": {
+      "Comment": "4b: ResultPath, OutputPath",
+      "Type": "Pass",
+      "Next": "Verify4b",
+      "ResultPath": "$.result",
+      "OutputPath": "$.result"
+    },
+    "Verify4b": {
+      "Type":  "Choice",
+      "Choices": [
+        {
+          "And": [
+            {"Variable": "$.color.passed_in", "StringEquals": "test4b"}
+          ], "Next": "Succeed"
+        }
+      ],
+      "Default": "Fail4b"
+    },
+    "Fail4b": {
+      "Type": "Fail",
+      "Error": "Test 4b Failure"
+    },
+
+    "Succeed": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}

--- a/spec/fixtures/test-task-invalid-image-name.asl
+++ b/spec/fixtures/test-task-invalid-image-name.asl
@@ -1,0 +1,12 @@
+{
+  "Comment": "An example of the Amazon States Language using an invalid resource (it must be lower case)",
+  "StartAt": "FirstState",
+  "States": {
+    "FirstState": {
+      "Type": "Task",
+      "TimeoutSeconds": 20,
+      "Resource": "docker://kbrock/HELLO-WORLD:latest",
+      "End": true
+    }
+  }
+}

--- a/spec/fixtures/test-task-unknown-image-name.asl
+++ b/spec/fixtures/test-task-unknown-image-name.asl
@@ -1,0 +1,13 @@
+{
+  "StartAt": "UnknownImageName",
+  "States": {
+    "UnknownImageNameRun": {
+      "Type": "Task",
+      "Resource": "docker://docker.io/kbrock/unknown:latest",
+      "Parameters": {
+        "ERROR": "failure message"
+      },
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
fixtures / integration tests

## Overview

A number of asl files are working differently in floe from AWS State Language runtime.

Here are some fixtures to ensure that both environments work the same.

## File Naming

- `test-[state]-[status]-comment`

#### State

The `State` is the `State` under test.
We currently have tests for `Pass`, `Fail`, `Task`, and `Choice`.

#### Status

- The `pass` files contain a number of tests run inline.
- The `fail` tests take a parameter like `{"test":1}` to subequent tests. Since these throw an uncatchable runtime error, we need to execute each individually.
- The `invalid` tests have a parser error. They are not json errors, but rather semantic errors.

## Future

#### runner script

I currently have a runner script [ref]. Though working, it is still a WIP. I can add to this repo if desired.

#### Tasks

I have tests for tasks, but am unsure the best way to post the hello world container. It outputs to stderr, stdout, and changes the return code.

Can't remember where we had agreed upon putting this.

[ref]: https://gist.github.com/kbrock/bd4461d4316375a433976043e6472d09
