### PR TITLE
[WIP] No longer store payload in States

### DIFF
--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -101,6 +101,7 @@ module Floe
 
       # NOTE: this is a string, and states use an array
       @name        = name || "State Machine"
+      # NOTE: payload is stored to look up valid state names
       @payload     = payload
       @context     = context
       @comment     = payload["Comment"]

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -10,7 +10,6 @@ module Floe
 
       def initialize(workflow, name, payload)
         @name         = name
-        @payload      = payload
 
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -27,11 +27,10 @@ module Floe
         end
       end
 
-      attr_reader :next, :payload, :children, :name
+      attr_reader :next, :children, :name
 
       def initialize(workflow, name, payload, children = nil)
         @name      = name
-        @payload   = payload
         @children  = children
         @next      = payload["Next"]
 

--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -17,7 +17,7 @@ module Floe
           super
 
           @variable = parse_path("Variable", payload)
-          parse_compare_key
+          parse_compare_key(payload)
           @compare_predicate = parse_predicate(payload)
         end
 
@@ -114,7 +114,7 @@ module Floe
         # rubocop:enable Style/OptionalBooleanParameter
 
         # parse the compare key at initialization time
-        def parse_compare_key
+        def parse_compare_key(payload)
           payload.each_key do |key|
             # e.g. (String)(GreaterThan)(Path)
             if (match_values = OPERATION.match(key))

--- a/lib/floe/workflow/intrinsic_function.rb
+++ b/lib/floe/workflow/intrinsic_function.rb
@@ -11,10 +11,7 @@ module Floe
         payload.start_with?("States.")
       end
 
-      attr_reader :payload
-
       def initialize(payload)
-        @payload = payload
         @tree    = Parser.new.parse(payload)
 
         Floe.logger.debug { "Parsed intrinsic function: #{payload.inspect} => #{tree.inspect}" }

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -10,7 +10,6 @@ module Floe
 
       def initialize(_workflow, name, payload)
         @name             = name
-        @payload          = payload
 
         @error_equals     = payload["ErrorEquals"]
         @interval_seconds = payload["IntervalSeconds"] || 1.0

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -22,11 +22,10 @@ module Floe
         end
       end
 
-      attr_reader :comment, :name, :type, :payload
+      attr_reader :comment, :name, :type
 
       def initialize(_workflow, name, payload)
         @name     = name
-        @payload  = payload
         @type     = payload["Type"]
         @comment  = payload["Comment"]
       end

--- a/lib/floe/workflow/states/choice.rb
+++ b/lib/floe/workflow/states/choice.rb
@@ -9,10 +9,10 @@ module Floe
         def initialize(workflow, name, payload)
           super
 
-          validate_state!(workflow)
-
-          @choices = payload["Choices"].map.with_index { |choice, i| ChoiceRule.build(workflow, name + ["Choices", i.to_s], choice) }
+          @choices = payload["Choices"]&.map&.with_index { |choice, i| ChoiceRule.build(workflow, name + ["Choices", i.to_s], choice) }
           @default = payload["Default"]
+
+          validate_state!(workflow)
 
           @input_path  = Path.new(payload.fetch("InputPath", "$"))
           @output_path = Path.new(payload.fetch("OutputPath", "$"))
@@ -45,12 +45,12 @@ module Floe
         end
 
         def validate_state_choices!
-          missing_field_error!("Choices") unless payload.key?("Choices")
-          invalid_field_error!("Choices", nil, "must be a non-empty array") unless payload["Choices"].kind_of?(Array) && !payload["Choices"].empty?
+          missing_field_error!("Choices") if @choices.nil?
+          invalid_field_error!("Choices", nil, "must be a non-empty array") unless @choices.kind_of?(Array) && !@choices.empty?
         end
 
         def validate_state_default!(workflow)
-          invalid_field_error!("Default", payload["Default"], "is not found in \"States\"") if payload["Default"] && !workflow_state?(payload["Default"], workflow)
+          invalid_field_error!("Default", @default, "is not found in \"States\"") if @default && !workflow_state?(@default, workflow)
         end
       end
     end


### PR DESCRIPTION
Overview
---

We use `Payload#payload` in `State#initialize`, but then do not use it again.

This PR still passes `payload` to `initialize`, but no longer stores it in an instance variable.

Before
------

I had kept `@payload` around to make debugging easier, but in truth, I have never used it to debug.

After
-----

We no longer store `State#payload`.

We do need `Workflow#payload` to validate the `State#Next` values in `State#initalize`.
If we store/pass `Workflow#payload["State"].keys` into `State#initialize`, then this can be dropped.

We do need `Path#payload`, but this is not a `payload` but rather a path location.

WIP
---

This is valid, it is ready, and I like it.
Leaving as WIP to mark it as not a priority.