### PR TITLE
Loosen the exception msg matcher for JSON failures

### DIFF
--- a/spec/workflow/intrinsic_function_spec.rb
+++ b/spec/workflow/intrinsic_function_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Floe::Workflow::IntrinsicFunction do
       end
 
       it "fails with invalid argument values" do
-        expect { described_class.value("States.StringToJson($.input)", {}, {"input" => "foo"}) }.to raise_error(ArgumentError, "invalid value for argument 1 to States.StringToJson (invalid json: unexpected token at 'foo')")
+        expect { described_class.value("States.StringToJson($.input)", {}, {"input" => "foo"}) }.to raise_error(ArgumentError, /invalid value for argument 1 to States.StringToJson \(invalid json/)
       end
     end
 

--- a/spec/workflow_spec.rb
+++ b/spec/workflow_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Floe::Workflow do
     it "raises an exception for invalid context" do
       payload = {"StartAt" => "FirstState", "States" => {"FirstState" => {"Type" => "Succeed"}}}
 
-      expect { described_class.new(payload, "invalid context") }.to raise_error(Floe::InvalidExecutionInput, "Invalid State Machine Execution Input: unexpected character: 'invalid context': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')")
+      expect { described_class.new(payload, "invalid context") }.to raise_error(Floe::InvalidExecutionInput, /Invalid State Machine Execution Input: unexpected character: /)
     end
   end
 


### PR DESCRIPTION
Be more resilient to JSON.parse exception message changes in tests

e.g.
```
expected ArgumentError with "invalid value for argument 1 to States.StringToJson (invalid json: unexpected token at 'foo')"
got      ArgumentError with "invalid value for argument 1 to States.StringToJson (invalid json: unexpected token 'foo' at line 1 column 1)"
```

Fixes https://github.com/ManageIQ/floe/actions/runs/15090561095/job/42418494901
Related https://github.com/ManageIQ/floe/pull/300

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
