### PR TITLE
Allow credentials referenced from parameters

### DIFF
--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -5,8 +5,6 @@ module Floe
     class Context
       include Logging
 
-      attr_accessor :credentials
-
       # @param context [Json|Hash] (default, create another with input and execution params)
       # @param input [Hash] (default: {})
       def initialize(context = nil, input: nil, credentials: nil, logger: nil)
@@ -14,14 +12,13 @@ module Floe
         input   = JSON.parse(input || "{}")
 
         @context = context || {}
+        self["Credentials"]        ||= credentials || {}
         self["Execution"]          ||= {}
         self["Execution"]["Input"] ||= input
         self["State"]              ||= {}
         self["StateHistory"]       ||= []
         self["StateMachine"]       ||= {}
         self["Task"]               ||= {}
-
-        @credentials = credentials || {}
 
         self.logger = logger if logger
       rescue JSON::ParserError => err
@@ -30,6 +27,10 @@ module Floe
 
       def execution
         @context["Execution"]
+      end
+
+      def credentials
+        @context["Credentials"]
       end
 
       def started?
@@ -138,8 +139,18 @@ module Floe
         @context.dig(*args)
       end
 
+      def inspect
+        format("#<%s: %s>", self.class.name, safe_context.inspect)
+      end
+
       def to_h
-        @context
+        safe_context
+      end
+
+      private
+
+      def safe_context
+        @context.except("Credentials")
       end
     end
   end

--- a/lib/floe/workflow/reference_path.rb
+++ b/lib/floe/workflow/reference_path.rb
@@ -8,10 +8,13 @@ module Floe
       def initialize(*)
         super
 
-        raise Floe::InvalidWorkflowError, "Invalid Reference Path" if payload.match?(/@|,|:|\?/)
+        raise Floe::InvalidWorkflowError, "Invalid Reference Path"              if payload.match?(/@|,|:|\?/)
+        raise Floe::InvalidWorkflowError, "Reference Path cannot start with $$" if payload.start_with?("$$") && !payload.start_with?("$$.Credentials")
+
+        path_shift = payload.start_with?("$$.Credentials") ? 3 : 1
 
         @path = JsonPath.new(payload)
-                        .path[1..]
+                        .path[path_shift..]
                         .map { |v| v.match(/\[(?<name>.+)\]/)["name"] }
                         .filter_map { |v| v[0] == "'" ? v.delete("'") : v.to_i }
       end

--- a/lib/floe/workflow/states/child_workflow_mixin.rb
+++ b/lib/floe/workflow/states/child_workflow_mixin.rb
@@ -49,7 +49,7 @@ module Floe
         end
 
         def each_child_context(context)
-          context.state[child_context_key].map { |ctx| Context.new(ctx) }
+          context.state[child_context_key].map { |ctx| Context.new(ctx, :credentials => context.credentials) }
         end
       end
     end

--- a/lib/floe/workflow/states/input_output_mixin.rb
+++ b/lib/floe/workflow/states/input_output_mixin.rb
@@ -15,9 +15,8 @@ module Floe
           return if output_path.nil?
 
           results = result_selector.value(context, results) if @result_selector
-          if result_path.payload.start_with?("$.Credentials")
-            credentials = result_path.set(context.credentials, results)["Credentials"]
-            context.credentials.merge!(credentials)
+          if result_path.payload.match?(/^\$\$\.Credentials\b/)
+            context.credentials.merge!(result_path.set(context.credentials, results))
             output = context.input.dup
           else
             output = result_path.set(context.input.dup, results)

--- a/lib/floe/workflow/states/task.rb
+++ b/lib/floe/workflow/states/task.rb
@@ -40,7 +40,8 @@ module Floe
           super
 
           input          = process_input(context)
-          runner_context = runner.run_async!(resource, input, credentials&.value({}, context.credentials), context)
+          secrets        = credentials&.value(context, context.input)
+          runner_context = runner.run_async!(resource, input, secrets, context)
 
           context.state["RunnerContext"] = runner_context
         end

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -195,4 +195,26 @@ RSpec.describe Floe::Workflow::Context do
       expect(ctx.status).to eq("failure")
     end
   end
+
+  describe "#inspect" do
+    context "with Credentials" do
+      let(:credentials) { {"username" => "user", "password" => "password"} }
+      let(:ctx)         { described_class.new(:input => input.to_json, :credentials => credentials) }
+
+      it "doesn't expose credentials when printing context" do
+        expect(ctx.inspect).not_to include("password")
+      end
+    end
+  end
+
+  describe "#to_h" do
+    context "with Credentials" do
+      let(:credentials) { {"username" => "user", "password" => "password"} }
+      let(:ctx)         { described_class.new(:input => input.to_json, :credentials => credentials) }
+
+      it "doesn't expose credentials when printing context" do
+        expect(ctx.to_h).not_to include("Credentials")
+      end
+    end
+  end
 end

--- a/spec/workflow/path_spec.rb
+++ b/spec/workflow/path_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe Floe::Workflow::Path do
       end
     end
 
+    context "referencing credentials" do
+      let(:context) { Floe::Workflow::Context.new({}, :credentials => {"password" => "s3cret"}) }
+      let(:input)   { {} }
+
+      it "with a missing value" do
+        expect { described_class.new("$$.Credentials.username").value(context, input) }.to raise_error(Floe::PathError, "Path [$$.Credentials.username] references an invalid value")
+      end
+
+      it "returns the password" do
+        expect(described_class.new("$$.Credentials.password").value(context, input)).to eq("s3cret")
+      end
+    end
+
     context "referencing the inputs" do
       it "with a missing value" do
         expect { described_class.new("$.foo").value({"foo" => "bar"}, {}) }.to raise_error(Floe::PathError, "Path [$.foo] references an invalid value")

--- a/spec/workflow/reference_path_spec.rb
+++ b/spec/workflow/reference_path_spec.rb
@@ -2,12 +2,18 @@ RSpec.describe Floe::Workflow::ReferencePath do
   let(:subject) { described_class.new(payload) }
 
   describe "#initialize" do
-    context "with invalid value" do
-      let(:payload) { "$.foo@.bar" }
+    it "with invalid character raises an exception" do
+      expect { described_class.new("$.foo@.bar") }
+        .to raise_error(Floe::InvalidWorkflowError, "Invalid Reference Path")
+    end
 
-      it "raises an exception" do
-        expect { subject }.to raise_error(Floe::InvalidWorkflowError, "Invalid Reference Path")
-      end
+    it "inserting into Context raises an exception" do
+      expect { described_class.new("$$.Execution.Id") }
+        .to raise_error(Floe::InvalidWorkflowError, "Reference Path cannot start with $$")
+    end
+
+    it "with $$.Credentials" do
+      expect { described_class.new("$$.Credentials.AuthToken") }.not_to raise_error
     end
   end
 

--- a/spec/workflow/states/pass_spec.rb
+++ b/spec/workflow/states/pass_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Floe::Workflow::States::Pass do
               "user"     => "luggage",
               "password" => "1234"
             },
-            "ResultPath" => "$.Credentials",
+            "ResultPath" => "$$.Credentials",
             "Next"       => "SuccessState"
           },
           "SuccessState" => {"Type" => "Succeed"}


### PR DESCRIPTION
Built on:
- [x] https://github.com/ManageIQ/floe/pull/307

This allows for Credentials to be accessed from Parameters, e.g.:
```
"Headers.$": {
  "ContentType": "application/json",
  "Authorization.$": "States.Format('Basic {}', States.Base64Encode(States.Format('{}:{}', $$.Credentials.username, $$.Credentials.password)))"
}
```

NOTE I changed how the Task.Credentials field is processed so that it can be more consistent with how Credentials are handled by Parameters, that being `$.` takes from state input and `$$.Credentials` takes from Context.Credentials.

We'll have to update our examples to match this.

TODO:
- [x] Currently assigning to Credentials is special-cased in process_output checking for `ResultPath: $.Credentials`, but `$$.Credentials` blows up the Path initialize

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
