### PR TITLE
Fix podman/docker container_ref trailing newline

### DIFF
--- a/lib/floe/container_runner/docker.rb
+++ b/lib/floe/container_runner/docker.rb
@@ -129,7 +129,7 @@ module Floe
         logger.debug("Running #{AwesomeSpawn.build_command_line(self.class::DOCKER_COMMAND, params)}")
 
         result = docker!(*params)
-        result.output
+        result.output.chomp
       end
 
       def run_container_params(image, env, secrets_file)

--- a/spec/container_runner/docker_spec.rb
+++ b/spec/container_runner/docker_spec.rb
@@ -15,21 +15,27 @@ RSpec.describe Floe::ContainerRunner::Docker do
     end
 
     it "calls docker run with the image name" do
-      stub_good_run!("docker", :params => ["run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest",], :output => container_id)
+      stub_good_run!("docker", :params => ["run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest",], :output => "#{container_id}\n")
 
       subject.run_async!("docker://hello-world:latest")
     end
 
     it "passes environment variables to docker run" do
-      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
       subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"})
     end
 
     it "passes a secrets volume to docker run" do
-      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:v, a_string_including(":/run/secrets")], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:v, a_string_including(":/run/secrets")], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
       subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
+    end
+
+    it "sets the container id in runner_context" do
+      stub_good_run!("docker", :params => ["run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest",], :output => "#{container_id}\n")
+
+      expect(subject.run_async!("docker://hello-world:latest")).to include("container_ref" => container_id)
     end
 
     context "with network=host" do

--- a/spec/container_runner/kubernetes_spec.rb
+++ b/spec/container_runner/kubernetes_spec.rb
@@ -78,6 +78,28 @@ RSpec.describe Floe::ContainerRunner::Kubernetes do
       subject.run_async!("docker://hello-world:latest")
     end
 
+    it "sets the pod name in runner_context" do
+      expected_pod_spec = hash_including(
+        :kind       => "Pod",
+        :apiVersion => "v1",
+        :metadata   => {
+          :name      => a_string_starting_with("floe-hello-world-"),
+          :namespace => "default"
+        },
+        :spec       => hash_including(
+          :containers => [
+            hash_including(
+              :name  => "floe-hello-world",
+              :image => "hello-world:latest"
+            )
+          ]
+        )
+      )
+      stub_kubernetes_run(:spec => expected_pod_spec, :status => false, :cleanup => false)
+
+      expect(subject.run_async!("docker://hello-world:latest")).to include("container_ref" => a_string_starting_with("floe-hello-world-"))
+    end
+
     it "calls kubectl run with an image name <= 63 characters" do
       expected_pod_spec = hash_including(
         :kind       => "Pod",

--- a/spec/container_runner/podman_spec.rb
+++ b/spec/container_runner/podman_spec.rb
@@ -15,20 +15,26 @@ RSpec.describe Floe::ContainerRunner::Podman do
     end
 
     it "calls docker run with the image name" do
-      stub_good_run!("podman", :params => ["run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+      stub_good_run!("podman", :params => ["run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
       subject.run_async!("docker://hello-world:latest")
     end
 
     it "passes environment variables to podman run" do
-      stub_good_run!("podman", :params => ["run", :detach, [:e, "FOO=BAR"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+      stub_good_run!("podman", :params => ["run", :detach, [:e, "FOO=BAR"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
       subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"})
     end
 
+    it "sets the container id in runner_context" do
+      stub_good_run!("podman", :params => ["run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
+
+      expect(subject.run_async!("docker://hello-world:latest")).to include("container_ref" => container_id)
+    end
+
     it "passes a secrets volume to podman run" do
       stub_good_run!("podman", :params => ["secret", "create", anything, "-"], :in_data => {"luggage_password" => "12345"}.to_json)
-      stub_good_run!("podman", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, a_string_including("_CREDENTIALS=")], [:secret, anything], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+      stub_good_run!("podman", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, a_string_including("_CREDENTIALS=")], [:secret, anything], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
       subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
     end
@@ -116,7 +122,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"identity" => ".ssh/id_rsa.pub"} }
 
         it "calls docker run with --identity .ssh/id_rsa.pub" do
-          stub_good_run!("podman", :params => [[:identity, ".ssh/id_rsa.pub"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => [[:identity, ".ssh/id_rsa.pub"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -126,7 +132,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"log-level" => "debug"} }
 
         it "calls docker run with --log-level debug" do
-          stub_good_run!("podman", :params => [[:"log-level", "debug"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => [[:"log-level", "debug"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -136,7 +142,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"network" => "host"} }
 
         it "calls docker run with --net host" do
-          stub_good_run!("podman", :params => ["run", :detach, [:net, "host"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => ["run", :detach, [:net, "host"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -146,7 +152,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"noout" => "true"} }
 
         it "calls docker run with --noout" do
-          stub_good_run!("podman", :params => [:noout, "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => [:noout, "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -156,7 +162,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"pull-policy" => "newer"} }
 
         it "calls podman run with --noout" do
-          stub_good_run!("podman", :params => ["run", :detach, [:pull, "newer"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => ["run", :detach, [:pull, "newer"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -166,7 +172,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"root" => "/run/containers/storage"} }
 
         it "calls docker run with --root /run/containers/storage" do
-          stub_good_run!("podman", :params => [[:root, "/run/containers/storage"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => [[:root, "/run/containers/storage"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -176,7 +182,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"runroot" => "/run/containers/runtime"} }
 
         it "calls docker run with --runroot /run/containers/runtime" do
-          stub_good_run!("podman", :params => [[:runroot, "/run/containers/runtime"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => [[:runroot, "/run/containers/runtime"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -186,7 +192,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"runtime-flag" => "'log debug'"} }
 
         it "calls docker run with --runtime-flag 'log debug'" do
-          stub_good_run!("podman", :params => [[:"runtime-flag", "'log debug'"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => [[:"runtime-flag", "'log debug'"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -196,7 +202,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"storage-driver" => "overlay"} }
 
         it "calls docker run with --storage-driver overlay" do
-          stub_good_run!("podman", :params => [[:"storage-driver", "overlay"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => [[:"storage-driver", "overlay"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end
@@ -206,7 +212,7 @@ RSpec.describe Floe::ContainerRunner::Podman do
         let(:runner_options) { {"storage-opt" => "ignore_chown_errors=true"} }
 
         it "calls docker run with --storage-driver overlay" do
-          stub_good_run!("podman", :params => [[:"storage-opt", "ignore_chown_errors=true"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => container_id)
+          stub_good_run!("podman", :params => [[:"storage-opt", "ignore_chown_errors=true"], "run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
           subject.run_async!("docker://hello-world:latest")
         end


### PR DESCRIPTION
Since docker and podman use AwesomeSpawn to run a command-line utility the result that we use to get the container_ref has a trailing newline.

This causes issues trying to match the container_ref with one coming from events.

```
   131:         result = docker!(*params)
   132:         require 'byebug'; byebug
=> 133:         result.output
   134:       end

(byebug) result.output
"7c640ef968d2ce923418a3de8eedae5a19c0a31f1264417b0088e0df57d0bac8\n"
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
