### PR TITLE
In ChoiceRule use Regexp.union to join strings in a regular expression

### DIFF
--- a/lib/floe/workflow/choice_rule/data.rb
+++ b/lib/floe/workflow/choice_rule/data.rb
@@ -9,9 +9,9 @@ module Floe
         OPERATIONS = TYPES.each_with_object({}) { |dt, a| a[dt] = :"is_#{dt.downcase}?" }
                           .merge(COMPARES.each_with_object({}) { |op, a| a[op] = :"op_#{op.downcase}?" }).freeze
         # e.g.: (Is)(String), (Is)(Present)
-        TYPE_CHECK = /^Is(#{TYPES.join("|")})$/
+        TYPE_CHECK = /^Is(#{Regexp.union(TYPES)})$/
         # e.g.: (String)(LessThan)(Path), (Numeric)(GreaterThanEquals)()
-        OPERATION  = /^(#{(TYPES - %w[Null Present]).join("|")})(#{COMPARES.join("|")})(Path)?$/
+        OPERATION  = /^(#{Regexp.union(TYPES - %w[Null Present])})(#{Regexp.union(COMPARES)})(Path)?$/
 
         attr_reader :variable, :compare_key, :operator, :type, :compare_predicate, :path
 


### PR DESCRIPTION
This adds escaping and other good stuff
Since these values are static, they really don't do much.

I'm neutral, but @Fryguy likes it so... ¯\\_(ツ)_/¯