### PR TITLE
Add step functions tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /tmp/
 
 Gemfile.lock
+
+tools/StepFunctionsLocal/


### PR DESCRIPTION
Whether we merge #244 or not, I think it's useful to have a known place where the tool could exist, so this exacts the .gitignore entry from #244 for that purpose.  Locally this would help me a lot, cause every so often I accidentally commit it and it's huge :)