### PR TITLE
Label containers/pods with workflow Execution ID

### DIFF
--- a/lib/floe/container_runner/docker.rb
+++ b/lib/floe/container_runner/docker.rb
@@ -158,11 +158,11 @@ module Floe
         event   = docker_event_status_to_event(status)
         running = event != :delete
 
-        name, exit_code = notice.dig("Actor", "Attributes")&.values_at("name", "exitCode")
+        name, exit_code, execution_id = notice.dig("Actor", "Attributes")&.values_at("name", "exitCode", "execution_id")
 
         runner_context = {"container_ref" => name, "container_state" => {"Running" => running, "ExitCode" => exit_code.to_i}}
 
-        [event, runner_context]
+        [event, {"execution_id" => execution_id, "runner_context" => runner_context}]
       rescue JSON::ParserError
         []
       end

--- a/lib/floe/container_runner/docker.rb
+++ b/lib/floe/container_runner/docker.rb
@@ -18,11 +18,11 @@ module Floe
         @pull_policy = options["pull-policy"]
       end
 
-      def run_async!(resource, env = {}, secrets = {}, _context = {})
+      def run_async!(resource, env, secrets, context)
         raise ArgumentError, "Invalid resource" unless resource&.start_with?("docker://")
 
-        image = resource.sub("docker://", "")
-
+        image          = resource.sub("docker://", "")
+        execution_id   = context.execution["Id"]
         runner_context = {}
 
         if secrets && !secrets.empty?
@@ -30,7 +30,7 @@ module Floe
         end
 
         begin
-          runner_context["container_ref"] = run_container(image, env, runner_context["secrets_ref"])
+          runner_context["container_ref"] = run_container(image, env, execution_id, runner_context["secrets_ref"])
           runner_context
         rescue AwesomeSpawn::CommandResultError => err
           cleanup(runner_context)
@@ -123,8 +123,8 @@ module Floe
 
       attr_reader :network
 
-      def run_container(image, env, secrets_file)
-        params = run_container_params(image, env, secrets_file)
+      def run_container(image, env, execution_id, secrets_file)
+        params = run_container_params(image, env, execution_id, secrets_file)
 
         logger.debug("Running #{AwesomeSpawn.build_command_line(self.class::DOCKER_COMMAND, params)}")
 
@@ -132,13 +132,14 @@ module Floe
         result.output.chomp
       end
 
-      def run_container_params(image, env, secrets_file)
+      def run_container_params(image, env, execution_id, secrets_file)
         params  = ["run"]
         params << :detach
         params += env.map { |k, v| [:e, "#{k}=#{v}"] }
         params << [:e, "_CREDENTIALS=/run/secrets"] if secrets_file
         params << [:pull, @pull_policy] if @pull_policy
         params << [:net, "host"] if @network == "host"
+        params << [:label, "execution_id=#{execution_id}"]
         params << [:v, "#{secrets_file}:/run/secrets:z"] if secrets_file
         params << [:name, container_name(image)]
         params << image

--- a/lib/floe/container_runner/kubernetes.rb
+++ b/lib/floe/container_runner/kubernetes.rb
@@ -295,9 +295,10 @@ module Floe
 
         pod             = notice.object
         container_ref   = pod.metadata.name
+        execution_id    = pod.metadata.labels["execution_id"]
         container_state = pod.to_h[:status].deep_stringify_keys
 
-        {"container_ref" => container_ref, "container_state" => container_state}
+        {"execution_id" => execution_id, "runner_context" => {"container_ref" => container_ref, "container_state" => container_state}}
       end
 
       def kubeclient

--- a/lib/floe/container_runner/podman.rb
+++ b/lib/floe/container_runner/podman.rb
@@ -30,13 +30,14 @@ module Floe
 
       private
 
-      def run_container_params(image, env, secret)
+      def run_container_params(image, env, execution_id, secret)
         params  = ["run"]
         params << :detach
         params += env.map { |k, v| [:e, "#{k}=#{v}"] }
         params << [:e, "_CREDENTIALS=/run/secrets/#{secret}"] if secret
         params << [:pull, @pull_policy] if @pull_policy
         params << [:net, "host"]        if @network == "host"
+        params << [:label, "execution_id=#{execution_id}"]
         params << [:secret, secret] if secret
         params << [:name, container_name(image)]
         params << image

--- a/lib/floe/container_runner/podman.rb
+++ b/lib/floe/container_runner/podman.rb
@@ -56,14 +56,16 @@ module Floe
       end
 
       def parse_notice(notice)
-        id, status, exit_code = JSON.parse(notice).values_at("ID", "Status", "ContainerExitCode")
+        notice = JSON.parse(notice)
+        id, status, exit_code, attributes = notice.values_at("ID", "Status", "ContainerExitCode", "Attributes")
 
-        event   = podman_event_status_to_event(status)
-        running = event != :delete
+        execution_id = attributes&.dig("execution_id")
+        event        = podman_event_status_to_event(status)
+        running      = event != :delete
 
         runner_context = {"container_ref" => id, "container_state" => {"Running" => running, "ExitCode" => exit_code.to_i}}
 
-        [event, runner_context]
+        [event, {"execution_id" => execution_id, "runner_context" => runner_context}]
       rescue JSON::ParserError
         []
       end

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -63,8 +63,10 @@ module Floe
 
           loop do
             # Block until an event is raised
-            event, runner_context = queue.pop
+            event, data = queue.pop
             break if event.nil?
+
+            _execution_id, runner_context = data.values_at("execution_id", "runner_context")
 
             # If the event is for one of our workflows set the updated runner_context
             workflows.each do |workflow|

--- a/spec/container_runner/docker_spec.rb
+++ b/spec/container_runner/docker_spec.rb
@@ -2,49 +2,51 @@ RSpec.describe Floe::ContainerRunner::Docker do
   require "securerandom"
 
   let(:subject)        { described_class.new(runner_options) }
+  let(:execution_id)   { SecureRandom.uuid }
+  let(:context)        { Floe::Workflow::Context.new({"Execution" => {"Id" => execution_id}}) }
   let(:runner_options) { {} }
   let(:container_id)   { SecureRandom.hex }
 
   describe "#run_async!" do
     it "raises an exception without a resource" do
-      expect { subject.run_async!(nil) }.to raise_error(ArgumentError, "Invalid resource")
+      expect { subject.run_async!(nil, {}, {}, context) }.to raise_error(ArgumentError, "Invalid resource")
     end
 
     it "raises an exception for an invalid resource uri" do
-      expect { subject.run_async!("arn:abcd:efgh") }.to raise_error(ArgumentError, "Invalid resource")
+      expect { subject.run_async!("arn:abcd:efgh", {}, {}, context) }.to raise_error(ArgumentError, "Invalid resource")
     end
 
     it "calls docker run with the image name" do
-      stub_good_run!("docker", :params => ["run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest",], :output => "#{container_id}\n")
+      stub_good_run!("docker", :params => ["run", :detach, [:label, "execution_id=#{execution_id}"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest",], :output => "#{container_id}\n")
 
-      subject.run_async!("docker://hello-world:latest")
+      subject.run_async!("docker://hello-world:latest", {}, {}, context)
     end
 
     it "passes environment variables to docker run" do
-      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
+      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:label, "execution_id=#{execution_id}"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
-      subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"})
+      subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {}, context)
     end
 
     it "passes a secrets volume to docker run" do
-      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:v, a_string_including(":/run/secrets")], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
+      stub_good_run!("docker", :params => ["run", :detach, [:e, "FOO=BAR"], [:e, "_CREDENTIALS=/run/secrets"], [:label, "execution_id=#{execution_id}"], [:v, a_string_including(":/run/secrets")], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"], :output => "#{container_id}\n")
 
-      subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"})
+      subject.run_async!("docker://hello-world:latest", {"FOO" => "BAR"}, {"luggage_password" => "12345"}, context)
     end
 
     it "sets the container id in runner_context" do
-      stub_good_run!("docker", :params => ["run", :detach, [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest",], :output => "#{container_id}\n")
+      stub_good_run!("docker", :params => ["run", :detach, [:label, "execution_id=#{execution_id}"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest",], :output => "#{container_id}\n")
 
-      expect(subject.run_async!("docker://hello-world:latest")).to include("container_ref" => container_id)
+      expect(subject.run_async!("docker://hello-world:latest", {}, {}, context)).to include("container_ref" => container_id)
     end
 
     context "with network=host" do
       let(:runner_options) { {"network" => "host"} }
 
       it "calls docker run with --net host" do
-        stub_good_run!("docker", :params => ["run", :detach, [:net, "host"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"])
+        stub_good_run!("docker", :params => ["run", :detach, [:net, "host"], [:label, "execution_id=#{execution_id}"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"])
 
-        subject.run_async!("docker://hello-world:latest")
+        subject.run_async!("docker://hello-world:latest", {}, {}, context)
       end
     end
 
@@ -52,9 +54,9 @@ RSpec.describe Floe::ContainerRunner::Docker do
       let(:runner_options) { {"pull-policy" => "always"} }
 
       it "calls docker run with --pull always" do
-        stub_good_run!("docker", :params => ["run", :detach, [:pull, "always"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"])
+        stub_good_run!("docker", :params => ["run", :detach, [:pull, "always"], [:label, "execution_id=#{execution_id}"], [:name, a_string_starting_with("floe-hello-world-")], "hello-world:latest"])
 
-        subject.run_async!("docker://hello-world:latest")
+        subject.run_async!("docker://hello-world:latest", {}, {}, context)
       end
     end
   end


### PR DESCRIPTION
Add a label to the containers/pods that get created for a workflow to make it easier to track which workflow a container is running for.  We can include this information in the `Floe::ContainerRunner.wait` information so that it is easier to associate a docker event with a particular workflow.

Kubernetes:
```
$ oc describe pod floe-sleep-860c91ff -n default
Name:             floe-sleep-860c91ff
Namespace:        default
Priority:         0
Service Account:  default
Node:             crc/192.168.126.11
Start Time:       Tue, 20 Aug 2024 12:45:35 -0400
Labels:           execution_id=187ca386-be9d-46ae-a26f-995ade0cdc94
```

Podman:
```
$ podman inspect floe-sleep-0bd31e77 | jq '.[].Config.Labels'
{
  "execution_id": "439cf44f-b49c-422b-8245-7d5d29c7cdc4",
  "io.buildah.version": "1.35.3"
}
```

Docker:
```
$ docker inspect floe-sleep-89fc1e96 | jq '.[].Config.Labels'
{
  "execution_id": "97714c1a-0569-43f1-9898-fafe8daaacdc",
  "io.buildah.version": "1.35.3"
}
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
