### PR TITLE
Only workflow accesses workflow#payload

### DIFF
--- a/lib/floe/validation_mixin.rb
+++ b/lib/floe/validation_mixin.rb
@@ -23,7 +23,7 @@ module Floe
     end
 
     def workflow_state?(field_value, workflow)
-      workflow.payload["States"] ? workflow.payload["States"].include?(field_value) : true
+      workflow.workflow_state?(field_value, workflow)
     end
 
     def wrap_parser_error(field_name, field_value)

--- a/lib/floe/workflow_base.rb
+++ b/lib/floe/workflow_base.rb
@@ -77,6 +77,11 @@ module Floe
       context.output.to_json if end?(context)
     end
 
+    # overrides ValidationMixin#workflow_state?
+    def workflow_state?(field_value, _workflow)
+      @payload["States"].include?(field_value)
+    end
+
     private
 
     def step!(context)


### PR DESCRIPTION
This is only used at `initialization` time.

This essentially makes `workflow#payload` private to `Workflow`/

Took out of #320 - the rest of that PR is not necessary

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
