### PR TITLE
Use send for choice operations

### DIFF
--- a/spec/workflow/choice_rule_spec.rb
+++ b/spec/workflow/choice_rule_spec.rb
@@ -34,8 +34,13 @@ RSpec.describe Floe::Workflow::ChoiceRule do
     end
 
     context "with non-path Compare Key" do
-      let(:choices) { [{"Variable" => "$foo", "StringEqualsPath" => "wrong", "Next" => "FirstMatchState"}] }
+      let(:choices) { [{"Variable" => "$.foo", "StringEqualsPath" => "wrong", "Next" => "FirstMatchState"}] }
       it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data field \"StringEqualsPath\" value \"wrong\" Path [wrong] must start with \"$\"") }
+    end
+
+    context "with invalid Compare Key" do
+      let(:choices) { [{"Variable" => "$.foo", "IntegerMatchPath" => "$.foo", "Next" => "FirstMatchState"}] }
+      it { expect { workflow }.to raise_exception(Floe::InvalidWorkflowError, "States.Choice1.Choices.0.Data requires a compare key") }
     end
 
     context "with second level Next (Not)" do


### PR DESCRIPTION
Pulled out of https://github.com/ManageIQ/floe/pull/189

This looks up the operation name up front and avoids the `case`