### PR TITLE
Handle either tolerated_failure_count or tolerated_failure_percentage

### DIFF
--- a/lib/floe/workflow/states/map.rb
+++ b/lib/floe/workflow/states/map.rb
@@ -110,13 +110,18 @@ module Floe
           total      = contexts.count
 
           return true if num_failed.zero? || total.zero?
-          return true if tolerated_failure_percentage && tolerated_failure_percentage == 100
+          return false if tolerated_failure_count.nil? && tolerated_failure_percentage.nil?
+
           # Some have failed, check the tolerated_failure thresholds to see if
           # we should fail the whole state.
-          return true if tolerated_failure_count      && num_failed < tolerated_failure_count
-          return true if tolerated_failure_percentage && (100 * num_failed / total.to_f) < tolerated_failure_percentage
+          #
+          # If either ToleratedFailureCount or ToleratedFailurePercentage are breached
+          # then the whole state is considered failed.
+          count_tolerated = tolerated_failure_count.nil?      || num_failed < tolerated_failure_count
+          pct_tolerated   = tolerated_failure_percentage.nil? || tolerated_failure_percentage == 100 ||
+                            ((100 * num_failed / total.to_f) < tolerated_failure_percentage)
 
-          false
+          count_tolerated && pct_tolerated
         end
 
         private

--- a/spec/workflow/states/map_spec.rb
+++ b/spec/workflow/states/map_spec.rb
@@ -263,6 +263,44 @@ RSpec.describe Floe::Workflow::States::Map do
           end
         end
       end
+
+      context "with both ToleratedFailureCount and ToleratedFailurePercentage" do
+        context "with ToleratedFailureCount being lower than the failed percentge" do
+          let(:tolerated_failure_percentage) { 50 }
+          let(:tolerated_failure_count)      { 1 }
+
+          it "returns false" do
+            expect(state.success?(ctx)).to be_falsey
+          end
+        end
+
+        context "with ToleratedFailurePercentage being lower than the failed count" do
+          let(:tolerated_failure_percentage) { 10 }
+          let(:tolerated_failure_count)      { 3 }
+
+          it "returns false" do
+            expect(state.success?(ctx)).to be_falsey
+          end
+        end
+
+        context "with neither being high enough for success" do
+          let(:tolerated_failure_percentage) { 10 }
+          let(:tolerated_failure_count)      { 1 }
+
+          it "returns false" do
+            expect(state.success?(ctx)).to be_falsey
+          end
+        end
+
+        context "with both being high enough for success" do
+          let(:tolerated_failure_percentage) { 50 }
+          let(:tolerated_failure_count)      { 3 }
+
+          it "returns true" do
+            expect(state.success?(ctx)).to be_truthy
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/floe/pull/282#discussion_r1792238478 to handle both ToleratedFailureCount and ToleratedFailurePercent present

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
