### PR TITLE
Enable support for Hashes in States.Hash

### DIFF
--- a/lib/floe/workflow/intrinsic_function/transformer.rb
+++ b/lib/floe/workflow/intrinsic_function/transformer.rb
@@ -177,7 +177,7 @@ module Floe
         rule(:states_hash => {:args => subtree(:args)}) do
           args = Transformer.process_args(args(), "States.Hash", [Object, String])
           data, algorithm = *args
-          raise NotImplementedError if data.kind_of?(Hash)
+
           if data.nil?
             raise ArgumentError, "invalid value for argument 1 to States.Hash (given null, expected non-null)"
           end
@@ -189,8 +189,8 @@ module Floe
 
           require "openssl"
           algorithm = algorithm.sub("-", "")
-          data = data.to_json unless data.kind_of?(String)
-          OpenSSL::Digest.hexdigest(algorithm, data)
+          data = JSON.generate(data) unless data.kind_of?(String)
+          OpenSSL::Digest.hexdigest(algorithm, data).force_encoding("UTF-8")
         end
 
         rule(:states_json_merge => {:args => subtree(:args)}) do

--- a/spec/workflow/intrinsic_function_spec.rb
+++ b/spec/workflow/intrinsic_function_spec.rb
@@ -501,7 +501,12 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
       end
 
       it "with a hash" do
-        pending("Not implemented yet")
+        result = described_class.value("States.Hash($.data, 'SHA-1')", {}, {"data" => {"foo" => "bar"}})
+        expect(result).to eq("a5e744d0164540d33b1d7ea616c28f2fa97e754a")
+      end
+
+      it "with a hash (matching the stepfunctions simulator)" do
+        pending "TODO: figure out how the stepfunctions simulator serializes hashes"
 
         result = described_class.value("States.Hash($.data, 'SHA-1')", {}, {"data" => {"foo" => "bar"}})
         expect(result).to eq("dc2935b70ad43836e2e74df2d9758b1e51397997")


### PR DESCRIPTION
While the actual hash value is different from the stepfunctions simulator it is still internally consistent, so it's usable. This would only create problems if someone ran this States.Hash in floe and tried to compare it to the exact same run in AWS, which seems unlikely. Even so, I added a pending test so we can try to figure it out later.

@kbrock or @agrare Please review.  Follow up to #64 