### PR TITLE
Choice State enforces type checking

### DIFF
--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -16,7 +16,7 @@ module Floe
         def initialize(_workflow, _name, payload)
           super
 
-          @variable = parse_path("Variable", payload)
+          @variable = parse_path("Variable")
           parse_compare_key
         end
 
@@ -119,7 +119,7 @@ module Floe
             if (match_values = OPERATION.match(key))
               @compare_key = key
               @type, _operator, @path = match_values.captures
-              @compare_predicate = parse_predicate(payload, type)
+              @compare_predicate = parse_predicate(type)
               break
             end
             # e.g. (Is)(String)
@@ -127,7 +127,7 @@ module Floe
               @compare_key = key
               # type: nil means no runtime type checking.
               @type = @path = nil
-              @compare_predicate = parse_predicate(payload, "Boolean")
+              @compare_predicate = parse_predicate("Boolean")
               break
             end
           end
@@ -136,8 +136,8 @@ module Floe
 
         # parse predicate at initilization time
         # @return the right predicate attached to the compare key
-        def parse_predicate(payload, data_type)
-          path ? parse_path(compare_key, payload) : parse_field(compare_key, payload, data_type)
+        def parse_predicate(data_type)
+          path ? parse_path(compare_key) : parse_field(compare_key, data_type)
         end
 
         # @return right hand predicate - input path or static payload value)
@@ -153,14 +153,14 @@ module Floe
 
         # parse path at initilization time
         # helper method to parse a path from the payload
-        def parse_path(field_name, payload)
+        def parse_path(field_name)
           value = payload[field_name]
           missing_field_error!(field_name) unless value
           wrap_parser_error(field_name, value) { Path.new(value) }
         end
 
         # parse predicate field at initialization time
-        def parse_field(field_name, payload, data_type)
+        def parse_field(field_name, data_type)
           value = payload[field_name]
           return value if correct_type?(value, data_type)
 


### PR DESCRIPTION
# Overview

At runtime, ensure the `Variable` and predicate values are the right type.

# Change

```json
{"num1": 5, "str1": "z"}

{"Variable": "$.str1", "StringGreaterThanPath": "$.num1"}
```

Before: ruby runtime error
After: `Floe::ExecutionError`

```json
{"Variable": "$.str1", "StringGreaterThan": 5}
```

Before: ruby `Runtime` error
After: `Floe::InvalidWorkflowError`

# Implementation

We already have a method that verifies a value is a certain type. (e.g.: `is_string?`)

So adding type checking is easy:
- Write down the `type` from the comparison value (e.g.: comparison value `StringGreaterThan` => `@type="String"`)
- Translate `TYPES["String"]` to `is_string?`
- Call `is_string?` on our `Variable` and predicate values at runtime to ensure the `Input` has the correct data types.

# Details

📖 There are actually 3 different scenarios and they all act a little differently.

### Path

```json
{"Variable": "$.foo", "StringGreaterThanPath": "$.bar"}
```

- `$.foo` must point to a `String` or there is a runtime error.
- `$.bar` must point to a `String` or there is a runtime error.
- Else, actual comparison can take place (at runtime).

### Static predicate value

Change: At initialization time, we use `type` to verify the predicate value.

```json
{"Variable": "$.foo", "StringGreaterThan": "big"}
```

- `$.foo` must point to a `String` or there is a runtime error.
- `"big"` must be a `String` or there is an initialization error.
- Else, actual comparison can take place.

### Type checking

We do not want runtime errors thrown.
At initialization time, we still want to ensure the predicate is a `Boolean`. This contrasts the other cases because this has a type of `String`, yet we want the predicate to be a `Boolean`.

The code does not set a `type`, which effectively disables runtime type checking.

```json
{"Variable": "$.foo", "IsString": true}
```

- `$.foo` can point to any data type. If it is a `String`, then it resolves to `true`
- Else, it resolves to `false`
