### PR TITLE
More granular compare_key and determine path at initialization time

### DIFF
--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Floe::Workflow::ChoiceRule do
       end
 
       context "with an invalid compare key" do
-        let(:choices) { [{"Variable" => "$.foo", "InvalidCompare" => "$.bar", "Next" => "FirstMatchState"}] }
+        let(:choices) { [{"Variable" => "$.foo", "StringBeGone" => "$.bar", "Next" => "FirstMatchState"}] }
         let(:input)   { {"foo" => 0, "bar" => 1} }
 
         it "fails" do


### PR DESCRIPTION
Invalid operators no longer slip through the cracks at parse time

This could have been written as `payload.keys.detect { |key| COMPARE_KEYS.match?(key) || TYPES.match?(key) }`,
but we'd just have to write it this when when we add type checking (the next PR)
