### PR TITLE
Fix invalid container names after normalizing

### DIFF
--- a/lib/floe/container_runner/docker_mixin.rb
+++ b/lib/floe/container_runner/docker_mixin.rb
@@ -24,6 +24,9 @@ module Floe
         # This does not follow the leading and trailing character restriction because we will embed it
         # below with a prefix and suffix that already conform to the RFC.
         normalized_name = name.downcase.gsub(/[^a-z0-9-]/, "-")[0, MAX_CONTAINER_NAME_SIZE]
+        # Ensure that the normalized_name doesn't end in any invalid characters after we
+        # limited the length to the MAX_CONTAINER_NAME_SIZE.
+        normalized_name.gsub!(/[^a-z0-9]+$/, "")
 
         "floe-#{normalized_name}-#{SecureRandom.hex(4)}"
       end


### PR DESCRIPTION
If an image name is longer than the length allowed by MAX_CONTAINER_NAME_SIZE it is chopped down to the max allowed size.

If the image name happens to have a character that is valid in the middle of the name but would be valid as a trailing character then after limiting the size of the string this name will become invalid.

For example an image named
"docker.io/manageiq/workflows-examples-provision-vm-service-power-on-vm:latest" will have a normalized_name of
"workflows-examples-provision-vm-service-power-on-" which will fail when the pod gets created.

```
HTTP status code 422, Pod \"floe-workflows-examples-provision-vm-service-power-on--8cd51a52\" is invalid: spec.containers[0].name: Invalid value: \"floe-workflows-examples-provision-vm-service-power-on-\": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name', or '123-abc', regex used for validation is 'a-z0-9?')
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
