### PR TITLE
declare active support dependency

### DIFF
--- a/floe.gemspec
+++ b/floe.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activesupport", ">5.2"
   spec.add_dependency "awesome_spawn", "~>1.6"
   spec.add_dependency "io-wait"
   spec.add_dependency "jsonpath", "~>1.1"

--- a/lib/floe/container_runner/kubernetes.rb
+++ b/lib/floe/container_runner/kubernetes.rb
@@ -11,7 +11,7 @@ module Floe
       FAILURE_REASONS = %w[CrashLoopBackOff ImagePullBackOff ErrImagePull].freeze
 
       def initialize(options = {})
-        require "active_support/core_ext/hash/keys"
+        require "active_support/core_ext/hash/keys" # deep_stringify_keys
         require "awesome_spawn"
         require "securerandom"
         require "base64"


### PR DESCRIPTION
`deep_stringify_keys`, used in `kubernetes`, requires `active_support`.
Would have preferred to to drop this method and `active_support`
(Concerned this will trigger a bunch of active support version bumps when CVEs come in)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
