### PR TITLE
Split out ChoiceRule spec to be similar to other specs

### DIFF
--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe Floe::Workflow::States::Choice do
 
   let(:payload) do
     {
-      "Choice1"          => {
-        "Type"    => "Choice",
-        "Choices" => choices,
-        "Default" => "DefaultState"
-      },
+      "Choice1"          => {"Type" => "Choice", "Choices" => choices, "Default" => "DefaultState"},
       "FirstMatchState"  => {"Type" => "Succeed"},
       "SecondMatchState" => {"Type" => "Succeed"},
       "DefaultState"     => {"Type" => "Succeed"}


### PR DESCRIPTION
Currently use use `payload` for the Workflow#payload.
And then in spec we use `choices` to represent choices, or `retriers` and `catchers` to represent that addition to the `payload`.

This does the same for the `ChoiceRule` spec