### PR TITLE
In ChoiceRule::Data, parse compare key and variable 

### DIFF
--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -3,6 +3,8 @@
 module Floe
   class Workflow
     class ChoiceRule
+      include ValidationMixin
+
       class << self
         def build(workflow, name, payload)
           if (sub_payloads = payload["Not"])
@@ -27,11 +29,13 @@ module Floe
 
       attr_reader :next, :payload, :children, :name
 
-      def initialize(_workflow, name, payload, children = nil)
+      def initialize(workflow, name, payload, children = nil)
         @name      = name
         @payload   = payload
         @children  = children
         @next      = payload["Next"]
+
+        validate_next!(workflow)
       end
 
       def true?(*)
@@ -39,6 +43,33 @@ module Floe
       end
 
       private
+
+      def validate_next!(workflow)
+        if is_child?
+          # non-top level nodes don't allow a next
+          invalid_field_error!("Next", @next, "not allowed in a child rule") if @next
+        elsif !@next
+          # top level nodes require a next
+          missing_field_error!("Next")
+        elsif !workflow_state?(@next, workflow)
+          # top level nodes require a next field that is found
+          invalid_field_error!("Next", @next, "is not found in \"States\"")
+        end
+      end
+
+      # returns true if this is a child rule underneath an And/Or/Not
+      # {
+      #   "Or": [
+      #     {"Variable": "$.foo", "IsString": true},
+      #     {"Variable": "$.foo", "IsBoolean": true}
+      #   ], "Next": "Finished"
+      # }
+      #
+      # The Or node, has no conjunction parent, so it is not a child (requires a Next)
+      # The 2 Data nodes have a conjunction parent, so each one is a child (do not allow a Next)
+      def is_child? # rubocop:disable Naming/PredicateName
+        !(%w[And Or Not] & name[0..-2]).empty?
+      end
     end
   end
 end

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -25,15 +25,13 @@ module Floe
         end
       end
 
-      attr_reader :next, :payload, :variable, :children, :name
+      attr_reader :next, :payload, :children, :name
 
       def initialize(_workflow, name, payload, children = nil)
         @name      = name
         @payload   = payload
         @children  = children
-
-        @next     = payload["Next"]
-        @variable = payload["Variable"]
+        @next      = payload["Next"]
       end
 
       def true?(*)
@@ -41,10 +39,6 @@ module Floe
       end
 
       private
-
-      def variable_value(context, input)
-        Path.value(variable, context, input)
-      end
     end
   end
 end

--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -6,14 +6,14 @@ module Floe
       class Data < Floe::Workflow::ChoiceRule
         COMPARE_KEYS = %w[IsNull IsPresent IsNumeric IsString IsBoolean IsTimestamp String Numeric Boolean Timestamp].freeze
 
-        attr_reader :variable, :compare_key
+        attr_reader :variable, :compare_key, :value, :path
 
         def initialize(_workflow, _name, payload)
           super
 
           @variable = parse_path("Variable", payload)
-          @compare_key = payload.keys.detect { |key| key.match?(/^(#{COMPARE_KEYS.join("|")})/) }
-          parser_error!("requires a compare key") unless compare_key
+          parse_compare_key
+          @value = path ? parse_path(compare_key, payload) : payload[compare_key]
         end
 
         def true?(context, input)
@@ -104,8 +104,15 @@ module Floe
           false
         end
 
+        def parse_compare_key
+          @compare_key = payload.keys.detect { |key| key.match?(/^(#{COMPARE_KEYS.join("|")})/) }
+          parser_error!("requires a compare key") unless compare_key
+
+          @path = compare_key.end_with?("Path")
+        end
+
         def compare_value(context, input)
-          compare_key.end_with?("Path") ? Path.value(payload[compare_key], context, input) : payload[compare_key]
+          path ? value.value(context, input) : value
         end
 
         def variable_value(context, input)

--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -6,10 +6,12 @@ module Floe
       class Data < Floe::Workflow::ChoiceRule
         COMPARE_KEYS = %w[IsNull IsPresent IsNumeric IsString IsBoolean IsTimestamp String Numeric Boolean Timestamp].freeze
 
-        attr_reader :compare_key
+        attr_reader :variable, :compare_key
 
         def initialize(*)
           super
+
+          @variable = payload["Variable"]
           @compare_key = payload.keys.detect { |key| key.match?(/^(#{COMPARE_KEYS.join("|")})/) }
 
           raise Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key" if @compare_key.nil?
@@ -105,6 +107,10 @@ module Floe
 
         def compare_value(context, input)
           compare_key.end_with?("Path") ? Path.value(payload[compare_key], context, input) : payload[compare_key]
+        end
+
+        def variable_value(context, input)
+          Path.value(variable, context, input)
         end
       end
     end

--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -4,6 +4,17 @@ module Floe
   class Workflow
     class ChoiceRule
       class Data < Floe::Workflow::ChoiceRule
+        COMPARE_KEYS = %w[IsNull IsPresent IsNumeric IsString IsBoolean IsTimestamp String Numeric Boolean Timestamp].freeze
+
+        attr_reader :compare_key
+
+        def initialize(*)
+          super
+          @compare_key = payload.keys.detect { |key| key.match?(/^(#{COMPARE_KEYS.join("|")})/) }
+
+          raise Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key" if @compare_key.nil?
+        end
+
         def true?(context, input)
           return presence_check(context, input) if compare_key == "IsPresent"
 
@@ -90,10 +101,6 @@ module Floe
           true
         rescue TypeError, Date::Error
           false
-        end
-
-        def compare_key
-          @compare_key ||= payload.keys.detect { |key| key.match?(/^(IsNull|IsPresent|IsNumeric|IsString|IsBoolean|IsTimestamp|String|Numeric|Boolean|Timestamp)/) }
         end
 
         def compare_value(context, input)

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -16,6 +16,34 @@ RSpec.describe Floe::Workflow::ChoiceRule do
     it "works with valid next" do
       workflow
     end
+
+    context "with unknown Next" do
+      let(:choices) { [{"Variable" => "$.foo", "StringEquals" => "bar", "Next" => "Missing"}] }
+      it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data field \"Next\" value \"Missing\" is not found in \"States\"") }
+    end
+
+    context "with Variable missing" do
+      let(:choices) { [{"StringEquals" => "bar", "Next" => "FirstMatchState"}] }
+
+      it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data does not have required field \"Variable\"") }
+    end
+
+    context "with non-path Variable" do
+      let(:choices) { [{"Variable" => "wrong", "Next" => "FirstMatchState"}] }
+      it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data field \"Variable\" value \"wrong\" Path [wrong] must start with \"$\"") }
+    end
+
+    context "with second level Next (Not)" do
+      let(:choices) { [{"Not" => {"Variable" => "$.foo", "StringEquals" => "bar", "Next" => "FirstMatchState"}, "Next" => "FirstMatchState"}] }
+
+      it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Not.0.Data field \"Next\" value \"FirstMatchState\" not allowed in a child rule") }
+    end
+
+    context "with second level Next (And)" do
+      let(:choices) { [{"And" => [{"Variable" => "$.foo", "StringEquals" => "bar", "Next" => "FirstMatchState"}], "Next" => "FirstMatchState"}] }
+
+      it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.And.0.Data field \"Next\" value \"FirstMatchState\" not allowed in a child rule") }
+    end
   end
 
   describe "#true?" do
@@ -25,7 +53,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
 
     context "with abstract top level class" do
       let(:input) { {} }
-      let(:subject) { described_class.new(workflow, ["Choice1", "Choices", 1], choices.first).true?(context, input) }
+      let(:subject) { described_class.new(workflow, ["Choice1", "Choices", 1, "Data"], choices.first).true?(context, input) }
 
       it "is not implemented" do
         expect { subject }.to raise_exception(NotImplementedError)
@@ -109,7 +137,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
         let(:input) { {"foo" => "bar"} }
 
         it "raises an exception" do
-          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key")
+          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data requires a compare key")
         end
       end
 
@@ -118,7 +146,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
         let(:input)   { {"foo" => 0, "bar" => 1} }
 
         it "fails" do
-          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key")
+          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data requires a compare key")
         end
       end
 

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data field \"Variable\" value \"wrong\" Path [wrong] must start with \"$\"") }
     end
 
+    context "with non-path Compare Key" do
+      let(:choices) { [{"Variable" => "$foo", "StringEqualsPath" => "wrong", "Next" => "FirstMatchState"}] }
+      it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data field \"StringEqualsPath\" value \"wrong\" Path [wrong] must start with \"$\"") }
+    end
+
     context "with second level Next (Not)" do
       let(:choices) { [{"Not" => {"Variable" => "$.foo", "StringEquals" => "bar", "Next" => "FirstMatchState"}, "Next" => "FirstMatchState"}] }
 

--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -104,6 +104,24 @@ RSpec.describe Floe::Workflow::ChoiceRule do
         end
       end
 
+      context "with a missing compare key" do
+        let(:choices) { [{"Variable" => "$.foo", "Next" => "FirstMatchState"}] }
+        let(:input) { {"foo" => "bar"} }
+
+        it "raises an exception" do
+          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key")
+        end
+      end
+
+      context "with an invalid compare key" do
+        let(:choices) { [{"Variable" => "$.foo", "InvalidCompare" => "$.bar", "Next" => "FirstMatchState"}] }
+        let(:input)   { {"foo" => 0, "bar" => 1} }
+
+        it "fails" do
+          expect { subject }.to raise_exception(Floe::InvalidWorkflowError, "Data-test Expression Choice Rule must have a compare key")
+        end
+      end
+
       context "with IsNull" do
         let(:choices) { [{"Variable" => "$.foo", "IsNull" => true, "Next" => "FirstMatchState"}] }
 

--- a/spec/workflow/states/choice_spec.rb
+++ b/spec/workflow/states/choice_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Floe::Workflow::States::Choice do
     context "with a missing variable" do
       it "shows error" do
         workflow.run_nonblock
+        expect(ctx.failed?).to eq(true)
         expect(ctx.output).to eq(
           {
             "Cause" => "Path [$.foo] references an invalid value",


### PR DESCRIPTION
```json
{
  "Choices": [
    {"Variable": "$.foo", "GreaterThanPath": "$.bar", "Next": "Phase2"}
  ]
}
```

## Changes

| Concept | value | change |
|---------|-------|--------|
|`@variable`|`"$.foo"`|Move over to `ChoiceRule::Data`. Store as a `Path`.|
|`@compare_key`|`"GreaterThanPath"`| Validate. Store in variable.|
|`@path`|`true`|Store in variable. `true` when key has `"Path"` in it.|
|`@value`|`"$.bar"`|Store in variable as `String` or `Path` depending upon `@path`.
|`@next`|`"Phase2"`|Validate. Required if top level condition.|


## Changes in words

- Move `Variable` over to `ChoiceRule::Data` since this is only valid for those cases.
- Validates the compare key and keep as a variable.
- Validates the compare key value and keep as a variable.
- If compare key is a path, then `@path = true` and `@value` is a `Path`.
- Validate `Next`.

