### PR TITLE
`kill -TERM` the docker wait process before exiting

### DIFF
--- a/lib/floe/container_runner/docker.rb
+++ b/lib/floe/container_runner/docker.rb
@@ -92,10 +92,12 @@ module Floe
           Process.kill(0, pid)
         rescue Errno::ESRCH
           # Break out of the loop if the `docker events` process has exited
+          pid = nil
           break
         end
       ensure
         r.close
+        sigterm(pid) if pid
       end
 
       def status!(runner_context)


### PR DESCRIPTION
When exiting the wait loop we should ensure that the docker/podman wait process is terminated.

This prevents `podman events` processes from hanging around after the caller has exited.  This isn't an issue on systems using systemd because the entire worker slice is torn down, but on development machines these will continue to run after the caller has exited.

Related:
- [ ] https://github.com/ManageIQ/awesome_spawn/pull/85
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
