### PR TITLE
Choice rule payload validation path

### DIFF
--- a/lib/floe.rb
+++ b/lib/floe.rb
@@ -43,6 +43,7 @@ module Floe
   class Error < StandardError; end
   class InvalidWorkflowError < Error; end
   class InvalidExecutionInput < Error; end
+  class PathError < Error; end
 
   def self.logger
     @logger ||= NullLogger.new

--- a/lib/floe/workflow/path.rb
+++ b/lib/floe/workflow/path.rb
@@ -34,7 +34,18 @@ module Floe
         return obj if path == "$"
 
         results = JsonPath.on(obj, path)
-        results.count < 2 ? results.first : results
+        case results.count
+        when 0
+          raise Floe::PathError, "Path [#{payload}] references an invalid value"
+        when 1
+          results.first
+        else
+          results
+        end
+      end
+
+      def to_s
+        payload
       end
     end
   end

--- a/spec/workflow/intrinsic_function_spec.rb
+++ b/spec/workflow/intrinsic_function_spec.rb
@@ -655,8 +655,8 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
       end
 
       it "handles invalid path references" do
-        result = described_class.value("States.Array($.xxx)", {"context" => {"baz" => "qux"}}, {"input" => {"foo" => "bar"}})
-        expect(result).to eq([nil])
+        ctx = {"context" => {"baz" => "qux"}}, {"input" => {"foo" => "bar"}}
+        expect { described_class.value("States.Array($.xxx)", ctx) }.to raise_error(Floe::PathError, "Path [$.xxx] references an invalid value")
       end
     end
 

--- a/spec/workflow/path_spec.rb
+++ b/spec/workflow/path_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Floe::Workflow::Path do
   describe "#value" do
     context "referencing the global context" do
       it "with a missing value" do
-        expect(described_class.new("$$.foo").value({})).to be_nil
+        expect { described_class.new("$$.foo").value({}, {"foo" => "bar"}) }.to raise_error(Floe::PathError, "Path [$$.foo] references an invalid value")
       end
 
       it "with a single value" do
-        expect(described_class.new("$$.foo").value({"foo" => "bar"})).to eq("bar")
+        expect(described_class.new("$$.foo").value({"foo" => "bar"}, {})).to eq("bar")
       end
 
       it "with a nested hash" do
-        expect(described_class.new("$$.foo.bar").value({"foo" => {"bar" => "baz"}})).to eq("baz")
+        expect(described_class.new("$$.foo.bar").value({"foo" => {"bar" => "baz"}}, {})).to eq("baz")
       end
 
       it "with an array" do
@@ -33,7 +33,7 @@ RSpec.describe Floe::Workflow::Path do
 
     context "referencing the inputs" do
       it "with a missing value" do
-        expect(described_class.new("$.foo").value({"foo" => "bar"})).to be_nil
+        expect { described_class.new("$.foo").value({"foo" => "bar"}, {}) }.to raise_error(Floe::PathError, "Path [$.foo] references an invalid value")
       end
 
       it "with a single value" do

--- a/spec/workflow/state_spec.rb
+++ b/spec/workflow/state_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Floe::Workflow::State do
 
     it "is finished" do
       state.start(ctx)
-      state.finish(ctx)
+      state.mark_finished(ctx)
 
       expect(ctx.state_started?).to eq(true)
     end
@@ -63,7 +63,7 @@ RSpec.describe Floe::Workflow::State do
 
     it "is finished" do
       state.start(ctx)
-      state.finish(ctx)
+      state.mark_finished(ctx)
 
       expect(ctx.state_finished?).to eq(true)
     end

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -49,8 +49,14 @@ RSpec.describe Floe::Workflow::States::Choice do
 
   describe "#run_nonblock!" do
     context "with a missing variable" do
-      it "raises an exception" do
-        expect { state.run_nonblock!(ctx) }.to raise_error(RuntimeError, "No such variable [$.foo]")
+      it "shows error" do
+        workflow.run_nonblock
+        expect(ctx.output).to eq(
+          {
+            "Cause" => "Path [$.foo] references an invalid value",
+            "Error" => "States.Runtime"
+          }
+        )
       end
     end
 


### PR DESCRIPTION
extracted from #189 

# Before

If the path referenced a missing value in the input, treat it as a nil.

# After

If the path references a missing value in the input, raise an error.

- introduced `presence_check` method to check if it is present up front.
- This also affects Intrinsic methods. You can see the changed spec.
- This respects `IsPresent: false` and `IsPresent: true`