### PR TITLE
Return an Error for failed http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,27 @@ HTTP Parameters:
   * `User` - String - User for the proxy.
   * `Password` - String - Pasword for the proxy
 
+Output:
+A successful HTTP request will return the response Status, Body, and Headers. For example,
+```json
+{
+  "Status": 200,
+  "Body": {"result": {"foo": "bar"}},
+  "Headers": {"content-type": "application/json"}
+}
+```
+
+Errors:
+If an HTTP request fails, the `floe://http` builtin method will return an error payload that includes
+the error code, the reason, and the response Status, Body, and Headers. For example,
+```json
+{
+  "Error": "States.Http.StatusCode.404",
+  "Cause": "Not Found",
+  "Details": {"Status": 404, "Body": {"code": 404, "reason": "Page not found"}, "Headers": {"content-type": "application/json"}}
+}
+```
+
 #### Docker resource
 
 The docker resource runner takes a docker image URI, including the registry, name, and tag.

--- a/lib/floe/builtin_runner.rb
+++ b/lib/floe/builtin_runner.rb
@@ -7,9 +7,11 @@ module Floe
     SCHEME_PREFIX = "#{SCHEME}://".freeze
 
     class << self
-      def error!(runner_context = {}, cause:, error: "States.TaskFailed")
+      def error!(runner_context = {}, cause: nil, error: "States.TaskFailed", output: nil)
+        output ||= {"Error" => error, "Cause" => cause}
+
         runner_context.merge!(
-          "running" => false, "success" => false, "output" => {"Error" => error, "Cause" => cause}
+          "running" => false, "success" => false, "output" => output
         )
       end
 

--- a/lib/floe/builtin_runner.rb
+++ b/lib/floe/builtin_runner.rb
@@ -7,8 +7,8 @@ module Floe
     SCHEME_PREFIX = "#{SCHEME}://".freeze
 
     class << self
-      def error!(runner_context = {}, cause: nil, error: "States.TaskFailed", output: nil)
-        output ||= {"Error" => error, "Cause" => cause}
+      def error!(runner_context = {}, cause: nil, error: "States.TaskFailed", details: nil)
+        output = {"Error" => error, "Cause" => cause, "Details" => details}.compact
 
         runner_context.merge!(
           "running" => false, "success" => false, "output" => output

--- a/lib/floe/builtin_runner/methods.rb
+++ b/lib/floe/builtin_runner/methods.rb
@@ -92,13 +92,12 @@ module Floe
           faraday_request.body = body if body
         end
 
-        output = {"Status" => response.status, "Body" => response.body, "Headers" => response.headers}
-
         if response.success?
+          output = {"Status" => response.status, "Body" => response.body, "Headers" => response.headers}
           BuiltinRunner.success!({}, :output => output)
         else
-          output["Error"] = "States.TaskFailed"
-          output["Cause"] = response.reason_phrase
+          output = {"Error" => "States.TaskFailed", "Cause" => response.reason_phrase, "Details" => response.body}
+
           BuiltinRunner.error!({}, :output => output)
         end
       rescue ::Faraday::ConnectionFailed => err

--- a/lib/floe/builtin_runner/methods.rb
+++ b/lib/floe/builtin_runner/methods.rb
@@ -94,7 +94,15 @@ module Floe
 
         output = {"Status" => response.status, "Body" => response.body, "Headers" => response.headers}
 
-        BuiltinRunner.success!({}, :output => output)
+        if response.success?
+          BuiltinRunner.success!({}, :output => output)
+        else
+          output["Error"] = "States.TaskFailed"
+          output["Cause"] = response.reason_phrase
+          BuiltinRunner.error!({}, :output => output)
+        end
+      rescue ::Faraday::ConnectionFailed => err
+        BuiltinRunner.error!({}, :cause => err.to_s)
       end
 
       private_class_method def self.http_verify_params(params)

--- a/lib/floe/builtin_runner/methods.rb
+++ b/lib/floe/builtin_runner/methods.rb
@@ -96,7 +96,7 @@ module Floe
           output = {"Status" => response.status, "Body" => response.body, "Headers" => response.headers}
           BuiltinRunner.success!({}, :output => output)
         else
-          output = {"Error" => "States.TaskFailed", "Cause" => response.reason_phrase, "Details" => response.body}
+          output = {"Error" => "States.Http.StatusCode.#{response.status}", "Cause" => response.reason_phrase, "Details" => response.body}
 
           BuiltinRunner.error!({}, :output => output)
         end

--- a/lib/floe/builtin_runner/methods.rb
+++ b/lib/floe/builtin_runner/methods.rb
@@ -92,13 +92,12 @@ module Floe
           faraday_request.body = body if body
         end
 
+        output = {"Status" => response.status, "Body" => response.body, "Headers" => response.headers}
+
         if response.success?
-          output = {"Status" => response.status, "Body" => response.body, "Headers" => response.headers}
           BuiltinRunner.success!({}, :output => output)
         else
-          output = {"Error" => "States.Http.StatusCode.#{response.status}", "Cause" => response.reason_phrase, "Details" => response.body}
-
-          BuiltinRunner.error!({}, :output => output)
+          BuiltinRunner.error!({}, :error => "States.Http.StatusCode.#{response.status}", :cause => response.reason_phrase, :details => output)
         end
       rescue ::Faraday::ConnectionFailed => err
         BuiltinRunner.error!({}, :cause => err.to_s)

--- a/spec/builtin_runner/methods_spec.rb
+++ b/spec/builtin_runner/methods_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Floe::BuiltinRunner::Methods do
           .to include(
             "running" => false,
             "success" => false,
-            "output"  => {"Error" => "States.TaskFailed", "Cause" => "Not Found", "Details" => {"code" => 404, "details" => "Page Not Found"}}
+            "output"  => {"Error" => "States.Http.StatusCode.404", "Cause" => "Not Found", "Details" => {"code" => 404, "details" => "Page Not Found"}}
           )
       end
 

--- a/spec/builtin_runner/methods_spec.rb
+++ b/spec/builtin_runner/methods_spec.rb
@@ -162,15 +162,36 @@ RSpec.describe Floe::BuiltinRunner::Methods do
       end
 
       it "returns an error for a non 200 status" do
-        expect(faraday_stub).to receive(:get).and_return(Faraday::Response.new(:status => 404, :body => {"code" => 404, "details" => "Page Not Found"}, :reason_phrase => "Not Found"))
+        expect(faraday_stub)
+          .to receive(:get)
+          .and_return(
+            Faraday::Response.new(
+              :status           => 404,
+              :response_body    => {"code" => 404, "details" => "Page Not Found"},
+              :response_headers => {"content-type" => "application/json"},
+              :reason_phrase    => "Not Found"
+            )
+          )
 
         params = {"Method" => "GET", "Url" => "http://localhost"}
         runner_context = described_class.http(params, secrets, ctx)
+
         expect(runner_context)
           .to include(
             "running" => false,
             "success" => false,
-            "output"  => {"Error" => "States.Http.StatusCode.404", "Cause" => "Not Found", "Details" => {"code" => 404, "details" => "Page Not Found"}}
+            "output"  => {
+              "Error"   => "States.Http.StatusCode.404",
+              "Cause"   => "Not Found",
+              "Details" => {
+                "Body"    => {
+                  "code"    => 404,
+                  "details" => "Page Not Found"
+                },
+                "Headers" => {"content-type" => "application/json"},
+                "Status"  => 404
+              }
+            }
           )
       end
 

--- a/spec/builtin_runner/methods_spec.rb
+++ b/spec/builtin_runner/methods_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Floe::BuiltinRunner::Methods do
       end
 
       it "returns an error for a non 200 status" do
-        expect(faraday_stub).to receive(:get).and_return(Faraday::Response.new(:status => 404, :body => "{}", :reason_phrase => "Not Found"))
+        expect(faraday_stub).to receive(:get).and_return(Faraday::Response.new(:status => 404, :body => {"code" => 404, "details" => "Page Not Found"}, :reason_phrase => "Not Found"))
 
         params = {"Method" => "GET", "Url" => "http://localhost"}
         runner_context = described_class.http(params, secrets, ctx)
@@ -170,7 +170,7 @@ RSpec.describe Floe::BuiltinRunner::Methods do
           .to include(
             "running" => false,
             "success" => false,
-            "output"  => {"Error" => "States.TaskFailed", "Cause" => "Not Found", "Status" => 404, "Body" => "{}", "Headers" => nil}
+            "output"  => {"Error" => "States.TaskFailed", "Cause" => "Not Found", "Details" => {"code" => 404, "details" => "Page Not Found"}}
           )
       end
 

--- a/spec/builtin_runner/methods_spec.rb
+++ b/spec/builtin_runner/methods_spec.rb
@@ -148,6 +148,32 @@ RSpec.describe Floe::BuiltinRunner::Methods do
           )
       end
 
+      it "returns an error when the connection is refused" do
+        expect(faraday_stub).to receive(:get).and_raise(Faraday::ConnectionFailed, "Failed to open TCP connection to http://localhost")
+
+        params = {"Method" => "GET", "Url" => "http://localhost"}
+        runner_context = described_class.http(params, secrets, ctx)
+        expect(runner_context)
+          .to include(
+            "running" => false,
+            "success" => false,
+            "output"  => {"Cause" => "Failed to open TCP connection to http://localhost", "Error" => "States.TaskFailed"}
+          )
+      end
+
+      it "returns an error for a non 200 status" do
+        expect(faraday_stub).to receive(:get).and_return(Faraday::Response.new(:status => 404, :body => "{}", :reason_phrase => "Not Found"))
+
+        params = {"Method" => "GET", "Url" => "http://localhost"}
+        runner_context = described_class.http(params, secrets, ctx)
+        expect(runner_context)
+          .to include(
+            "running" => false,
+            "success" => false,
+            "output"  => {"Error" => "States.TaskFailed", "Cause" => "Not Found", "Status" => 404, "Body" => "{}", "Headers" => nil}
+          )
+      end
+
       it "with query parameters" do
         expect(Faraday)
           .to receive(:new)


### PR DESCRIPTION
If an HTTP request fails we should return an error from the state. This extends the error payload with additional parameters including the status and body/headers.

Example unauthenticated API request:
```
irb(main):001> Floe::BuiltinRunner::Methods.http({"Url" => "http://localhost:3000/api/vms", "Options" => {"Encoding" => "JSON"}}, {}, {})
=> 
{"running"=>false,
 "success"=>false,
 "output"=>
  {"Error"=>"States.TaskFailed",
   "Cause"=>"Unauthorized"}
   "Details"=>
    {"Status"=>401,
     "Body"=>
      {"error"=>
        {"kind"=>"unauthorized",
         "message"=>"Api::BaseController::Authentication::AuthenticationError",
         "klass"=>"Api::BaseController::Authentication::AuthenticationError"}},
     "Headers"=>
      {"content-type"=>"application/json",
       "content-length"=>"169"}}}
}
```

After this change, the `http` builtin method will return an error payload for all non-200 return codes.
```json
{
  "Error": "States.Http.StatusCode.404",
  "Cause": "Not Found",
  "Details": {"Status": 404, "Body": {"code": 404, "reason": "Page not found"}, "Headers": {"content-type": "application/json"}}
}
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
