### PR TITLE
Add floe://log builtin method

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,31 @@ Task Runner Types:
 
 This is the "builtin" runner and exposes methods that are executed internally without having to call out to a docker image.
 
+##### Log builtin method
+
+`floe://log` allows you to write a message to the logger.
+
+Example:
+```json
+{
+  "Comment": "Print log message",
+  "StartAt": "Log",
+  "States": {
+    "Log": {
+      "Type": "Task",
+      "Resource": "floe://log",
+      "Parameters": {
+        "Level": "INFO",
+        "Message": "Hello, Floe!"
+      },
+      "End": true
+    }
+```
+
+Log Parameters:
+* `Level` (required) - Log level. Permitted values: `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`, or `UNKNOWN`.  Defaults to `INFO`.
+* `Message` (required) - The message to log
+
 ##### HTTP builtin method
 
 `floe://http` allows you to execute HTTP method calls.

--- a/examples/log.asl
+++ b/examples/log.asl
@@ -1,0 +1,33 @@
+{
+  "Comment": "Print log messages",
+  "StartAt": "Log Info",
+  "States": {
+    "Log Info": {
+      "Type": "Task",
+      "Resource": "floe://log",
+      "Parameters": {
+        "Level": "INFO",
+        "Message": "Hello, Floe!"
+      },
+      "Next": "Log Debug"
+    },
+    "Log Debug": {
+      "Type": "Task",
+      "Resource": "floe://log",
+      "Parameters": {
+        "Level": "DEBUG",
+        "Message": "Hello, Floe!"
+      },
+      "Next": "Log From Input"
+    },
+    "Log From Input": {
+      "Type": "Task",
+      "Resource": "floe://log",
+      "Parameters": {
+        "Level": "INFO",
+        "Message.$": "States.Format('Hello, {}!', $.name)"
+      },
+      "End": true
+    }
+  }
+}

--- a/lib/floe/workflow.rb
+++ b/lib/floe/workflow.rb
@@ -150,15 +150,7 @@ module Floe
 
     # setup a workflow
     def start_workflow
-      return if context.state_name
-
-      context.state["Name"]  = start_at
-      context.state["Input"] = context.execution["Input"].dup
-      context.state["Guid"]  = SecureRandom.uuid
-
-      context.execution["Id"]      ||= SecureRandom.uuid
-      context.execution["StartTime"] = Time.now.utc.iso8601
-
+      context.prepare_start(start_at)
       self
     end
 

--- a/lib/floe/workflow/context.rb
+++ b/lib/floe/workflow/context.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "securerandom"
+
 module Floe
   class Workflow
     class Context
@@ -23,6 +25,17 @@ module Floe
         self.logger = logger if logger
       rescue JSON::ParserError => err
         raise Floe::InvalidExecutionInput, "Invalid State Machine Execution Input: #{err}: was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')"
+      end
+
+      def prepare_start(start_at)
+        return if started?
+
+        state["Name"]  = start_at
+        state["Input"] = execution["Input"].dup
+        state["Guid"]  = SecureRandom.uuid
+
+        execution["Id"]      ||= SecureRandom.uuid
+        execution["StartTime"] = Time.now.utc.iso8601
       end
 
       def execution


### PR DESCRIPTION
@agrare Please review.

This includes a minor refactor moving the "start" preparation code into context itself, so it can be reused in tests.

Running the examples/log.asl gives:

```
$ exe/floe examples/log.asl '{"name": "Jason"}'
D, [2025-12-02T17:20:57.016834 #66243] DEBUG -- : Parsed intrinsic function: "States.Format('Hello, {}!', $.name)" => {:states_format=>{:args=>[{:arg=>{:string=>"'Hello, {}!'"@14}}, {:arg=>{:jsonpath=>"$.name"@28}}]}}
I, [2025-12-02T17:20:57.016900 #66243]  INFO -- : Checking 1 workflows...
I, [2025-12-02T17:20:57.017018 #66243]  INFO -- : Running state: [Task:Log Info] with input [{"name":"Jason"}]...
I, [2025-12-02T17:20:57.019198 #66243]  INFO -- : Hello, Floe!
I, [2025-12-02T17:20:57.020048 #66243]  INFO -- : Running state: [Task:Log Info] with input [{"name":"Jason"}]...Complete - next state [Log Debug] output: [{"name":"Jason"}]
I, [2025-12-02T17:20:57.020108 #66243]  INFO -- : Running state: [Task:Log Debug] with input [{"name":"Jason"}]...
D, [2025-12-02T17:20:57.020128 #66243] DEBUG -- : Hello, Floe!
I, [2025-12-02T17:20:57.020168 #66243]  INFO -- : Running state: [Task:Log Debug] with input [{"name":"Jason"}]...Complete - next state [Log From Input] output: [{"name":"Jason"}]
I, [2025-12-02T17:20:57.020190 #66243]  INFO -- : Running state: [Task:Log From Input] with input [{"name":"Jason"}]...
I, [2025-12-02T17:20:57.020479 #66243]  INFO -- : Hello, Jason!
I, [2025-12-02T17:20:57.020520 #66243]  INFO -- : Running state: [Task:Log From Input] with input [{"name":"Jason"}]...Complete workflow - output: [{"name":"Jason"}]
I, [2025-12-02T17:20:57.020549 #66243]  INFO -- : Checking 1 workflows...Complete - 1 ready
I, [2025-12-02T17:20:57.020570 #66243]  INFO -- : {"name":"Jason"}
```