### PR TITLE
Fix interpolation of deeply nested dynamic fields

### DIFF
--- a/examples/http.asl
+++ b/examples/http.asl
@@ -8,7 +8,7 @@
       "Parameters": {
         "Method": "GET",
         "Url": "http://localhost:3000/api/auth",
-        "Headers.$": {
+        "Headers": {
           "ContentType": "application/json",
           "Authorization.$": "States.Format('Basic {}', States.Base64Encode(States.Format('{}:{}', $$.Credentials.username, $$.Credentials.password)))"
         },
@@ -24,7 +24,7 @@
       "Parameters": {
         "Method": "GET",
         "Url": "http://localhost:3000/api/vms",
-        "Headers.$": {
+        "Headers": {
           "ContentType": "application/json",
           "X-Auth-Token.$": "$$.Credentials.auth_token"
         },

--- a/spec/workflow/payload_template_spec.rb
+++ b/spec/workflow/payload_template_spec.rb
@@ -39,22 +39,65 @@ RSpec.describe Floe::Workflow::PayloadTemplate do
         expect(subject.value(context, inputs)).to eq({"foo" => "bar", "bar" => "baz"})
       end
 
-      context "with an invalid payload" do
+      context "with key conflicts" do
         let(:payload) { {"foo.$" => "$.foo", "foo" => "bar"} }
 
         it "raises an exception" do
           expect { subject }.to raise_error(Floe::InvalidWorkflowError, "both foo.$ and foo present")
         end
       end
-    end
 
-    context "with nested dynamic values" do
-      let(:payload) { {"foo.$" => ["$.foo", "$$.bar"], "bar.$" => {"hello.$" => "$.greeting"}} }
-      let(:context) { {"bar" => "baz"} }
-      let(:inputs)  { {"foo" => "bar", "greeting" => "world"} }
+      context "with invalid value data type" do
+        context "of Integer" do
+          let(:payload) { {"foo.$" => 123} }
 
-      it "returns the value from the inputs" do
-        expect(subject.value(context, inputs)).to eq({"foo" => ["bar", "baz"], "bar" => {"hello" => "world"}})
+          it "raises an exception" do
+            expect { subject }.to raise_error(Floe::InvalidWorkflowError, "The value for the field \"foo.$\" must be a String that contains a valid Reference Path or Intrinsic Function expression")
+          end
+        end
+
+        context "of Array" do
+          let(:payload) { {"foo.$" => ["foo"]} }
+
+          it "raises an exception" do
+            expect { subject }.to raise_error(Floe::InvalidWorkflowError, "The value for the field \"foo.$\" must be a String that contains a valid Reference Path or Intrinsic Function expression")
+          end
+        end
+
+        context "of Hash" do
+          let(:payload) { {"foo.$" => {"foo" => "bar"}} }
+
+          it "raises an exception" do
+            expect { subject }.to raise_error(Floe::InvalidWorkflowError, "The value for the field \"foo.$\" must be a String that contains a valid Reference Path or Intrinsic Function expression")
+          end
+        end
+      end
+
+      context "with invalid value string" do
+        let(:payload) { {"foo.$" => "foo"} }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(Floe::InvalidWorkflowError, "The value for the field \"foo.$\" must be a String that contains a valid Reference Path or Intrinsic Function expression")
+        end
+      end
+
+      context "that are deeply nested Paths" do
+        let(:payload) { {"foo" => {"bar" => {"baz.$" => "$.baz"}}} }
+        let(:context) { {} }
+        let(:inputs)  { {"baz" => 123} }
+
+        it "returns the value from the inputs" do
+          expect(subject.value(context, inputs)).to eq({"foo" => {"bar" => {"baz" => 123}}})
+        end
+      end
+
+      context "that are deeply nested Intrinsic Functions" do
+        let(:payload) { {"foo" => {"bar" => {"baz.$" => "States.UUID()"}}} }
+        let(:context) { {} }
+
+        it "returns the value from the inputs" do
+          expect(subject.value(context, inputs)).to match({"foo" => {"bar" => {"baz" => a_string_matching(/^\h{8}-\h{4}-\h{4}-\h{4}-\h{12}$/)}}})
+        end
       end
     end
   end


### PR DESCRIPTION
Additionally, fix the issue where interpolated fields can only be of type String.

@agrare Please review.

Also this might break existing workflows, but they were incorrect to begin with - the fix is very simple (you can see an example in the http.asl example)
