### PR TITLE
Use op_prefix for ops

### DIFF
--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -80,27 +80,27 @@ module Floe
         # rubocop:enable Naming/PredicateName
         # rubocop:enable Style/OptionalBooleanParameter
 
-        def equals?(lhs, rhs)
+        def op_equals?(lhs, rhs)
           lhs == rhs
         end
 
-        def lessthan?(lhs, rhs)
+        def op_lessthan?(lhs, rhs)
           lhs < rhs
         end
 
-        def greaterthan?(lhs, rhs)
+        def op_greaterthan?(lhs, rhs)
           lhs > rhs
         end
 
-        def lessthanequals?(lhs, rhs)
+        def op_lessthanequals?(lhs, rhs)
           lhs <= rhs
         end
 
-        def greaterthanequals?(lhs, rhs)
+        def op_greaterthanequals?(lhs, rhs)
           lhs >= rhs
         end
 
-        def matches?(lhs, rhs)
+        def op_matches?(lhs, rhs)
           lhs.match?(Regexp.escape(rhs).gsub('\*', '.*?'))
         end
 
@@ -111,7 +111,7 @@ module Floe
             if (match_values = OPERATION.match(key))
               @compare_key = key
               @type, operator, @path = match_values.captures
-              @operation = "#{operator.downcase}?".to_sym
+              @operation = "op_#{operator.downcase}?".to_sym
               @compare_predicate = parse_predicate(type)
               break
             end


### PR DESCRIPTION
In response to: https://github.com/ManageIQ/floe/pull/295/files#r1870341288

Boolean operations use is_{boolean,string,...}
But for regular actions, they overlapped with ruby's `equals?` So those have been changed to `op_{equals}?`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
