### PR TITLE
[WIP] Catch and display path errors

### DIFF
--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -22,6 +22,12 @@ module Floe
       raise Floe::ExecutionError.new(self.class.field_error_text(name, field_name, field_value, comment), floe_error)
     end
 
+    def wrap_runtime_error(field_name, field_value)
+      yield
+    rescue Floe::ExecutionError => e
+      runtime_field_error!(field_name, field_value, e.message)
+    end
+
     def workflow_state?(field_value, workflow)
       workflow.payload["States"] ? workflow.payload["States"].include?(field_value) : true
     end

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -14,7 +14,7 @@ module Floe
 
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]
-        @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))
+        @result_path  = wrap_parser_error("ResultPath", payload.fetch("ResultPath", nil)) { ReferencePath.new(payload.fetch("ResultPath", "$")) }
 
         missing_field_error!("ErrorEquals") if !@error_equals.kind_of?(Array) || @error_equals.empty?
         validate_state_next!(workflow)

--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -51,7 +51,7 @@ module Floe
           rhs = compare_value(context, input)
           lhs = variable_value(context, input)
           send(OPERATIONS[operator], lhs, rhs)
-        rescue Floe::PathError
+        rescue Floe::ExecutionError
           # For IsPresent, we can expect the lhs to not be present in some cases,
           #                This throws a PathError. We handle that special case here.
           # Example:
@@ -188,7 +188,7 @@ module Floe
 
         # fetch a path at runtime
         def fetch_path(field_name, field_path, context, input)
-          value = field_path.value(context, input)
+          value = wrap_runtime_error(field_name, field_path.to_s) { field_path.value(context, input) }
           # if this is an operation (GreaterThanPath), ensure the value is the correct type
           return value if type.nil? || correct_type?(value, type)
 

--- a/lib/floe/workflow/intrinsic_function/transformer.rb
+++ b/lib/floe/workflow/intrinsic_function/transformer.rb
@@ -75,7 +75,7 @@ module Floe
 
         rule(:string   => simple(:v)) { v.to_s[1..-2] }
         rule(:number   => simple(:v)) { v.match(/[eE.]/) ? Float(v) : Integer(v) }
-        rule(:jsonpath => simple(:v)) { Floe::Workflow::Path.value(v.to_s, context, input) }
+        rule(:jsonpath => simple(:v)) { Floe::Workflow::Path.value(v.to_s, context, input) } # improve error here
 
         STATES_FORMAT_PLACEHOLDER = /(?<!\\)\{\}/
 

--- a/lib/floe/workflow/path.rb
+++ b/lib/floe/workflow/path.rb
@@ -36,7 +36,7 @@ module Floe
         results = JsonPath.on(obj, path)
         case results.count
         when 0
-          raise Floe::PathError, "Path [#{payload}] references an invalid value"
+          raise Floe::PathError, "references an invalid value"
         when 1
           results.first
         else

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -13,8 +13,8 @@ module Floe
           @default = payload["Default"]
           validate_state!(workflow)
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @input_path  = wrap_parser_error("InputPath", payload.fetch("InputPath", nil)) { Path.new(payload.fetch("InputPath", "$")) }
+          @output_path = wrap_parser_error("OutputPath", payload.fetch("OutputPath", nil)) { Path.new(payload.fetch("OutputPath", "$")) }
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -18,8 +18,8 @@ module Floe
         end
 
         def finish(context)
-          input      = input_path.value(context, context.input)
-          output     = output_path.value(context, input)
+          input      = wrap_runtime_error("InputPath", input_path.to_s) { input_path.value(context, context.input) }
+          output     = wrap_runtime_error("OutputPath", output_path.to_s) { output_path.value(context, input) }
           next_state = choices.detect { |choice| choice.true?(context, output) }&.next || default
 
           runtime_field_error!("Default", nil, "not defined and no match found", :floe_error => "States.NoChoiceMatched") if next_state.nil?

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -21,8 +21,8 @@ module Floe
           # see https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-fail-state.html
           #     https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html#asl-intrsc-func-generic
           context.output     = {
-            "Error" => @error_path ? @error_path.value(context, context.input) : error,
-            "Cause" => @cause_path ? @cause_path.value(context, context.input) : cause
+            "Error" => error_path ? wrap_runtime_error("ErrorPath", error_path.to_s) { @error_path.value(context, context.input) } : error,
+            "Cause" => cause_path ? wrap_runtime_error("CausePath", cause_path.to_s) { @cause_path.value(context, context.input) } : cause
           }.compact
           super
         end

--- a/lib/floe/workflow/states/fail.rb
+++ b/lib/floe/workflow/states/fail.rb
@@ -11,8 +11,8 @@ module Floe
 
           @cause      = payload["Cause"]
           @error      = payload["Error"]
-          @cause_path = Path.new(payload["CausePath"]) if payload["CausePath"]
-          @error_path = Path.new(payload["ErrorPath"]) if payload["ErrorPath"]
+          @cause_path = wrap_parser_error("CausePath", payload["CausePath"]) { Path.new(payload["CausePath"]) } if payload["CausePath"]
+          @error_path = wrap_parser_error("ErrorPath", payload["ErrorPath"]) { Path.new(payload["ErrorPath"]) } if payload["ErrorPath"]
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/input_output_mixin.rb
+++ b/lib/floe/workflow/states/input_output_mixin.rb
@@ -5,8 +5,8 @@ module Floe
     module States
       module InputOutputMixin
         def process_input(context)
-          input = input_path.value(context, context.input)
-          input = parameters.value(context, input) if parameters
+          input = wrap_runtime_error("InputPath", input_path.to_s) { input_path.value(context, context.input) }
+          input = wrap_runtime_error("Parameters", parameters.to_s) { parameters.value(context, input) } if parameters
           input
         end
 
@@ -14,15 +14,16 @@ module Floe
           return context.input.dup if results.nil?
           return if output_path.nil?
 
-          results = result_selector.value(context, results) if @result_selector
+          results = wrap_runtime_error("ResultSelector", @result_selector.to_s) { result_selector.value(context, results) } if @result_selector
           if result_path.payload.match?(/^\$\$\.Credentials\b/)
-            context.credentials.merge!(result_path.set(context.credentials, results))
+            credentials = wrap_runtime_error("ResultPath", result_path.to_s) { result_path.set(context.credentials, results) }
+            context.credentials.merge!(credentials) if credentials
             output = context.input.dup
           else
             output = result_path.set(context.input.dup, results)
           end
 
-          output_path.value(context, output)
+          wrap_runtime_error("OutputPath", output_path.to_s) { output_path.value(context, output) }
         end
       end
     end

--- a/lib/floe/workflow/states/map.rb
+++ b/lib/floe/workflow/states/map.rb
@@ -43,7 +43,7 @@ module Floe
 
         def process_input(context)
           input = super
-          input = items_path.value(context, input)
+          input = wrap_runtime_error("ItemPath", items_path.to_s) { items_path.value(context, input) }
           input = item_batcher.value(context, input, context.state["Input"]) if item_batcher
           input
         end

--- a/lib/floe/workflow/states/pass.rb
+++ b/lib/floe/workflow/states/pass.rb
@@ -16,10 +16,10 @@ module Floe
           @end         = !!payload["End"]
           @result      = payload["Result"]
 
-          @parameters  = PayloadTemplate.new(payload["Parameters"]) if payload["Parameters"]
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
-          @result_path = ReferencePath.new(payload.fetch("ResultPath", "$"))
+          @parameters  = wrap_parser_error("Parameters", payload["Parameters"]) { PayloadTemplate.new(payload["Parameters"]) } if payload["Parameters"]
+          @input_path  = wrap_parser_error("InputPath", payload.fetch("InputPath", nil)) { Path.new(payload.fetch("InputPath", "$")) }
+          @output_path = wrap_parser_error("OutputPath", payload.fetch("OutputPath", nil)) { Path.new(payload.fetch("OutputPath", "$")) }
+          @result_path = wrap_parser_error("ResultPath", payload.fetch("ResultPath", nil)) { ReferencePath.new(payload.fetch("ResultPath", "$")) }
 
           validate_state!(workflow)
         end

--- a/lib/floe/workflow/states/retry_catch_mixin.rb
+++ b/lib/floe/workflow/states/retry_catch_mixin.rb
@@ -38,7 +38,7 @@ module Floe
           return if catcher.nil?
 
           context.next_state = catcher.next
-          context.output     = catcher.result_path.set(context.input, error)
+          context.output     = wrap_runtime_error("ResultPath", result_path.to_s) { catcher.result_path.set(context.input, error) }
           context.logger.info("Running state: [#{long_name}] with input [#{context.json_input}]...CatchError - next state: [#{context.next_state}] output: [#{context.json_output}]")
 
           true

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -14,8 +14,8 @@ module Floe
         end
 
         def finish(context)
-          input              = input_path.value(context, context.input)
-          context.output     = output_path.value(context, input)
+          input              = wrap_runtime_error("InputPath", input_path.to_s) { input_path.value(context, context.input) }
+          context.output     = wrap_runtime_error("OutputPath", output_path.to_s) { output_path.value(context, input) }
           context.next_state = nil
 
           super

--- a/lib/floe/workflow/states/succeed.rb
+++ b/lib/floe/workflow/states/succeed.rb
@@ -9,8 +9,8 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @input_path  = wrap_parser_error("InputPath", payload.fetch("InputPath", nil)) { Path.new(payload.fetch("InputPath", "$")) }
+          @output_path = wrap_parser_error("OutputPath", payload.fetch("OutputPath", nil)) { Path.new(payload.fetch("OutputPath", "$")) }
         end
 
         def finish(context)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -26,12 +26,12 @@ module Floe
           @timeout_seconds   = payload["TimeoutSeconds"]
           @retry             = payload["Retry"].to_a.map.with_index { |retrier, i| Retrier.new(workflow, name + ["Retry", i.to_s], retrier) }
           @catch             = payload["Catch"].to_a.map.with_index { |catcher, i| Catcher.new(workflow, name + ["Catch", i.to_s], catcher) }
-          @input_path        = Path.new(payload.fetch("InputPath", "$"))
-          @output_path       = Path.new(payload.fetch("OutputPath", "$"))
-          @result_path       = ReferencePath.new(payload.fetch("ResultPath", "$"))
-          @parameters        = PayloadTemplate.new(payload["Parameters"])     if payload["Parameters"]
-          @result_selector   = PayloadTemplate.new(payload["ResultSelector"]) if payload["ResultSelector"]
-          @credentials       = PayloadTemplate.new(payload["Credentials"])    if payload["Credentials"]
+          @input_path        = wrap_parser_error("InputPath", payload.fetch("InputPath", nil)) { Path.new(payload.fetch("InputPath", "$")) }
+          @output_path       = wrap_parser_error("OutputPath", payload.fetch("OutputPath", nil)) { Path.new(payload.fetch("OutputPath", "$")) }
+          @result_path       = wrap_parser_error("ResultPath", payload.fetch("ResultPath", nil)) { ReferencePath.new(payload.fetch("ResultPath", "$")) }
+          @parameters        = wrap_parser_error("Parameters", payload["Parameters"]) { PayloadTemplate.new(payload["Parameters"]) }             if payload["Parameters"]
+          @result_selector   = wrap_parser_error("ResultSelector", payload["ResultSelector"]) { PayloadTemplate.new(payload["ResultSelector"]) } if payload["ResultSelector"]
+          @credentials       = wrap_parser_error("Credentials", payload["Credentials"]) { PayloadTemplate.new(payload["Credentials"]) }          if payload["Credentials"]
 
           validate_state!(workflow)
         end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -17,11 +17,10 @@ module Floe
           @end            = !!payload["End"]
           @seconds        = payload["Seconds"]&.to_i
           @timestamp      = payload["Timestamp"]
-          @timestamp_path = Path.new(payload["TimestampPath"]) if payload.key?("TimestampPath")
-          @seconds_path   = Path.new(payload["SecondsPath"]) if payload.key?("SecondsPath")
-
-          @input_path  = Path.new(payload.fetch("InputPath", "$"))
-          @output_path = Path.new(payload.fetch("OutputPath", "$"))
+          @timestamp_path = wrap_parser_error("TimestampPath", payload["TimestampPath"]) { Path.new(payload["TimestampPath"]) } if payload.key?("TimestampPath")
+          @seconds_path   = wrap_parser_error("SecondsPath", payload["SecondsPath"]) { Path.new(payload["SecondsPath"]) } if payload.key?("SecondsPath")
+          @input_path     = wrap_parser_error("InputPath", payload["InputPath"]) { Path.new(payload.fetch("InputPath", "$")) }
+          @output_path    = wrap_parser_error("OutputPath", payload["OutputPath"]) { Path.new(payload.fetch("OutputPath", "$")) }
 
           validate_state!(workflow)
         end

--- a/lib/floe/workflow/states/wait.rb
+++ b/lib/floe/workflow/states/wait.rb
@@ -28,18 +28,18 @@ module Floe
         def start(context)
           super
 
-          input = input_path.value(context, context.input)
+          input = wrap_runtime_error("InputPath", input_path.to_s) { input_path.value(context, context.input) }
 
           wait_until!(
             context,
-            :seconds => seconds_path ? seconds_path.value(context, input).to_i : seconds,
-            :time    => timestamp_path ? timestamp_path.value(context, input) : timestamp
+            :seconds => seconds_path ? wrap_runtime_error("SecondsPath", seconds_path.to_s) { seconds_path.value(context, input).to_i } : seconds,
+            :time    => timestamp_path ? wrap_runtime_error("TimestampPath", timestamp_path.to_s) { timestamp_path.value(context, input) } : timestamp
           )
         end
 
         def finish(context)
-          input          = input_path.value(context, context.input)
-          context.output = output_path.value(context, input)
+          input          = wrap_runtime_error("InputPath", input_path.to_s) { input_path.value(context, context.input) }
+          context.output = wrap_runtime_error("OutputPath", input_path.to_s) { output_path.value(context, input) }
           super
         end
 

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
         let(:input) { {} }
 
         it "raises an exception" do
-          expect { subject }.to raise_exception(Floe::PathError, "Path [$.foo] references an invalid value")
+          expect { subject }.to raise_exception(Floe::ExecutionError, "States.Choice1.Choices.0.Data field \"Variable\" value \"$.foo\" references an invalid value")
         end
       end
 
@@ -408,7 +408,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
 
         context "with path not found" do
           let(:input) { {"foo" => 2} }
-          it { expect { subject }.to raise_error(Floe::PathError, "Path [$.bar] references an invalid value") }
+          it { expect { subject }.to raise_exception(Floe::ExecutionError, "States.Choice1.Choices.0.Data field \"NumericEqualsPath\" value \"$.bar\" references an invalid value") }
         end
       end
 
@@ -593,7 +593,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
 
         context "that does not exist" do
           let(:input) { {} }
-          it { expect { subject }.to raise_exception(Floe::PathError, "Path [$.foo] references an invalid value") }
+          it { expect { subject }.to raise_exception(Floe::ExecutionError, "States.Choice1.Choices.0.Data field \"Variable\" value \"$.foo\" references an invalid value") }
         end
 
         context "that references a number" do

--- a/spec/workflow/intrinsic_function_spec.rb
+++ b/spec/workflow/intrinsic_function_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
       end
 
       it "fails with invalid argument values" do
-        expect { described_class.value("States.StringToJson($.input)", {}, {"input" => "foo"}) }.to raise_error(ArgumentError, /invalid value for argument 1 to States.StringToJson \(invalid json/)
+        expect { described_class.value("States.StringToJson($.input)", {}, {"input" => "foo"}) }.to raise_error(ArgumentError, /invalid value for argument 1 to States\.StringToJson \(invalid json: unexpected token .*\)/)
       end
     end
 
@@ -990,7 +990,7 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
 
       it "handles invalid path references" do
         ctx = {"context" => {"baz" => "qux"}}, {"input" => {"foo" => "bar"}}
-        expect { described_class.value("States.Array($.xxx)", ctx) }.to raise_error(Floe::PathError, "Path [$.xxx] references an invalid value")
+        expect { described_class.value("States.Array($.xxx)", ctx) }.to raise_error(Floe::PathError, "references an invalid value")
       end
     end
 

--- a/spec/workflow/path_spec.rb
+++ b/spec/workflow/path_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Floe::Workflow::Path do
   describe "#value" do
     context "referencing the global context" do
       it "with a missing value" do
-        expect { described_class.new("$$.foo").value({}, {"foo" => "bar"}) }.to raise_error(Floe::PathError, "Path [$$.foo] references an invalid value")
+        expect { described_class.new("$$.foo").value({}, {"foo" => "bar"}) }.to raise_error(Floe::PathError, "references an invalid value")
       end
 
       it "with a single value" do
@@ -36,7 +36,7 @@ RSpec.describe Floe::Workflow::Path do
       let(:input)   { {} }
 
       it "with a missing value" do
-        expect { described_class.new("$$.Credentials.username").value(context, input) }.to raise_error(Floe::PathError, "Path [$$.Credentials.username] references an invalid value")
+        expect { described_class.new("$$.Credentials.username").value(context, input) }.to raise_error(Floe::PathError, "references an invalid value")
       end
 
       it "returns the password" do
@@ -46,7 +46,7 @@ RSpec.describe Floe::Workflow::Path do
 
     context "referencing the inputs" do
       it "with a missing value" do
-        expect { described_class.new("$.foo").value({"foo" => "bar"}, {}) }.to raise_error(Floe::PathError, "Path [$.foo] references an invalid value")
+        expect { described_class.new("$.foo").value({"foo" => "bar"}, {}) }.to raise_error(Floe::PathError, "references an invalid value")
       end
 
       it "with a single value" do

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Floe::Workflow::States::Choice do
         expect(ctx.failed?).to eq(true)
         expect(ctx.output).to eq(
           {
-            "Cause" => "Path [$.foo] references an invalid value",
+            "Cause" => "States.Choice1.Choices.0.Data field \"Variable\" value \"$.foo\" references an invalid value",
             "Error" => "States.Runtime"
           }
         )

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Floe::Workflow::States::Pass do
         expect(ctx.state_finished?).to eq(true)
         expect(ctx.output).to eq(
           {
-            "Cause" => "Path [$.missing] references an invalid value",
+            "Cause" => "States.PassState field \"InputPath\" value \"$.missing\" references an invalid value",
             "Error" => "States.Runtime"
           }
         )
@@ -191,7 +191,7 @@ RSpec.describe Floe::Workflow::States::Pass do
         expect(ctx.state_finished?).to eq(true)
         expect(ctx.output).to eq(
           {
-            "Cause" => "Path [$.missing.spot] references an invalid value",
+            "Cause" => "States.PassState field \"OutputPath\" value \"$.missing.spot\" references an invalid value",
             "Error" => "States.Runtime"
           }
         )
@@ -264,7 +264,7 @@ RSpec.describe Floe::Workflow::States::Pass do
 
         it "detects missing value" do
           workflow.run_nonblock
-          expect(ctx.output).to eq({"Cause" => "Path [$.color] references an invalid value", "Error" => "States.Runtime"})
+          expect(ctx.output).to eq({"Cause" => "States.Pass field \"InputPath\" value \"$.color\" references an invalid value", "Error" => "States.Runtime"})
         end
       end
 

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Floe::Workflow::States::Pass do
         }
       end
 
-      it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "Path [bad] must start with \"$\"") }
+      it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.PassState field \"InputPath\" value \"bad\" Path [bad] must start with \"$\"") }
     end
 
     context "With an invalid OutputPath" do
@@ -112,7 +112,7 @@ RSpec.describe Floe::Workflow::States::Pass do
         }
       end
 
-      it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "Path [bad] must start with \"$\"") }
+      it { expect { workflow }.to raise_error(Floe::InvalidWorkflowError, "States.PassState field \"OutputPath\" value \"bad\" Path [bad] must start with \"$\"") }
     end
   end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -40,10 +40,12 @@ RSpec.describe Floe::Workflow do
       expect { described_class.new(payload) }.to raise_error(Floe::InvalidWorkflowError, "State Machine field \"StartAt\" value \"Foo\" is not found in \"States\"")
     end
 
+    # this error gets truncated when embedded in the parent string, so is basically useless
     it "raises an exception for invalid context" do
       payload = {"StartAt" => "FirstState", "States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload, "invalid context") }.to raise_error(Floe::InvalidExecutionInput, /Invalid State Machine Execution Input: unexpected character: /)
+      expect { described_class.new(payload, "invalid context") }.to raise_error(Floe::InvalidExecutionInput,
+        /unexpected.*'invalid.*: was expecting \(JSON String, Number, Array, Object or token 'null', 'true' or 'false'\)/)
     end
   end
 


### PR DESCRIPTION
Depends upon
- [x] #189

2.5 things:

- If a user specifies a bad path in a workflow, display a meaningful message.
- If a user specifies a path that fails a lookup in runtime, display a meaningful message.
- (This is not working with templates - not worse, but not informative/better either)

# Invalid path (validation)

```
    "Test1": {
      "Comment": "Parameter not a path",
      "Type":  "Pass",
      "InputPath": "nonparam",
      "End": true
    }
```

aws:

```
Field "InputPath" defined at "State Machine.Test1" is not a JSONPath
```

## Before

```
Path [nonparam] must start with "$"
```

## After

```
States.Test1 field "InputPath" value "nonparam" Path [nonparam] must start with "$"
```

# Path not found (runtime)

```
    "Test2": {
      "Type":  "Pass",
      "InputPath": "$.missing"
      "End": true
    }
```

aws:

```
Invalid path '$.missing' : No results for path: $['missing']
```

Before
======

```
{}
```

After
=====

```
{
  "Error":"States.RuntimeError",
  "Cause":"States.Test2 field \"InputPath\" value \"$.missing\" references an invalid value"
}
```

