### PR TITLE
Move the Parslet parse into initialize so that invalid function definition will fail on workflow load

### DIFF
--- a/lib/floe/workflow/intrinsic_function.rb
+++ b/lib/floe/workflow/intrinsic_function.rb
@@ -15,19 +15,20 @@ module Floe
 
       def initialize(payload)
         @payload = payload
+        @tree    = Parser.new.parse(payload)
+
+        Floe.logger.debug { "Parsed intrinsic function: #{payload.inspect} => #{tree.inspect}" }
+      rescue Parslet::ParseFailed => err
+        raise Floe::InvalidWorkflowError, err.message
       end
 
       def value(context = {}, input = {})
-        begin
-          tree = Parser.new.parse(payload)
-        rescue Parslet::ParseFailed => err
-          raise Floe::InvalidWorkflowError, err.message
-        end
-
-        Floe.logger.debug { "Parsed intrinsic function: #{payload.inspect} => #{tree.inspect}" }
-
         Transformer.new.apply(tree, :context => context, :input => input)
       end
+
+      private
+
+      attr_reader :tree
     end
   end
 end

--- a/spec/workflow/intrinsic_function_spec.rb
+++ b/spec/workflow/intrinsic_function_spec.rb
@@ -679,4 +679,10 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
       end
     end
   end
+
+  describe "#initialize" do
+    it "raises an InvalidWorkflowError on invalid function definition" do
+      expect { described_class.new("States.Array") }.to raise_error(Floe::InvalidWorkflowError, /Expected one of \[[A-Z0-9_, ]+\] at line 1 char 1./)
+    end
+  end
 end


### PR DESCRIPTION
I still need to handle the exception types for other failures, but this is a quick way to raise an exception earlier than runtime for a number of failure types
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
