### PR TITLE
[WIP] No longer store payload in States

### DIFF
--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -23,7 +23,7 @@ module Floe
     end
 
     def workflow_state?(field_value, workflow)
-      workflow.payload["States"] ? workflow.payload["States"].include?(field_value) : true
+      workflow.workflow_state?(field_value, workflow)
     end
 
     def wrap_parser_error(field_name, field_value)

--- a/lib/floe/workflow/catcher.rb
+++ b/lib/floe/workflow/catcher.rb
@@ -10,8 +10,6 @@ module Floe
 
       def initialize(workflow, name, payload)
         @name         = name
-        @payload      = payload
-
         @error_equals = payload["ErrorEquals"]
         @next         = payload["Next"]
         @result_path  = ReferencePath.new(payload.fetch("ResultPath", "$"))

--- a/lib/floe/workflow/choice_rule.rb
+++ b/lib/floe/workflow/choice_rule.rb
@@ -27,11 +27,10 @@ module Floe
         end
       end
 
-      attr_reader :next, :payload, :children, :name
+      attr_reader :next, :children, :name
 
       def initialize(workflow, name, payload, children = nil)
         @name      = name
-        @payload   = payload
         @children  = children
         @next      = payload["Next"]
 

--- a/lib/floe/workflow/intrinsic_function.rb
+++ b/lib/floe/workflow/intrinsic_function.rb
@@ -11,11 +11,8 @@ module Floe
         payload.start_with?("States.")
       end
 
-      attr_reader :payload
-
       def initialize(payload)
-        @payload = payload
-        @tree    = Parser.new.parse(payload)
+        @tree = Parser.new.parse(payload)
 
         Floe.logger.debug { "Parsed intrinsic function: #{payload.inspect} => #{tree.inspect}" }
       rescue Parslet::ParseFailed => err

--- a/lib/floe/workflow/retrier.rb
+++ b/lib/floe/workflow/retrier.rb
@@ -10,8 +10,6 @@ module Floe
 
       def initialize(_workflow, name, payload)
         @name             = name
-        @payload          = payload
-
         @error_equals     = payload["ErrorEquals"]
         @interval_seconds = payload["IntervalSeconds"] || 1.0
         @max_attempts     = payload["MaxAttempts"] || 3

--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -21,11 +21,10 @@ module Floe
         end
       end
 
-      attr_reader :comment, :name, :type, :payload
+      attr_reader :comment, :name, :type
 
       def initialize(_workflow, name, payload)
         @name     = name
-        @payload  = payload
         @type     = payload["Type"]
         @comment  = payload["Comment"]
       end

--- a/lib/floe/workflow_base.rb
+++ b/lib/floe/workflow_base.rb
@@ -4,7 +4,7 @@ module Floe
   class WorkflowBase
     include ValidationMixin
 
-    attr_reader :name, :payload, :start_at, :states, :states_by_name
+    attr_reader :name, :start_at, :states, :states_by_name
 
     def initialize(payload, name = nil)
       # NOTE: this is a string, and states use an array
@@ -75,6 +75,11 @@ module Floe
 
     def output(context)
       context.output.to_json if end?(context)
+    end
+
+    # overrides ValidationMixin#workflow_state?
+    def workflow_state?(field_value, _workflow)
+      @payload["States"] ? @payload["States"].include?(field_value) : true
     end
 
     private


### PR DESCRIPTION
Overview
---

We use `Payload#payload` in `State#initialize`, but then do not use it again.

This PR still passes `payload` to `initialize`, but drops the `payload` variable.

I kept `payload` around to make debugging easier, but in truth, I have never used it to debug.

Exceptions
---

We do need `Workflow#payload` to validate the state references in `"Next"`. If we store/pass `Workflow#payload["State"].keys` into child initializers, then this can be dropped.

We do need `Path#payload`, but this is not a payload but rather a path location. So basically the name is bad
