### PR TITLE
Fix edge cases with States.Array

### DIFF
--- a/lib/floe/workflow/intrinsic_function/parser.rb
+++ b/lib/floe/workflow/intrinsic_function/parser.rb
@@ -40,10 +40,16 @@ module Floe
         end
 
         rule(:arg) do
-          string | number | jsonpath | true_literal | false_literal | null_literal | expression
+          (
+            string | number | jsonpath | true_literal | false_literal | null_literal | expression
+          ).as(:arg)
         end
 
-        rule(:args) { arg >> (comma_sep >> arg).repeat }
+        rule(:args) do
+          (
+            arg >> (comma_sep >> arg).repeat
+          ).maybe.as(:args)
+        end
 
         rule(:states_array) do
           (

--- a/lib/floe/workflow/intrinsic_function/transformer.rb
+++ b/lib/floe/workflow/intrinsic_function/transformer.rb
@@ -9,6 +9,19 @@ module Floe
   class Workflow
     class IntrinsicFunction
       class Transformer < Parslet::Transform
+        def self.resolve_args(args)
+          if args.nil?
+            # 0 args
+            []
+          elsif args.kind_of?(Array)
+            # >1 arg
+            args.map { |a| a[:arg] }
+          else
+            # 1 arg
+            [args[:arg]]
+          end
+        end
+
         rule(:null_literal  => simple(:v)) { nil }
         rule(:true_literal  => simple(:v)) { true }
         rule(:false_literal => simple(:v)) { false }
@@ -17,7 +30,8 @@ module Floe
         rule(:number   => simple(:v)) { v.match(/[eE.]/) ? Float(v) : Integer(v) }
         rule(:jsonpath => simple(:v)) { Floe::Workflow::Path.value(v.to_s, context, input) }
 
-        rule(:states_array => subtree(:args)) { args.kind_of?(Array) ? args : [args] }
+        rule(:states_array => {:args => subtree(:args)}) { Transformer.resolve_args(args) }
+
         rule(:states_uuid  => subtree(:args)) { SecureRandom.uuid }
       end
     end

--- a/spec/workflow/intrinsic_function/parser_spec.rb
+++ b/spec/workflow/intrinsic_function/parser_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe Floe::Workflow::IntrinsicFunction::Parser do
       expect(subject).to parse("false")
       expect(subject).to parse("null")
       expect(subject).to parse("$.input")
+      expect(subject).to parse("States.Array()")
     end
   end
 
@@ -182,10 +183,14 @@ RSpec.describe Floe::Workflow::IntrinsicFunction::Parser do
     subject { described_class.new.args }
 
     it do
+      expect(subject).to parse("")
       expect(subject).to parse(%q|'str'|)
       expect(subject).to parse(%q|'str', 123|)
       expect(subject).to parse(%q|'str', 123, true, false, null, $.input|)
+      expect(subject).to parse(%q|'str', 123, true, false, null, $.input, States.Array()|)
       expect(subject).to parse(%q|'str',   123,true|)
+      expect(subject).to parse("null")
+      expect(subject).to parse("States.Array()")
     end
   end
 
@@ -193,10 +198,13 @@ RSpec.describe Floe::Workflow::IntrinsicFunction::Parser do
     subject { described_class.new.states_array }
 
     it do
+      expect(subject).to parse(%q|States.Array()|)
       expect(subject).to parse(%q|States.Array('str')|)
       expect(subject).to parse(%q|States.Array('str', 123)|)
       expect(subject).to parse(%q|States.Array('str', 123, true, false, null, $.input)|)
       expect(subject).to parse(%q|States.Array('str',   123,true)|)
+      expect(subject).to parse(%q|States.Array(null)|)
+      expect(subject).to parse(%q|States.Array(States.Array())|)
     end
   end
 

--- a/spec/workflow/intrinsic_function_spec.rb
+++ b/spec/workflow/intrinsic_function_spec.rb
@@ -21,9 +21,24 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
 
   describe ".value" do
     describe "States.Array" do
+      it "with no values" do
+        result = described_class.value("States.Array()")
+        expect(result).to eq([])
+      end
+
       it "with a single value" do
         result = described_class.value("States.Array(1)")
         expect(result).to eq([1])
+      end
+
+      it "with a single null value" do
+        result = described_class.value("States.Array(null)")
+        expect(result).to eq([nil])
+      end
+
+      it "with a single array value" do
+        result = described_class.value("States.Array(States.Array())")
+        expect(result).to eq([[]])
       end
 
       it "with multiple values" do
@@ -90,7 +105,7 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
 
     describe "with parsing errors" do
       it "does not parse missing parens" do
-        expect { described_class.value("States.UUID") }.to raise_error(Floe::InvalidWorkflowError, /Expected one of \[[A-Z_, ]+\] at line 1 char 1./)
+        expect { described_class.value("States.Array") }.to raise_error(Floe::InvalidWorkflowError, /Expected one of \[[A-Z_, ]+\] at line 1 char 1./)
       end
 
       it "does not parse missing closing paren" do
@@ -102,7 +117,7 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
       end
 
       it "keeps the parslet error as the cause" do
-        error = described_class.value("States.UUID") rescue $! # rubocop:disable Style/RescueModifier, Style/SpecialGlobalVars
+        error = described_class.value("States.Array") rescue $! # rubocop:disable Style/RescueModifier, Style/SpecialGlobalVars
         expect(error.cause).to be_a(Parslet::ParseFailed)
       end
     end


### PR DESCRIPTION
- Array with 0 parameters
- Array with a single null parameter
- Array with a single Array parameter

@agrare Please review.

---

To understand this better it's important to understand how parslet deals with maybe values.  So, after fixing the simple args list to be a maybe (to allow 0 parameters), we'd end up with:

```ruby
$ bin/console
irb(main):001:0> Floe::Workflow::IntrinsicFunction::Parser.new.parse("States.Array()")
=> {:states_array=>"States.Array()"@0}
irb(main):002:0> Floe::Workflow::IntrinsicFunction::Parser.new.parse("States.Array(1)")
=> {:states_array=>{:number=>"1"@13}}
irb(main):003:0> Floe::Workflow::IntrinsicFunction::Parser.new.parse("States.Array(1, 2)")
=> {:states_array=>[{:number=>"1"@13}, {:number=>"2"@16}]}
```

In other words, if you don't have any args, it returns the parsed slice (weird). With 1 arg it returns the arg directly, and with >1 arg, it returns them as an Array.  So, to make this less complicated to transform, this PR introduces the args as a dedicated token.

The next problem you hit is as it resolves the args from the bottom up, you can end up with cases which conflict with existing transforms.  For example,
- `States.Array()` will produce a tree like
  - `{:states_array=>{:args=>nil}}`
- `States.Array(null)` will produce a tree like
  - `{:states_array=>{:args=>{:null_literal=>"null"@13}}}`, and when that null_literal is processed from the bottom up, you'll get an intermediate tree of
  - `{:states_array=>{:args=>nil}}`

So, to solve this, we ensure that each arg is explicitly defined as an `:arg` in the parser.  Thus the case above becomes:
- `States.Array()` will produce a tree like
  - `{:states_array=>{:args=>nil}}`
- `States.Array(null)` will produce a tree like
  - `{:states_array=>{:args=>{:arg=>{:null_literal=>"null"@13}}}}` and when that null_literal is processed from the bottom up, you'll get an intermediate tree of
  - `{:states_array=>{:args=>{:arg=>nil}}}`