### PR TITLE
Fix sporadic test failure with Wait state

### DIFF
--- a/spec/workflow/states/wait_spec.rb
+++ b/spec/workflow/states/wait_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Floe::Workflow::States::Pass do
   let(:input)    { {} }
   let(:ctx)      { Floe::Workflow::Context.new(:input => input.to_json) }
   let(:state)    { workflow.start_workflow.current_state }
-  let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+  let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 10, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
 
   describe "#end?" do
     it "is non-terminal" do
@@ -29,7 +29,7 @@ RSpec.describe Floe::Workflow::States::Pass do
 
   describe "#running?" do
     context "with seconds" do
-      let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 1, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
+      let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Seconds" => 10, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running before finished" do
         state.start(ctx)
         expect(state.running?(ctx)).to be_truthy
@@ -41,10 +41,23 @@ RSpec.describe Floe::Workflow::States::Pass do
         end
         expect(state.running?(ctx)).to be_falsey
       end
+
+      it "run_nonblock marks workflow finished only after time has expired" do
+        workflow.run_nonblock
+        expect(workflow.end?).to eq(false)
+        expect(workflow.context.state_history.size).to eq(0)
+
+        Timecop.travel(Time.now.utc + 100) do
+          workflow.run_nonblock
+        end
+
+        expect(workflow.end?).to eq(true)
+        expect(workflow.context.state_history.size).to eq(2)
+      end
     end
 
     context "with secondsPath" do
-      let(:input)    { {"expire" => "1"} }
+      let(:input)    { {"expire" => "10"} }
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "SecondsPath" => "$.expire", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
         state.start(ctx)
@@ -57,10 +70,23 @@ RSpec.describe Floe::Workflow::States::Pass do
         end
         expect(state.running?(ctx)).to be_falsey
       end
+
+      it "run_nonblock marks workflow finished only after time has expired" do
+        workflow.run_nonblock
+        expect(workflow.end?).to eq(false)
+        expect(workflow.context.state_history.size).to eq(0)
+
+        Timecop.travel(Time.now.utc + 100) do
+          workflow.run_nonblock
+        end
+
+        expect(workflow.end?).to eq(true)
+        expect(workflow.context.state_history.size).to eq(2)
+      end
     end
 
-    context "with timestamp" do
-      let(:expiry) { Time.now.utc + 1 }
+    context "with Timestamp" do
+      let(:expiry) { Time.now.utc + 10 }
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "Timestamp" => expiry.iso8601, "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
         state.start(ctx)
@@ -73,10 +99,23 @@ RSpec.describe Floe::Workflow::States::Pass do
         end
         expect(state.running?(ctx)).to be_falsey
       end
+
+      it "run_nonblock marks workflow finished only after time has expired" do
+        workflow.run_nonblock
+        expect(workflow.end?).to eq(false)
+        expect(workflow.context.state_history.size).to eq(0)
+
+        Timecop.travel(Time.now.utc + 100) do
+          workflow.run_nonblock
+        end
+
+        expect(workflow.end?).to eq(true)
+        expect(workflow.context.state_history.size).to eq(2)
+      end
     end
 
-    context "with timestamp" do
-      let(:expiry) { Time.now.utc + 1 }
+    context "with TimestampPath" do
+      let(:expiry) { Time.now.utc + 10 }
       let(:input) { {"expire" => expiry.iso8601} }
       let(:workflow) { make_workflow(ctx, {"WaitState" => {"Type" => "Wait", "TimestampPath" => "$.expire", "Next" => "SuccessState"}, "SuccessState" => {"Type" => "Succeed"}}) }
       it "is running? before finished" do
@@ -91,12 +130,12 @@ RSpec.describe Floe::Workflow::States::Pass do
         expect(state.running?(ctx)).to be_falsey
       end
 
-      it "runs" do
+      it "run_nonblock marks workflow finished only after time has expired" do
         workflow.run_nonblock
         expect(workflow.end?).to eq(false)
         expect(workflow.context.state_history.size).to eq(0)
 
-        Timecop.travel(Time.now.utc + 10) do
+        Timecop.travel(Time.now.utc + 100) do
           workflow.run_nonblock
         end
 


### PR DESCRIPTION
I suspect there is an issue if the GHA runner is a little slow that the `workflow.run_nonblock` can finish before the `expect(workflow.end?).to eq(false)` can be invoked within 1 second.

https://github.com/ManageIQ/floe/actions/runs/9845986602/job/27182755884?pr=184
```
Failures:
  1) Floe::Workflow::States::Pass#running? with timestamp runs
     Failure/Error: expect(workflow.end?).to eq(false)

       expected: false
            got: true

Failed examples:

rspec ./spec/workflow/states/wait_spec.rb:94 # Floe::Workflow::States::Pass#running? with timestamp runs
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
