### PR TITLE
Fix Map/Parallel States checking container_runner#status! of finished states

### DIFF
--- a/lib/floe/container_runner/docker.rb
+++ b/lib/floe/container_runner/docker.rb
@@ -182,8 +182,8 @@ module Floe
 
       def inspect_container(container_id)
         JSON.parse(docker!("inspect", container_id).output).first
-      rescue
-        nil
+      rescue AwesomeSpawn::CommandResultError => err
+        raise Floe::ExecutionError.new("Failed to get status for container #{container_id}: #{err}")
       end
 
       def delete_container(container_id)

--- a/lib/floe/container_runner/kubernetes.rb
+++ b/lib/floe/container_runner/kubernetes.rb
@@ -155,6 +155,8 @@ module Floe
 
       def pod_info(pod_name)
         kubeclient.get_pod(pod_name, namespace)
+      rescue Kubeclient::HttpError => err
+        raise Floe::ExecutionError.new("Failed to get status for pod #{namespace}/#{pod_name}: #{err}")
       end
 
       def pod_running?(context)

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -55,8 +55,16 @@ module Floe
         mark_started(context)
       end
 
+      def started?(context)
+        context.state_started?
+      end
+
       def finish(context)
         mark_finished(context)
+      end
+
+      def finished?(context)
+        context.state_finished?
       end
 
       def mark_started(context)
@@ -87,7 +95,7 @@ module Floe
       end
 
       def ready?(context)
-        !context.state_started? || !running?(context)
+        !started?(context) || !running?(context)
       end
 
       def running?(context)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -61,7 +61,8 @@ module Floe
         end
 
         def running?(context)
-          return true if waiting?(context)
+          return true  if waiting?(context)
+          return false if finished?(context)
 
           runner.status!(context.state["RunnerContext"])
           runner.running?(context.state["RunnerContext"])

--- a/spec/container_runner/kubernetes_spec.rb
+++ b/spec/container_runner/kubernetes_spec.rb
@@ -403,7 +403,7 @@ RSpec.describe Floe::ContainerRunner::Kubernetes do
 
     it "raises an exception when getting pod info fails" do
       allow(kubeclient).to receive(:get_pod).and_raise(Kubeclient::ResourceNotFoundError.new(404, "Resource Not Found", {}))
-      expect { subject.status!(runner_context) }.to raise_error(Kubeclient::ResourceNotFoundError, /Resource Not Found/)
+      expect { subject.status!(runner_context) }.to raise_error(Floe::ExecutionError, /Failed to get status for pod/)
     end
   end
 


### PR DESCRIPTION
If a state is finished, map/parallel states are re-checking to see if these are ready which causes us to check status of a container that has already been removed.

This leads to: `kubeclient-4.12.0/lib/kubeclient/common.rb:130:in `rescue in handle_exception': pods "floe-sleep-f9149969" not found (Kubeclient::ResourceNotFoundError)`
```
$ exe/floe --kubernetes --container-runner-options=namespace=manageiq examples/parallel.asl
I, [2024-11-21T13:06:50.967364 #295618]  INFO -- : Checking 1 workflows...
I, [2024-11-21T13:06:50.967503 #295618]  INFO -- : Running state: [Parallel:FunWithMath] with input [{}]...
I, [2024-11-21T13:06:50.967751 #295618]  INFO -- : Running state: [Task:Add] with input [{}]...
I, [2024-11-21T13:06:51.053196 #295618]  INFO -- : Running state: [Task:Subtract] with input [{}]...
I, [2024-11-21T13:07:03.315566 #295618]  INFO -- : Running state: [Task:Add] with input [{}]...Complete workflow - output: [{}]
/home/grare/adam/.gem/ruby/3.3.0/gems/kubeclient-4.12.0/lib/kubeclient/common.rb:130:in `rescue in handle_exception': pods "floe-sleep-2de8e6e1" not found (Kubeclient::ResourceNotFoundError)
	from /home/grare/adam/.gem/ruby/3.3.0/gems/kubeclient-4.12.0/lib/kubeclient/common.rb:120:in `handle_exception'
	from /home/grare/adam/.gem/ruby/3.3.0/gems/kubeclient-4.12.0/lib/kubeclient/common.rb:368:in `get_entity'
	from /home/grare/adam/.gem/ruby/3.3.0/gems/kubeclient-4.12.0/lib/kubeclient/common.rb:244:in `block (2 levels) in define_entity_methods'
	from /home/grare/adam/src/manageiq/floe/lib/floe/container_runner/kubernetes.rb:157:in `pod_info'
	from /home/grare/adam/src/manageiq/floe/lib/floe/container_runner/kubernetes.rb:69:in `status!'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow/states/task.rb:66:in `running?'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow/state.rb:90:in `ready?'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow_base.rb:46:in `step_nonblock_ready?'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow/states/parallel.rb:50:in `block in step_nonblock!'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow/states/parallel.rb:49:in `each'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow/states/parallel.rb:49:in `step_nonblock!'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow/states/child_workflow_mixin.rb:10:in `run_nonblock!'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow.rb:111:in `step_nonblock'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow.rb:103:in `run_nonblock'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow.rb:37:in `each'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow.rb:37:in `block in wait'
	from <internal:kernel>:187:in `loop'
	from /home/grare/adam/src/manageiq/floe/lib/floe/workflow.rb:33:in `wait'
	from /home/grare/adam/src/manageiq/floe/lib/floe/cli.rb:29:in `run'
	from exe/floe:7:in `<main>'
```


This was only seen on kubernetes/openshift because docker&podman were eating the exception and returning `nil`.
Since I don't think you should check the status of a container that we already knowingly deleted, checking container status and getting an error back should be a Floe::ExecutionError.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
