### PR TITLE
Cops for format (and is_a)

### DIFF
--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -140,7 +140,7 @@ module Floe
       end
 
       def inspect
-        format("#<%s: %s>", self.class.name, safe_context.inspect)
+        "#<#{self.class.name}: #{safe_context.inspect}>"
       end
 
       def to_h

--- a/lib/floe/workflow/payload_template.rb
+++ b/lib/floe/workflow/payload_template.rb
@@ -48,7 +48,7 @@ module Floe
       end
 
       def check_dynamic_datatype(key, value)
-        unless value.is_a?(String)
+        unless value.kind_of?(String)
           raise Floe::InvalidWorkflowError, "The value for the field \"#{key}\" must be a String that contains a valid Reference Path or Intrinsic Function expression"
         end
       end

--- a/spec/workflow/context_spec.rb
+++ b/spec/workflow/context_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Floe::Workflow::Context do
-  let(:ctx) { described_class.new(:input => input.to_json) }
-  let(:input) { {"x" => "y"}.freeze }
+  let(:ctx)         { described_class.new(:input => input.to_json) }
+  let(:credentials) { {"username" => "user", "password" => "password"} }
+  let(:ctx_creds)   { described_class.new(:input => input.to_json, :credentials => credentials) }
+  let(:input)       { {"x" => "y"}.freeze }
 
   describe "#new" do
     it "with an empty context, sets input" do
@@ -197,24 +199,20 @@ RSpec.describe Floe::Workflow::Context do
   end
 
   describe "#inspect" do
-    context "with Credentials" do
-      let(:credentials) { {"username" => "user", "password" => "password"} }
-      let(:ctx)         { described_class.new(:input => input.to_json, :credentials => credentials) }
+    it "has the same value with or without credentials" do
+      # removing spaces because Hash#inspect in ruby 3.4 adds spaces that are not present before
+      expect(ctx.inspect.gsub(" ", "")).to eq("#<Floe::Workflow::Context: {\"Execution\" => {\"Input\" => {\"x\" => \"y\"}}, \"State\" => {}, \"StateHistory\" => [], \"StateMachine\" => {}, \"Task\" => {}}>".gsub(" ", ""))
+      expect(ctx_creds.inspect.gsub(" ", "")).to eq("#<Floe::Workflow::Context: {\"Execution\" => {\"Input\" => {\"x\" => \"y\"}}, \"State\" => {}, \"StateHistory\" => [], \"StateMachine\" => {}, \"Task\" => {}}>".gsub(" ", ""))
+    end
 
-      it "doesn't expose credentials when printing context" do
-        expect(ctx.inspect).not_to include("password")
-      end
+    it "doesn't expose credentials" do
+      expect(ctx_creds.inspect).not_to include("password")
     end
   end
 
   describe "#to_h" do
-    context "with Credentials" do
-      let(:credentials) { {"username" => "user", "password" => "password"} }
-      let(:ctx)         { described_class.new(:input => input.to_json, :credentials => credentials) }
-
-      it "doesn't expose credentials when printing context" do
-        expect(ctx.to_h).not_to include("Credentials")
-      end
+    it "doesn't expose credentials" do
+      expect(ctx_creds.to_h).not_to include("Credentials")
     end
   end
 end


### PR DESCRIPTION
extracted format from previous rubocops.
Added this PR as followup.

Not sure how I didn't see the `is_a?` rubocop failure.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
