### PR TITLE
Intrinsics States.JsonMerge

### DIFF
--- a/lib/floe/workflow/intrinsic_function/parser.rb
+++ b/lib/floe/workflow/intrinsic_function/parser.rb
@@ -67,6 +67,7 @@ module Floe
           :states_base64_encode,   "States.Base64Encode",
           :states_base64_decode,   "States.Base64Decode",
           :states_hash,            "States.Hash",
+          :states_json_merge,      "States.JsonMerge",
           :states_math_random,     "States.MathRandom",
           :states_math_add,        "States.MathAdd",
           :states_string_split,    "States.StringSplit",
@@ -93,6 +94,7 @@ module Floe
             states_base64_encode |
             states_base64_decode |
             states_hash |
+            states_json_merge |
             states_math_random |
             states_math_add |
             states_string_split |

--- a/lib/floe/workflow/intrinsic_function/transformer.rb
+++ b/lib/floe/workflow/intrinsic_function/transformer.rb
@@ -193,6 +193,18 @@ module Floe
           OpenSSL::Digest.hexdigest(algorithm, data)
         end
 
+        rule(:states_json_merge => {:args => subtree(:args)}) do
+          args = Transformer.process_args(args(), "States.JsonMerge", [Hash, Hash, [TrueClass, FalseClass]])
+          left, right, deep = *args
+
+          if deep
+            # NOTE: not implemented by aws States language and nuances not defined in docs
+            left.merge(right) { |_key, l, r| l.kind_of?(Hash) && r.kind_of?(Hash) ? l.merge(r) : r }
+          else
+            left.merge(right)
+          end
+        end
+
         rule(:states_json_to_string => {:args => subtree(:args)}) do
           args = Transformer.process_args(args(), "States.JsonToString", [Object])
           json = args.first

--- a/spec/workflow/intrinsic_function_spec.rb
+++ b/spec/workflow/intrinsic_function_spec.rb
@@ -529,6 +529,35 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
       end
     end
 
+    describe "States.JsonMerge" do
+      it "it merges with right hand precedence" do
+        result = described_class.value(
+          "States.JsonMerge($.left, $.right, false)", {},
+          {"left" => {"a" => "la", "b" => "lb"}, "right" => {"b" => "rb"}}
+        )
+        expect(result).to eq({"a" => "la", "b" => "rb"})
+      end
+
+      it "it deep merges with right hand precedence" do
+        result = described_class.value(
+          "States.JsonMerge($.left, $.right, true)", {},
+          {"left" => {"b" => {"ba" => "lb", "bb" => "lb"}}, "right" => {"b" => {"ba" => "rb"}}}
+        )
+        expect(result).to eq({"b" => {"ba" => "rb", "bb" => "lb"}})
+      end
+
+      it "fails with wrong number of parameters" do
+        expect { described_class.value("States.JsonMerge($.left, $.right)", {}, {"left" => [1, 2], "right" => {"a" => "la"}}) }.to raise_error(ArgumentError, "wrong number of arguments to States.JsonMerge (given 2, expected 3)")
+        expect { described_class.value("States.JsonMerge($.left, $.right, false, 5)", {}, {"left" => [1, 2], "right" => {"a" => "la"}}) }.to raise_error(ArgumentError, "wrong number of arguments to States.JsonMerge (given 4, expected 3)")
+      end
+
+      it "fails with wrong type of parameters" do
+        expect { described_class.value("States.JsonMerge($.left, $.right, false)", {}, {"left" => [1, 2], "right" => {"a" => "la"}}) }.to raise_error(ArgumentError, "wrong type for argument 1 to States.JsonMerge (given Array, expected Hash)")
+        expect { described_class.value("States.JsonMerge($.left, $.right, false)", {}, {"left" => {"a" => "la"}, "right" => [1, 2]}) }.to raise_error(ArgumentError, "wrong type for argument 2 to States.JsonMerge (given Array, expected Hash)")
+        expect { described_class.value("States.JsonMerge($.left, $.right, 5)", {}, {"left" => {"a" => "la"}, "right" => {"b" => "rb"}}) }.to raise_error(ArgumentError, "wrong type for argument 3 to States.JsonMerge (given Integer, expected one of TrueClass, FalseClass)")
+      end
+    end
+
     describe "States.JsonToString" do
       it "fetches values from the input" do
         # this is not in the spec but automatic as part of the parser


### PR DESCRIPTION
Part of #64

Ruby missing a `Boolean` is frustrating me more and more.

This adds `JsonMerge`.

Please share your thoughts on how to handle the Boolean Attribute.

The other solution I had was a multi argument that handles a crystal style argument and it went through each of them. But it still had more modification in the comparison portion of the check code

Another solution is to just specify Object, and then manually make a check, but this required duplication of the error message.