### PR TITLE
Add States.Format intrinsic function

### DIFF
--- a/lib/floe/workflow/intrinsic_function/parser.rb
+++ b/lib/floe/workflow/intrinsic_function/parser.rb
@@ -54,6 +54,7 @@ module Floe
         end
 
         [
+          :states_format,          "States.Format",
           :states_string_to_json,  "States.StringToJson",
           :states_json_to_string,  "States.JsonToString",
           :states_array,           "States.Array",
@@ -79,7 +80,8 @@ module Floe
         end
 
         rule(:expression) do
-          states_string_to_json |
+          states_format |
+            states_string_to_json |
             states_json_to_string |
             states_array |
             states_array_partition |

--- a/lib/floe/workflow/intrinsic_function/transformer.rb
+++ b/lib/floe/workflow/intrinsic_function/transformer.rb
@@ -50,7 +50,11 @@ module Floe
             args.zip(signature).each_with_index do |(arg, type), index|
               type = type.type if type.kind_of?(OptionalArg)
 
-              raise ArgumentError, "wrong type for argument #{index + 1} to #{function} (given #{arg.class}, expected #{type})" unless arg.kind_of?(type)
+              if type.kind_of?(Array)
+                raise ArgumentError, "wrong type for argument #{index + 1} to #{function} (given #{arg.class}, expected one of #{type.join(", ")})" unless type.any? { |t| arg.kind_of?(t) }
+              else
+                raise ArgumentError, "wrong type for argument #{index + 1} to #{function} (given #{arg.class}, expected #{type})" unless arg.kind_of?(type)
+              end
             end
           end
         end

--- a/spec/workflow/intrinsic_function/parser_spec.rb
+++ b/spec/workflow/intrinsic_function/parser_spec.rb
@@ -196,6 +196,16 @@ RSpec.describe Floe::Workflow::IntrinsicFunction::Parser do
     end
   end
 
+  describe "states_format" do
+    subject { described_class.new.states_format }
+
+    it do
+      expect(subject).to parse("States.Format('Your name is {}, we are in the year {}', 'Foo', 2020)")
+
+      expect(subject).to_not parse("States.Format")
+    end
+  end
+
   describe "states_string_to_json" do
     subject { described_class.new.states_string_to_json }
 


### PR DESCRIPTION
@kbrock Please review.

Note that I am finding a lot of complications around escaped characters particularly with how the spec describes them and what the stepfunctions tool is doing. So, I've marked these as TODO/pending, and plan to work on them in a follow up.  I think that States.Format is too useful to not get in based on these edge cases, so I'd like to merge this now, and work on those afterwards.

Part of https://github.com/ManageIQ/floe/issues/64