### PR TITLE
Use Kernel.spawn directly to ensure no intermediate `/bin/sh -c` shell is used

### DIFF
--- a/lib/floe/container_runner/docker.rb
+++ b/lib/floe/container_runner/docker.rb
@@ -46,13 +46,12 @@ module Floe
       end
 
       def wait(timeout: nil, events: %i[create update delete], &block)
-        until_timestamp = Time.now.utc + timeout if timeout
+        until_timestamp = (Time.now.utc + timeout).to_i if timeout
 
         r, w = IO.pipe
 
-        pid = AwesomeSpawn.run_detached(
-          self.class::DOCKER_COMMAND, :err => :out, :out => w, :params => wait_params(until_timestamp)
-        )
+        pid = Kernel.spawn({}, self.class::DOCKER_COMMAND, *wait_params(until_timestamp), :err => :out, :out => w)
+        Process.detach(pid)
 
         w.close
 
@@ -152,8 +151,10 @@ module Floe
       end
 
       def wait_params(until_timestamp)
-        params = ["events", [:format, "{{json .}}"], [:filter, "type=container"], [:since, Time.now.utc.to_i]]
-        params << [:until, until_timestamp.to_i] if until_timestamp
+        since_timestamp = Time.now.utc.to_i
+
+        params  = ["events", "--format", "{{json .}}", "--filter", "type=container", "--since", since_timestamp.to_s]
+        params += ["--until", until_timestamp.to_s] if until_timestamp
         params
       end
 


### PR DESCRIPTION
I'm working on an update to AwesomeSpawn (https://github.com/ManageIQ/awesome_spawn/pull/85) but since AwesomeSpwan handles way more cases then we need for this purpose I thought this would be a quick way to fix the issue of `podman events` sticking around after exit.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
