### PR TITLE
Fix child workflow mixin tight loop

### DIFF
--- a/lib/floe/workflow/states/child_workflow_mixin.rb
+++ b/lib/floe/workflow/states/child_workflow_mixin.rb
@@ -6,8 +6,7 @@ module Floe
       module ChildWorkflowMixin
         def run_nonblock!(context)
           start(context) unless context.state_started?
-
-          step_nonblock!(context) while running?(context)
+          step_nonblock!(context)
           return Errno::EAGAIN unless ready?(context)
 
           finish(context) if ended?(context)


### PR DESCRIPTION
When I moved to async/event driven for Map/Parallel I forgot to remove this loop.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
